### PR TITLE
New feature: run modes

### DIFF
--- a/hieradata/defaults/common.yaml
+++ b/hieradata/defaults/common.yaml
@@ -1,6 +1,8 @@
 ---
 classes:
   - profile::base::common
+classes_bootstrap:
+  - profile::base::common
 
 profile::base::common::manage_augeasproviders: true
 profile::base::common::manage_epel:            true

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -1,17 +1,22 @@
 # Assuming trusted_node_data = true in puppet.conf
 # https://docs.puppetlabs.com/puppet/3/reference/lang_variables.html#trusted-node-data
-# 
+#
 # We expect a certain certname format, e.g
-#  * role-location-identifier.domain.com
-#  * haproxy-bgo-01.snakeoil.int
+#  * location-role-identifier.domain.com
+#  * bgo-haproxy-01.snakeoil.internal
 #
 # Parse data from $trusted['certname'] for hiera lookup
-$verified_certname = $trusted['certname']
-$certname_a        = split($verified_certname, "-")
+$verified_certname = $::trusted['certname']
+$certname_a        = split($::verified_certname, '-')
 $location          = $::certname_a[0]
 $role              = $::certname_a[1]
 
-hiera_include('classes', [])
+# Query for classes_$runmode if $runmode is set
+if $::runmode {
+  hiera_include("classes_$runmode", [])
+} else {
+  hiera_include('classes', [])
+}
 
 # Empty default node
 node default { }


### PR DESCRIPTION
With this, hiera_include will only query for a special set of classes
to include if the runmode fact is set. This enables e.g bootstrap runs
with the same hiera data set as used for the 'full' runs:

FACTER_RUNMODE=bootstrap puppet apply site.pp

This will include all classes specified as classes_bootstrap in Hiera.