### PR TITLE
Set keymap=no in vconsole.conf

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -7,7 +7,7 @@ local  = 'iaas@git.norcams.org:'
 #
 # profile
 #
-mod 'profile', :ref => 'norcams-0.5.3',          :git => github + 'norcams/puppeels'
+mod 'profile', :ref => 'norcams-0.5.4',          :git => github + 'norcams/puppeels'
 
 #
 # profile::base::common

--- a/hieradata/common/common.yaml
+++ b/hieradata/common/common.yaml
@@ -2,10 +2,8 @@
 include:
   default:
     - profile::base::common
-    - hostname
   bootstrap:
     - profile::base::common
-    - hostname
 
 #
 # Location metadata

--- a/hieradata/common/modules/keyboard.yaml
+++ b/hieradata/common/modules/keyboard.yaml
@@ -1,0 +1,3 @@
+---
+keyboard::keymap: 'no'
+

--- a/hieradata/common/modules/profile.yaml
+++ b/hieradata/common/modules/profile.yaml
@@ -10,6 +10,8 @@ profile::base::common::manage_sudo:            true
 profile::base::common::manage_authconfig:      false
 profile::base::common::manage_firewall:        true
 profile::base::common::manage_timezones:       true
+profile::base::common::manage_hostname:        true
+profile::base::common::manage_keyboard:        true
 
 profile::base::common::common_packages:
   - 'tcpdump'


### PR DESCRIPTION
* Wrote a simple module "keyboard" that sets keymap=no in
  /etc/vconsole.conf on RHEL 7 family systems
* Moved hostname management to profile::common::base