### PR TITLE
Removing himlar Puppet module

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -1,14 +1,10 @@
 #
 # Puppetfile
 #
-mod 'himlar',
-  :git => 'https://github.com/norcams/himlar-profile',
-  :ref => '0.4.0'
-#  :branch => 'master'
 
 mod 'profile',
   :git => 'https://github.com/norcams/puppeels',
-  :branch => 'master'
+  :branch => 'norcams'
 
 #
 # login

--- a/hieradata/defaults/common.yaml
+++ b/hieradata/defaults/common.yaml
@@ -1,18 +1,19 @@
 ---
 classes:
-  - himlar::base::base
+  - profile::base::common
 
-himlar::base::base::manage_epel:       true
-himlar::base::base::manage_accounts:   true
-himlar::base::base::manage_logging:    false
-himlar::base::base::manage_monitoring: false
-himlar::base::base::manage_sshd:       true
-himlar::base::base::manage_ntp:        true
-himlar::base::base::manage_sudo:       true
-himlar::base::base::manage_authconfig: false
-himlar::base::base::base_packages:     false
+profile::base::common::manage_epel:       true
+profile::base::common::manage_accounts:   true
+profile::base::common::manage_logging:    false
+profile::base::common::manage_monitoring: false
+profile::base::common::manage_sshd:       true
+profile::base::common::manage_ntp:        true
+profile::base::common::manage_sudo:       true
+profile::base::common::manage_authconfig: false
+profile::base::common::common_packages:   false
+profile::base::common::manage_firewall:   false
 
-himlar::base::accounts::accounts:
+account::accounts:
   {}
 
 ntp::servers:

--- a/hieradata/defaults/login.yaml
+++ b/hieradata/defaults/login.yaml
@@ -1,6 +1,6 @@
 ---
 classes:
-  - himlar::admin::profile
+  - profile::base::login
 
 account::accounts:
   beddari:

--- a/provision/puppetrun.sh
+++ b/provision/puppetrun.sh
@@ -8,7 +8,7 @@ for m in $modules; do
 done
 
 # Set default certname
-certname="vagrant-base-dev.vagrant.local"
+certname="vagrant-common-dev.vagrant.local"
 # Override with env var if present
 certname="${HIMLAR_CERTNAME:-$certname}"
 # Override from command line argument $1 if present


### PR DESCRIPTION
Having a Puppet module named the same as the main project was confusing. Two profile modules ... was also confusing. This change fixes that, we will carry a norcams branch of puppeels instead, with our local changes.