### PR TITLE
Proxy iptables

### DIFF
--- a/hieradata/common/roles/proxy.yaml
+++ b/hieradata/common/roles/proxy.yaml
@@ -5,4 +5,5 @@ include:
 
 profile::network::services::dns_proxy: true
 profile::network::services::http_proxy: true
-
+profile::network::services::firewall_extras:
+  source: '%{network_mgmt1}/%{netmask_mgmt1}'

--- a/hieradata/osl/roles/proxy.yaml
+++ b/hieradata/osl/roles/proxy.yaml
@@ -8,3 +8,4 @@ named_interfaces::config:
      - dummy0
 
 profile::base::network::manage_dummy: true
+profile::network::services::manage_nat: true


### PR DESCRIPTION
The DNS and HTTP/HTTPS proxy feature should only be available from the management network.