### PR TITLE
Ceph backend for cinder

### DIFF
--- a/hieradata/common/modules/nova.yaml
+++ b/hieradata/common/modules/nova.yaml
@@ -45,6 +45,13 @@ nova::compute::vncserver_proxyclient_address: "%{ipaddress_mgmt1}"
 nova::compute::vncproxy_host: "%{hiera('service__address__consoleproxy')}"
 nova::compute::libvirt::vncserver_listen: "%{ipaddress_mgmt1}"
 
+nova::compute::rbd::libvirt_rbd_user: 'cinder'
+nova::compute::rbd::libvirt_rbd_secret_uuid: '363cb82c-793f-4aff-93f5-3332376c4369'
+nova::compute::rbd::libvirt_images_rbd_pool: 'volumes'
+nova::compute::rbd::rbd_keyring: 'client.cinder'
+nova::compute::rbd::ephemeral_storage: false
+nova::compute::rbd::manage_ceph_client: false
+
 nova::keystone::auth::region: "%{location}"
 nova::os_region_name: "%{location}"
 nova::network::neutron::neutron_region_name: "%{location}"

--- a/hieradata/common/roles/master.yaml
+++ b/hieradata/common/roles/master.yaml
@@ -15,7 +15,6 @@ include:
     - profile::openstack::volume::api
     - profile::openstack::volume::scheduler
     - profile::openstack::volume::storage
-    - cinder::setup_test_volume
     - profile::openstack::network::controller
 #    - profile::openstack::network::dhcp
 #    - profile::openstack::network::l3

--- a/hieradata/common/roles/master.yaml
+++ b/hieradata/common/roles/master.yaml
@@ -57,3 +57,22 @@ profile::openstack::network::policies:
   create_router:
     key:   'create_router'
     value: 'rule:admin_only'
+
+profile::openstack::volume::type:
+  rbd:
+    set_key: 'volume_backend_name'
+    set_value: 'rbd-volumes'
+    os_tenant_name: 'services'
+    os_password: 'cinder_pass'
+    os_username: 'cinder'
+    os_region_name: "%{location}"
+    os_auth_url: "http://%{hiera('service__address__keystone')}:5000/v2.0"
+
+profile::openstack::volume::backend::rbd:
+  rbd-volumes:
+    rbd_pool: 'volumes'
+    rbd_user: 'cinder'
+    rbd_secret_uuid: 'AQBypF1V2JYiChAA2qYbjM6jbXJBMmpXPkvwBg=='
+
+cinder::backends::enabled_backends:
+  - rbd-volumes

--- a/hieradata/dev01/common.yaml
+++ b/hieradata/dev01/common.yaml
@@ -25,7 +25,7 @@ ceph::profile::params::mon_host:                    '172.17.16.40:6789, 172.17.1
 ceph::profile::params::cluster_network:             '172.17.16.0/20'
 ceph::profile::params::public_network:              '172.17.16.0/20'
 
-profile::openstack::volume::enable_rbd: true
+profile::openstack::volume::manage_rbd: true
 profile::openstack::volume::api::enable_multibackend: true
 
 named_interfaces::config:

--- a/hieradata/dev01/common.yaml
+++ b/hieradata/dev01/common.yaml
@@ -25,6 +25,9 @@ ceph::profile::params::mon_host:                    '172.17.16.40:6789, 172.17.1
 ceph::profile::params::cluster_network:             '172.17.16.0/20'
 ceph::profile::params::public_network:              '172.17.16.0/20'
 
+profile::openstack::volume::enable_rbd: true
+profile::openstack::volume::api::enable_multibackend: true
+
 named_interfaces::config:
   mgmt:
      - eth0

--- a/hieradata/dev01/common.yaml
+++ b/hieradata/dev01/common.yaml
@@ -27,6 +27,7 @@ ceph::profile::params::public_network:              '172.17.16.0/20'
 
 profile::openstack::volume::manage_rbd: true
 profile::openstack::volume::api::enable_multibackend: true
+profile::openstack::compute::hypervisor::manage_libvirt_rbd: true
 
 named_interfaces::config:
   mgmt:

--- a/profile/manifests/openstack/compute/hypervisor.pp
+++ b/profile/manifests/openstack/compute/hypervisor.pp
@@ -1,5 +1,6 @@
 class profile::openstack::compute::hypervisor (
   $hypervisor_type = 'libvirt', # Possible value libvirt, vmware, xenserver
+  $manage_libvirt_rbd = false,
   $manage_telemetry = true,
   $manage_firewall = true,
   $firewall_extras = {},
@@ -14,6 +15,10 @@ class profile::openstack::compute::hypervisor (
     include "::nova::compute::${hypervisor_type}"
   } else {
     fail("Invalid hypervisor_type selected: ${hypervisor_type}")
+  }
+
+  if $manage_libvirt_rbd {
+    include ::nova::compute::rbd
   }
 
   if $manage_telemetry {

--- a/profile/manifests/openstack/volume.pp
+++ b/profile/manifests/openstack/volume.pp
@@ -1,10 +1,10 @@
 class profile::openstack::volume(
-  $enable_rbd = false,
+  $manage_rbd = false,
 ) {
   include ::cinder
   include ::cinder::ceilometer
 
-  if $enable_rbd {
+  if $manage_rbd {
     include profile::storage::cephclient
   }
 }

--- a/profile/manifests/openstack/volume.pp
+++ b/profile/manifests/openstack/volume.pp
@@ -1,4 +1,10 @@
-class profile::openstack::volume {
+class profile::openstack::volume(
+  $enable_rbd = false,
+) {
   include ::cinder
   include ::cinder::ceilometer
+
+  if $enable_rbd {
+    include profile::storage::cephclient
+  }
 }

--- a/profile/manifests/openstack/volume/api.pp
+++ b/profile/manifests/openstack/volume/api.pp
@@ -1,6 +1,7 @@
 class profile::openstack::volume::api(
   $manage_firewall = true,
   $firewall_extras = {},
+  $enable_multibackend = false,
 ){
   include profile::openstack::volume
 
@@ -16,5 +17,14 @@ class profile::openstack::volume::api(
           port   => 3260,
           extras => $firewall_extras,
     }
+  }
+
+  if $enable_multibackend {
+    include cinder::backends
+
+    create_resources(cinder::backend::rbd, hiera('profile::openstack::volume::backend::rbd', {}))
+    create_resources(cinder::type, hiera('profile::openstack::volume::type', {}))
+  } else {
+    include ::cinder::setup_test_volume
   }
 }

--- a/profile/manifests/storage/cephclient.pp
+++ b/profile/manifests/storage/cephclient.pp
@@ -1,0 +1,6 @@
+# Class: profile::storage::cephclient
+#
+#
+class profile::storage::cephclient {
+  include ::ceph::profile::client
+}


### PR DESCRIPTION
These changes give an option to choose ceph as backend to cinder. In addition, it facilitates the possibility for multiple cinder backends of the same and/or different type in any combination.

By default, cinder will be configured with only a single backend, a flat, iSCSI-backed lvm store in a loop file on the cinder node.
