### PR TITLE
ipmi and lldp support

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -7,7 +7,7 @@ local  = 'iaas@git.norcams.org:'
 #
 # profile
 #
-mod 'profile', :ref => 'norcams-0.8.3',          :git => github + 'norcams/puppeels'
+mod 'profile', :ref => 'norcams-0.9.0',          :git => github + 'norcams/puppeels'
 
 #
 # profile::base::common
@@ -25,6 +25,8 @@ mod 'firewall', :ref => '1.5.0',                 :git => github + 'puppetlabs/pu
 mod 'kmod', :ref => '2.1.0',                     :git => github + 'camptocamp/puppet-kmod'
 mod 'named_interfaces', :ref => '0.2.0',         :git => github + 'norcams/puppet-named_interfaces'
 mod 'network', :ref => 'v3.1.26-11-g3aa6685',    :git => github + 'beddari/puppet-network'
+mod 'ipmi', :ref => 'v2.1.0',                    :git => github + 'jhoblitt/puppet-ipmi'
+mod 'lldp', :ref => '06523de010',                :git => github + 'norcams/puppet-lldp'
 
 #
 # profile::base::login

--- a/hieradata/common/modules/ipmi.yaml
+++ b/hieradata/common/modules/ipmi.yaml
@@ -1,0 +1,4 @@
+---
+ipmi::service_ensure:         stopped
+ipmi::ipmievd_service_ensure: stopped
+ipmi::watchdog:               false

--- a/hieradata/common/modules/lldp.yaml
+++ b/hieradata/common/modules/lldp.yaml
@@ -1,0 +1,2 @@
+---
+lldp::package_source: vbernat

--- a/hieradata/common/modules/profile.yaml
+++ b/hieradata/common/modules/profile.yaml
@@ -12,6 +12,8 @@ profile::base::common::manage_firewall:        true
 profile::base::common::manage_timezones:       true
 profile::base::common::manage_keyboard:        true
 profile::base::common::manage_network:         true
+profile::base::common::include_virtual:        true
+profile::base::common::include_physical:       true
 
 profile::base::common::common_packages:
   - 'tcpdump'


### PR DESCRIPTION
This enables ipmi and lldp modules on physical servers. To do
this a new profile feature is added to make it possible to
include classes based on the value of $::is_virtual