### PR TITLE
Externalizing bootstrap and puppetrun scripts

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,56 +1,16 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-$provision=<<SHELL
-  install_puppet_and_tools()
-  {
-    rpm -ivh http://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
-    yum install -y puppet facter rubygems rubygem-deep_merge \
-      rubygem-puppet-lint git vim inotify-tools
-    # puppet settings
-    ln -sfT /vagrant/hieradata /etc/puppet/hieradata
-    puppet config set hiera_config /vagrant/hiera.yaml
-    puppet config set basemodulepath /vagrant/modules:/etc/puppet/modules
-    puppet config set disable_warnings deprecations
-    puppet config set trusted_node_data true
-  }
-  install_puppetfile()
-  {
-    PUPPETFILE=/vagrant/Puppetfile \
-    PUPPETFILE_DIR=/etc/puppet/modules \
-    r10k --verbose 4 puppetfile install
-  }
-  export PATH=$PATH:/usr/local/bin
-  command -v puppet >/dev/null 2>&1      || install_puppet_and_tools
-  command -v r10k >/dev/null 2>&1        || gem install r10k --no-ri --no-rdoc
-  test -n "$(ls -A /etc/puppet/modules)" || install_puppetfile
-SHELL
-
-$puppetrun=<<SHELL
-  # remove modules that are overridden in /vagrant/modules
-  modules="$(ls -d /vagrant/modules/*/)"
-  for m in $modules; do
-    echo "$m is overridden in /vagrant/modules"
-    rm -rf /etc/puppet/$(echo ${m#/vagrant/})
-  done
-
-  # Extract variable
-  HIMLAR_CERTNAME=#{ENV['HIMLAR_CERTNAME']}
-
-  puppet config set certname "${HIMLAR_CERTNAME:-vagrant-base-dev.vagrant.local}"
-  puppet apply --verbose /vagrant/manifests/site.pp
-SHELL
-
 VAGRANTFILE_API_VERSION = '2'
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = 'norcams/centos7'
 
-  config.vm.synced_folder '.', '/vagrant', type: 'rsync',
+  config.vm.synced_folder '.', '/opt/himlar', type: 'rsync',
     rsync__exclude: [ '.git/', '.vagrant/' ]
 
-  config.vm.provision :shell, :inline => $provision
-  config.vm.provision :shell, :inline => $puppetrun
+  config.vm.provision :shell, :path => "provision/bootstrap.sh"
+  config.vm.provision :shell, :path => "provision/puppetrun.sh", args: ENV["HIMLAR_CERTNAME"]
 
   if Vagrant.has_plugin?('vagrant-cachier')
     config.cache.scope = :machine

--- a/provision/bootstrap.sh
+++ b/provision/bootstrap.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+provision_puppet()
+{
+  # packages
+  rpm -ivh http://fedora.uib.no/epel/7/x86_64/e/epel-release-7-5.noarch.rpm
+  rpm -ivh http://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
+  yum install -y puppet facter rubygems rubygem-deep_merge \
+    rubygem-puppet-lint git vim inotify-tools
+  gem install r10k --no-ri --no-rdoc
+
+  # file locations
+  ln -sfT /opt/himlar/hieradata /etc/puppet/hieradata
+  ln -sfT /opt/himlar/manifests /etc/puppet/manifests
+  ln -sfT /opt/himlar/hiera.yaml /etc/puppet/hiera.yaml
+
+  # settings
+  puppet config set basemodulepath /opt/himlar/modules:/etc/puppet/modules
+  puppet config set disable_warnings deprecations
+  puppet config set trusted_node_data true
+}
+
+provision_puppetfile()
+{
+    PUPPETFILE=/opt/himlar/Puppetfile \
+    PUPPETFILE_DIR=/etc/puppet/modules \
+    r10k --verbose 4 puppetfile install
+}
+
+export PATH=$PATH:/usr/local/bin
+command -v puppet >/dev/null 2>&1                  || provision_puppet
+test -n "$(ls -A /etc/puppet/modules 2>/dev/null)" || provision_puppetfile
+

--- a/provision/puppetrun.sh
+++ b/provision/puppetrun.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# remove modules that are overridden in /opt/himlar/modules
+modules="$(ls -d /opt/himlar/modules/*/ 2>/dev/null)"
+for m in $modules; do
+  echo "$m is overridden in /opt/himlar/modules"
+  rm -rf /etc/puppet/$(echo ${m#/opt/himlar/})
+done
+
+# Set default certname
+certname="vagrant-base-dev.vagrant.local"
+# Override with env var if present
+certname="${HIMLAR_CERTNAME:-$certname}"
+# Override from command line argument $1 if present
+certname="${1:-$certname}"
+# Write final certname to puppet.conf
+puppet config set certname $certname
+
+puppet apply --verbose /etc/puppet/manifests/site.pp
+


### PR DESCRIPTION
This moves the scripts for bootstrap and puppetrun out of the
Vagrantfile. It also modifies the rsync path inside the instance
to /opt/himlar which is a better generic location