### PR TITLE
Added command line parms for puppet apply

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -42,5 +42,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   if ENV['HIMLAR_BRIDGE2']
     config.vm.network :public_network, dev: ENV['HIMLAR_BRIDGE2'], mode: 'bridge', auto_config: false
   end
+  if ENV['HIMLAR_INTERN']
+    config.vm.network :private_network, ip: '10.0.1.2', auto_config: false
+  end
+
 end
 

--- a/hieradata/defaults/foreman.yaml
+++ b/hieradata/defaults/foreman.yaml
@@ -12,7 +12,7 @@ foreman::admin_username:                      admin
 foreman::admin_password:                      changeme
 foreman::admin_email:                         admin@localhost.localdomain
 foreman::ssl:                                 false
-foreman::foreman_url:                         http://10.0.0.1
+#foreman::foreman_url:                         http://10.0.0.1
 foreman::cli::manage_root_config:             true
 foreman::plugin::discovery::install_images:   true
 foreman::plugin::discovery::source:           http://folk.uib.no/edpto/fdi-image-2.1.0/
@@ -25,20 +25,21 @@ foreman_proxy::registered_proxy_url:          http://127.0.0.1:8000
 foreman_proxy::register_in_foreman:           true
 foreman_proxy::manage_sudoersd:               false
 foreman_proxy::tftp:                          true
-foreman_proxy::tftp_servername:               10.0.0.1
+#foreman_proxy::tftp_servername:               10.0.0.1
 foreman_proxy::dhcp:                          true
 foreman_proxy::dhcp_managed:                  true
 foreman_proxy::dhcp_interface:                eth2
-foreman_proxy::dhcp_range:                    "10.0.0.100 10.0.0.250"
-foreman_proxy::dhcp_gateway:                  10.0.0.1
-foreman_proxy::dhcp_nameservers:              "10.0.0.1, 10.0.0.2"
+#foreman_proxy::dhcp_range:                    "10.0.0.100 10.0.0.250"
+#foreman_proxy::dhcp_gateway:                  10.0.0.1
+#foreman_proxy::dhcp_nameservers:              "10.0.0.1, 10.0.0.2"
 foreman_proxy::trusted_hosts:                 []
 foreman_proxy::dns:                           true
+foreman_proxy::dns_provider:                  'nsupdate'
 foreman_proxy::dns_managed:                   false
 foreman_proxy::bmc:                           true
 foreman_proxy::puppetrun:                     true
 foreman_proxy::puppetca:                      true
-puppet::server_foreman_url:                   http://10.0.0.1
+#puppet::server_foreman_url:                   http://10.0.0.1
 puppet::server:                               true
 puppet::server_report_api:                    v2
 puppet::server_facts:                         true

--- a/hieradata/vagrant/foreman.yaml
+++ b/hieradata/vagrant/foreman.yaml
@@ -1,3 +1,17 @@
 ---
-foreman_proxy::dhcp_interface:                eth0
+profile::base::common::manage_networkifs:     true
 
+foreman_proxy::dhcp_interface:                eth1
+
+foreman::foreman_url:                         http://10.0.2.15
+foreman_proxy::dhcp_range:                    "10.0.1.100 10.0.1.250"
+foreman_proxy::dhcp_gateway:                  10.0.1.1
+foreman_proxy::dhcp_nameservers:              "10.0.2.1, 10.0.2.2"
+puppet::server_foreman_url:                   http://10.0.2.15
+
+networkInterfaces:
+  eth1:
+    ipv4_ips:   10.0.1.2/24
+    ensure:     up
+    start_mode: onboot
+    type:       ethernet

--- a/provision/puppetrun.sh
+++ b/provision/puppetrun.sh
@@ -11,4 +11,4 @@ certname="${1:-$certname}"
 # Write final certname to puppet.conf
 puppet config set certname $certname
 
-puppet apply --verbose /etc/puppet/manifests/site.pp
+puppet apply --verbose --disable_warnings=deprecations --trusted_node_data /etc/puppet/manifests/site.pp


### PR DESCRIPTION
Needed to run puppet apply on foreman nodes without editing puppet.conf for every puppet run. 
Quick fix for #54. 
