### PR TITLE
New kickstart template allowing the choice of installdevice

### DIFF
--- a/provision/foreman-bgo-setup.sh
+++ b/provision/foreman-bgo-setup.sh
@@ -73,11 +73,15 @@ hammer proxy import-classes --environment "production" --id 1
 # TEMP FIX wrong url for some CentOS mirrors throug mirror.centos.org http://projects.theforeman.org/issues/6884
 hammer medium update --id 1 --path 'http://centos.uib.no/$version/os/$arch'
 
+# Download and create partition table
+wget -P http://folk.uib.no/edpto/provision_partition.erb
+hammer partition-table create --name "Kickstart partition instdev" --os-family Redhat --file /tmp/provision_partition.erb
+
 # Create OS
 hammer os create --name CentOS --major 7 --minor 0.1406 --description "CentOS 7.0" --family Redhat \
   --architecture-ids 1 \
   --medium-ids $(hammer medium list | grep CentOS | head -c1) \
-  --ptable-ids $(hammer partition-table list | grep "Kickstart default" | head -c1) 
+  --ptable-ids $(hammer partition-table list | grep "Kickstart partition instdev" | head -c1) 
 
 # Download and create templates
 wget -P /tmp http://folk.uib.no/edpto/provision_openstack.erb

--- a/provision/foreman-bgo-setup.sh
+++ b/provision/foreman-bgo-setup.sh
@@ -85,7 +85,7 @@ hammer os create --name CentOS --major 7 --minor 0.1406 --description "CentOS 7.
 
 # Download and create templates
 wget -P /tmp https://github.com/norcams/community-templates/blob/norcams/kickstart/norcams_provision.erb
-wget -P	/tmp https://github.com/norcams/community-templates/blob/norcams/kickstart/norcams_PXELinux.erb
+wget -P /tmp https://github.com/norcams/community-templates/blob/norcams/kickstart/norcams_PXELinux.erb
 hammer template create --name "Kickstart_openstack" --type provision --file /tmp/norcams_provision.erb
 hammer template create --name "Kickstart default PXELinux ifs" --type PXELinux --file /tmp/norcams_PXELinux.erb
 # Assign templates to OS

--- a/provision/foreman-bgo-setup.sh
+++ b/provision/foreman-bgo-setup.sh
@@ -74,8 +74,8 @@ hammer proxy import-classes --environment "production" --id 1
 hammer medium update --id 1 --path 'http://centos.uib.no/$version/os/$arch'
 
 # Download and create partition table
-wget -P http://folk.uib.no/edpto/provision_partition.erb
-hammer partition-table create --name "Kickstart partition instdev" --os-family Redhat --file /tmp/provision_partition.erb
+wget -P /tmp https://github.com/norcams/community-templates/blob/norcams/kickstart/norcams_disklayout.erb
+hammer partition-table create --name "Kickstart partition instdev" --os-family Redhat --file /tmp/norcams_disklayout.erb
 
 # Create OS
 hammer os create --name CentOS --major 7 --minor 0.1406 --description "CentOS 7.0" --family Redhat \
@@ -84,10 +84,10 @@ hammer os create --name CentOS --major 7 --minor 0.1406 --description "CentOS 7.
   --ptable-ids $(hammer partition-table list | grep "Kickstart partition instdev" | head -c1) 
 
 # Download and create templates
-wget -P /tmp http://folk.uib.no/edpto/provision_openstack.erb
-wget -P	/tmp http://folk.uib.no/edpto/provision_kickstart_ifs.erb
-hammer template create --name "Kickstart_openstack" --type provision --file /tmp/provision_openstack.erb
-hammer template create --name "Kickstart default PXELinux ifs" --type PXELinux --file /tmp/provision_kickstart_ifs.erb
+wget -P /tmp https://github.com/norcams/community-templates/blob/norcams/kickstart/norcams_provision.erb
+wget -P	/tmp https://github.com/norcams/community-templates/blob/norcams/kickstart/norcams_PXELinux.erb
+hammer template create --name "Kickstart_openstack" --type provision --file /tmp/norcams_provision.erb
+hammer template create --name "Kickstart default PXELinux ifs" --type PXELinux --file /tmp/norcams_PXELinux.erb
 # Assign templates to OS
 hammer template update --name "Kickstart default PXELinux ifs" --operatingsystem-ids 1
 hammer template update --name "Kickstart_openstack" --operatingsystem-ids 1

--- a/provision/foreman-osl-setup.sh
+++ b/provision/foreman-osl-setup.sh
@@ -36,14 +36,16 @@ hammer environment info --name "production"
 
 wget -P /tmp http://folk.uib.no/edpto/provision_openstack.erb
 wget -P /tmp http://folk.uib.no/edpto/provision_kickstart_ifs.erb
+wget -P	/tmp http://folk.uib.no/edpto/provision_partition.erb
 
+hammer partition-table create --name "Kickstart partition instdev" --os-family Redhat --file /tmp/provision_partition.erb
 hammer template create --name "Kickstart_openstack" --type provision --file /tmp/provision_openstack.erb
 hammer template create --name "Kickstart default PXELinux ifs" --type PXELinux --file /tmp/provision_kickstart_ifs.erb
 
 hammer os create --name CentOS --major 7 --minor 0.1406 --description "CentOS 7.0" --family Redhat \
   --architecture-ids 1 \
   --medium-ids $(hammer medium list | grep CentOS | head -c1) \
-  --ptable-ids $(hammer partition-table list | grep "Kickstart default" | head -c1) 
+  --ptable-ids $(hammer partition-table list | grep "Kickstart partition instdev" | head -c1) 
 
 hammer template update --name "Kickstart default PXELinux ifs" --operatingsystem-ids 1
 hammer template update --name "Kickstart_openstack" --operatingsystem-ids 1

--- a/provision/foreman-osl-setup.sh
+++ b/provision/foreman-osl-setup.sh
@@ -34,13 +34,13 @@ hammer subnet update --name "oob" \
 hammer environment create --name "production"
 hammer environment info --name "production"
 
-wget -P /tmp http://folk.uib.no/edpto/provision_openstack.erb
-wget -P /tmp http://folk.uib.no/edpto/provision_kickstart_ifs.erb
-wget -P /tmp http://folk.uib.no/edpto/provision_partition.erb
+wget -P /tmp https://github.com/norcams/community-templates/blob/norcams/kickstart/norcams_provision.erb
+wget -P /tmp https://github.com/norcams/community-templates/blob/norcams/kickstart/norcams_PXELinux.erb
+wget -P /tmp https://github.com/norcams/community-templates/blob/norcams/kickstart/norcams_disklayout.erb
 
-hammer partition-table create --name "Kickstart partition instdev" --os-family Redhat --file /tmp/provision_partition.erb
-hammer template create --name "Kickstart_openstack" --type provision --file /tmp/provision_openstack.erb
-hammer template create --name "Kickstart default PXELinux ifs" --type PXELinux --file /tmp/provision_kickstart_ifs.erb
+hammer partition-table create --name "Kickstart partition instdev" --os-family Redhat --file /tmp/norcams_disklayout.erb
+hammer template create --name "Kickstart_openstack" --type provision --file /tmp/norcams_provision.erb
+hammer template create --name "Kickstart default PXELinux ifs" --type PXELinux --file /tmp/norcams_PXELinux.erb
 
 hammer os create --name CentOS --major 7 --minor 0.1406 --description "CentOS 7.0" --family Redhat \
   --architecture-ids 1 \

--- a/provision/foreman-osl-setup.sh
+++ b/provision/foreman-osl-setup.sh
@@ -36,7 +36,7 @@ hammer environment info --name "production"
 
 wget -P /tmp http://folk.uib.no/edpto/provision_openstack.erb
 wget -P /tmp http://folk.uib.no/edpto/provision_kickstart_ifs.erb
-wget -P	/tmp http://folk.uib.no/edpto/provision_partition.erb
+wget -P /tmp http://folk.uib.no/edpto/provision_partition.erb
 
 hammer partition-table create --name "Kickstart partition instdev" --os-family Redhat --file /tmp/provision_partition.erb
 hammer template create --name "Kickstart_openstack" --type provision --file /tmp/provision_openstack.erb

--- a/provision/foreman-trd-setup.sh
+++ b/provision/foreman-trd-setup.sh
@@ -78,8 +78,8 @@ hammer proxy import-classes --environment "production" --id 1
 hammer medium update --id 1 --path 'http://centos.uib.no/$version/os/$arch'
 
 # Download and create partition	table
-wget -P http://folk.uib.no/edpto/provision_partition.erb
-hammer partition-table create --name "Kickstart partition instdev" --os-family Redhat --file /tmp/provision_partition.erb
+wget -P /tmp https://github.com/norcams/community-templates/blob/norcams/kickstart/norcams_disklayout.erb
+hammer partition-table create --name "Kickstart partition instdev" --os-family Redhat --file /tmp/norcams_disklayout.erb
 
 # Create OS
 hammer os create --name CentOS --major 7 --minor 0.1406 --description "CentOS 7.0" --family Redhat \
@@ -88,10 +88,10 @@ hammer os create --name CentOS --major 7 --minor 0.1406 --description "CentOS 7.
   --ptable-ids $(hammer partition-table list | grep "Kickstart partition instdev" | head -c1) 
 
 # Download and create templates
-wget -P /tmp http://folk.uib.no/edpto/provision_openstack.erb
-wget -P	/tmp http://folk.uib.no/edpto/provision_kickstart_ifs.erb
-hammer template create --name "Kickstart_openstack" --type provision --file /tmp/provision_openstack.erb
-hammer template create --name "Kickstart default PXELinux ifs" --type PXELinux --file /tmp/provision_kickstart_ifs.erb
+wget -P /tmp https://github.com/norcams/community-templates/blob/norcams/kickstart/norcams_provision.erb
+wget -P	/tmp https://github.com/norcams/community-templates/blob/norcams/kickstart/norcams_PXELinux.erb
+hammer template create --name "Kickstart_openstack" --type provision --file /tmp/norcams_provision.erb
+hammer template create --name "Kickstart default PXELinux ifs" --type PXELinux --file /tmp/norcams_provision.erb
 # Assign templates to OS
 hammer template update --name "Kickstart default PXELinux ifs" --operatingsystem-ids 1
 hammer template update --name "Kickstart_openstack" --operatingsystem-ids 1

--- a/provision/foreman-trd-setup.sh
+++ b/provision/foreman-trd-setup.sh
@@ -78,7 +78,7 @@ hammer proxy import-classes --environment "production" --id 1
 hammer medium update --id 1 --path 'http://centos.uib.no/$version/os/$arch'
 
 # Download and create partition	table
-wget -P	http://folk.uib.no/edpto/provision_partition.erb
+wget -P http://folk.uib.no/edpto/provision_partition.erb
 hammer partition-table create --name "Kickstart partition instdev" --os-family Redhat --file /tmp/provision_partition.erb
 
 # Create OS

--- a/provision/foreman-trd-setup.sh
+++ b/provision/foreman-trd-setup.sh
@@ -77,11 +77,15 @@ hammer proxy import-classes --environment "production" --id 1
 # TEMP FIX wrong url for some CentOS mirrors throug mirror.centos.org http://projects.theforeman.org/issues/6884
 hammer medium update --id 1 --path 'http://centos.uib.no/$version/os/$arch'
 
+# Download and create partition	table
+wget -P	http://folk.uib.no/edpto/provision_partition.erb
+hammer partition-table create --name "Kickstart partition instdev" --os-family Redhat --file /tmp/provision_partition.erb
+
 # Create OS
 hammer os create --name CentOS --major 7 --minor 0.1406 --description "CentOS 7.0" --family Redhat \
   --architecture-ids 1 \
   --medium-ids $(hammer medium list | grep CentOS | head -c1) \
-  --ptable-ids $(hammer partition-table list | grep "Kickstart default" | head -c1) 
+  --ptable-ids $(hammer partition-table list | grep "Kickstart partition instdev" | head -c1) 
 
 # Download and create templates
 wget -P /tmp http://folk.uib.no/edpto/provision_openstack.erb

--- a/provision/foreman-trd-setup.sh
+++ b/provision/foreman-trd-setup.sh
@@ -89,7 +89,7 @@ hammer os create --name CentOS --major 7 --minor 0.1406 --description "CentOS 7.
 
 # Download and create templates
 wget -P /tmp https://github.com/norcams/community-templates/blob/norcams/kickstart/norcams_provision.erb
-wget -P	/tmp https://github.com/norcams/community-templates/blob/norcams/kickstart/norcams_PXELinux.erb
+wget -P /tmp https://github.com/norcams/community-templates/blob/norcams/kickstart/norcams_PXELinux.erb
 hammer template create --name "Kickstart_openstack" --type provision --file /tmp/norcams_provision.erb
 hammer template create --name "Kickstart default PXELinux ifs" --type PXELinux --file /tmp/norcams_provision.erb
 # Assign templates to OS


### PR DESCRIPTION
With this modified kickstart template one can define a parameter "installdevice" (eg sdb). If the parameter is provided, kickstart will wipe all disk drives on the target and install linux to the provided installdevice. A volume group will be created on that device only, creating /boot, swap and a root lv spanning the rest of the device. This is useful on the storage nodes, where OS will be installed to sdm and vg/lvs on the other drives created by puppet.

If the "installdevice" parameter isn't provided, the default partitioning scheme will be used (useful for most VMs)