### PR TITLE
Enable mulitdomain support for Horizon

### DIFF
--- a/hieradata/common/modules/horizon.yaml
+++ b/hieradata/common/modules/horizon.yaml
@@ -14,6 +14,7 @@ horizon::horizon_ca: "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
 horizon::horizon_cert: "/etc/ssl/certs/%{::fqdn}.crt"
 horizon::horizon_key:  "/etc/ssl/certs/%{::fqdn}.key"
 
+horizon::keystone_multidomain_support: false
 horizon::api_versions:
   'identity': 3
 

--- a/hieradata/vagrant/modules/horizon.yaml
+++ b/hieradata/vagrant/modules/horizon.yaml
@@ -1,0 +1,2 @@
+---
+keystone::keystone_multidomain_support: true


### PR DESCRIPTION
This adds a variable to control mulitdomain support for Horizon and
enables it for the vagrant location
