### PR TITLE
Apache keystone

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -7,7 +7,7 @@ local  = 'iaas@git.norcams.org:'
 #
 # profile
 #
-mod 'profile', :ref => 'norcams-0.10.8',         :git => github + 'norcams/puppeels'
+mod 'profile', :ref => 'norcams-0.11',         :git => github + 'norcams/puppeels'
 
 #
 # profile::base::common

--- a/hieradata/common/modules/keystone.yaml
+++ b/hieradata/common/modules/keystone.yaml
@@ -8,6 +8,8 @@ keystone::db::mysql::allowed_hosts:
 keystone::roles::admin::email: user@example.com
 keystone::roles::admin::password: admin_pass
 
+keystone::service_name: "httpd"
+
 keystone::endpoint::public_url:   "http://%{hiera('service__address__keystone')}:5000"
 keystone::endpoint::internal_url: "http://%{hiera('service__address__keystone')}:5000"
 keystone::endpoint::admin_url:    "http://%{hiera('service__address__keystone_admin')}:35357"

--- a/hieradata/common/modules/keystone.yaml
+++ b/hieradata/common/modules/keystone.yaml
@@ -15,6 +15,8 @@ keystone::endpoint::internal_url: "http://%{hiera('service__address__keystone')}
 keystone::endpoint::admin_url:    "http://%{hiera('service__address__keystone_admin')}:35357"
 keystone::endpoint::region:       'RegionOne'
 
+keystone::wsgi::apache::ssl: false
+
 keystone::admin_token: admintoken
 keystone::public_bind_host: "%{ipaddress_public1}"
 keystone::admin_bind_host: "%{ipaddress_mgmt1}"


### PR DESCRIPTION
These commits enables an apache wsgi server in front of keystone. This is the recommended way of running keystone, and the traditional way is deprecated.

ssl is disabled by default (for now)

It can be reactively implemented on existing installations by stopping the openstack-keystone.service and then running puppet.