### PR TITLE
Add support for using the variable HIMLAR_CERT_NAME as the name for the ...

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -34,7 +34,10 @@ $puppetrun=<<SHELL
     rm -rf /etc/puppet/$(echo ${m#/vagrant/})
   done
 
-  puppet config set certname vagrant-base-dev.vagrant.local
+  if [ -z "$HIMLAR_CERT_NAME" ]; then
+    HIMLAR_CERT_NAME=vagrant-base-dev.vagrant.local
+  fi
+  puppet config set certname "$HIMLAR_CERT_NAME"
   puppet apply --verbose /vagrant/manifests/site.pp
 SHELL
 


### PR DESCRIPTION
...cert.

Example usage:
export HIMLAR_CERT_NAME=HIMLAR_CERT_NAME=vagrant-controller-dev.vagrant.local
vagrant up