### PR TITLE
Refactor of site.pp

### DIFF
--- a/hieradata/common/common.yaml
+++ b/hieradata/common/common.yaml
@@ -1,10 +1,11 @@
 ---
-classes:
-  - profile::base::common
-  - hostname
-classes_bootstrap:
-  - profile::base::common
-  - hostname
+include:
+  default:
+    - profile::base::common
+    - hostname
+  bootstrap:
+    - profile::base::common
+    - hostname
 
 #
 # Location metadata

--- a/hieradata/common/roles/cephmon.yaml
+++ b/hieradata/common/roles/cephmon.yaml
@@ -1,9 +1,10 @@
 ---
-classes:
-  - profile::storage::cephmon
-  - profile::storage::cephmon_firewall
-classes_bootstrap:
-  - profile::storage::cephmon_firewall
+include:
+  default:
+    - profile::storage::cephmon
+    - profile::storage::cephmon_firewall
+  bootstrap:
+    - profile::storage::cephmon_firewall
 
 profile::storage::cephmon_firewall::manage_firewall:  true
 

--- a/hieradata/common/roles/compute.yaml
+++ b/hieradata/common/roles/compute.yaml
@@ -1,6 +1,7 @@
 ---
-classes:
-   - profile::openstack::compute::hypervisor
+include:
+  default:
+    - profile::openstack::compute::hypervisor
 
 openstack_extras::repo::redhat::redhat::manage_rdo: true
 profile::base::common::manage_lvm: true

--- a/hieradata/common/roles/controller.yaml
+++ b/hieradata/common/roles/controller.yaml
@@ -1,7 +1,8 @@
 ---
-classes:
-   - profile::virtualization::libvirt
-   - foreman_bootstrap::instances
+include:
+  default:
+    - profile::virtualization::libvirt
+    - foreman_bootstrap::instances
 
 profile::base::common::manage_lvm: true
 

--- a/hieradata/common/roles/foreman.yaml
+++ b/hieradata/common/roles/foreman.yaml
@@ -1,14 +1,15 @@
 ---
-classes:
-  - profile::application::foreman
-  - profile::database::postgresql
-  - profile::network::services
-  - profile::webserver::apache
-  - foreman::cli
-  - foreman::compute::libvirt
-  - foreman::plugin::hooks
-  - foreman::plugin::discovery
-  - foreman::plugin::templates
+include:
+  default:
+    - profile::application::foreman
+    - profile::database::postgresql
+    - profile::network::services
+    - profile::webserver::apache
+    - foreman::cli
+    - foreman::compute::libvirt
+    - foreman::plugin::hooks
+    - foreman::plugin::discovery
+    - foreman::plugin::templates
 
 profile::application::foreman::manage_eyaml:    true
 profile::application::foreman::manage_firewall: true

--- a/hieradata/common/roles/leaf.yaml
+++ b/hieradata/common/roles/leaf.yaml
@@ -1,4 +1,5 @@
 ---
-classes:
-  - profile::network::leaf
+include:
+  default:
+    - profile::network::leaf
 

--- a/hieradata/common/roles/login.yaml
+++ b/hieradata/common/roles/login.yaml
@@ -1,8 +1,9 @@
 ---
-classes:
-  - profile::base::login
-  - profile::network::services
-  - foreman_bootstrap::instances
+include:
+  default:
+    - profile::base::login
+    - profile::network::services
+    - foreman_bootstrap::instances
 
 profile::base::common::manage_firewall: false
 

--- a/hieradata/common/roles/master.yaml
+++ b/hieradata/common/roles/master.yaml
@@ -1,20 +1,21 @@
 ---
-classes:
-   - profile::messaging::rabbitmq
-   - profile::openstack::compute::api
-   - profile::openstack::compute::scheduler
-   - profile::openstack::compute::conductor
-   - profile::openstack::compute::consoleauth
-   - profile::openstack::compute::consoleproxy
-   - profile::openstack::dashboard
-   - profile::openstack::database::sql
-   - profile::openstack::identity
-   - profile::openstack::image::api
-   - profile::openstack::image::registry
-   - profile::openstack::network::controller
-   - profile::openstack::network::dhcp
-   - profile::openstack::network::l3
-   - profile::openstack::network::metadata
+include:
+  default:
+    - profile::messaging::rabbitmq
+    - profile::openstack::compute::api
+    - profile::openstack::compute::scheduler
+    - profile::openstack::compute::conductor
+    - profile::openstack::compute::consoleauth
+    - profile::openstack::compute::consoleproxy
+    - profile::openstack::dashboard
+    - profile::openstack::database::sql
+    - profile::openstack::identity
+    - profile::openstack::image::api
+    - profile::openstack::image::registry
+    - profile::openstack::network::controller
+    - profile::openstack::network::dhcp
+    - profile::openstack::network::l3
+    - profile::openstack::network::metadata
 
 openstack_extras::repo::redhat::redhat::manage_rdo: true
 

--- a/hieradata/common/roles/storage.yaml
+++ b/hieradata/common/roles/storage.yaml
@@ -1,11 +1,12 @@
 ---
-classes:
-  - profile::storage::cephosd
-  - profile::storage::cephosd_firewall
-  - profile::base::lvm
-classes_bootstrap:
-  - profile::storage::cephosd_firewall
-  - profile::base::lvm
+include:
+  default:
+    - profile::storage::cephosd
+    - profile::storage::cephosd_firewall
+    - profile::base::lvm
+  bootstrap:
+    - profile::storage::cephosd_firewall
+    - profile::base::lvm
 
 profile::base::manage_lvm:                           true
 


### PR DESCRIPTION
* Renamed 'classes' hieradata variable to 'include' and changed it
  to a runmode-indexed hash. 'default' contains the array of classes
  to include in a normal Puppet run
* Reworked site.pp logic to provide output that is easier to follow
  when debugging