### PR TITLE
Integrating glance with ceph backend

### DIFF
--- a/hieradata/common/modules/ceph.yaml
+++ b/hieradata/common/modules/ceph.yaml
@@ -34,6 +34,13 @@ ceph::profile::params::client_keys:
     secret: 'AQCztJdSyNb0NBAASA2yPZPuwXeIQnDJ9O8gVw=='
     keyring_path: '/var/lib/ceph/bootstrap-mds/ceph.keyring'
     cap_mon: 'allow profile bootstrap-mds'
+  'client.glance':
+    secret: 'AQBGJ8dWKhgcNhAA+VU0GlKHcRLJSsJ8WouuSQ=='
+    mode: '0600'
+    user: 'glance'
+    group: 'glance'
+    cap_mon: 'allow r'
+    cap_osd: 'allow class-read object_prefix rbd_children, allow rwx pool=images'
   'client.volumes':
     secret: 'AQA4MPZTOGU0ARAAXH9a0fXxVq0X25n2yPREDw=='
     mode: '0600'

--- a/hieradata/common/modules/glance.yaml
+++ b/hieradata/common/modules/glance.yaml
@@ -5,6 +5,7 @@ glance::api::auth_uri: "http://%{hiera('service__address__keystone')}:5000/"
 glance::api::database_connection: "mysql://glance:glance_pass@%{hiera('service__address__mysql')}/glance"
 glance::api::workers: 1
 glance::api::registry_host: "%{hiera('service__address__glance_registry')}"
+glance::api::show_image_direct_url: true
 
 glance::registry::keystone_password: glance_pass
 glance::registry::bind_host: "%{ipaddress_public1}"
@@ -25,3 +26,6 @@ glance::keystone::auth::internal_url: "http://%{hiera('service__address__glance_
 
 glance::keystone::auth::region: "%{location}"
 glance::api::os_region_name: "%{location}"
+
+glance::backend::rbd::rbd_store_user: 'glance'
+glance::backend::rbd::rbd_store_pool: 'images'

--- a/hieradata/common/roles/cephmon.yaml
+++ b/hieradata/common/roles/cephmon.yaml
@@ -23,5 +23,5 @@ accounts::usergroups:
 accounts::accounts:
   'cinder':
     ensure: present
-  'glance'
+  'glance':
     ensure: present

--- a/hieradata/common/roles/cephmon.yaml
+++ b/hieradata/common/roles/cephmon.yaml
@@ -11,11 +11,17 @@ profile::storage::cephmon_firewall::manage_firewall:  true
 accounts::users:
   'cinder':
     ensure: present
+  'glance':
+    ensure: present
 
 accounts::usergroups:
   'cinder':
     - 'cinder'
+  'glance':
+    - 'glance'
 
 accounts::accounts:
   'cinder':
+    ensure: present
+  'glance'
     ensure: present

--- a/hieradata/common/roles/storage.yaml
+++ b/hieradata/common/roles/storage.yaml
@@ -18,13 +18,19 @@ profile::storage::cephosd_firewall::manage_firewall: true
 accounts::users:
   'cinder':
     ensure: present
+  'glance':
+    ensure: present
 
 accounts::usergroups:
   'cinder':
     - 'cinder'
+  'glance':
+    - 'glance'
 
 accounts::accounts:
   'cinder':
+    ensure: present
+  'glance'
     ensure: present
 
 ceph::profile::params::osd_journal_size: '10240'

--- a/hieradata/common/roles/storage.yaml
+++ b/hieradata/common/roles/storage.yaml
@@ -30,7 +30,7 @@ accounts::usergroups:
 accounts::accounts:
   'cinder':
     ensure: present
-  'glance'
+  'glance':
     ensure: present
 
 ceph::profile::params::osd_journal_size: '10240'

--- a/hieradata/dev01/common.yaml
+++ b/hieradata/dev01/common.yaml
@@ -29,6 +29,9 @@ profile::openstack::volume::manage_rbd: true
 profile::openstack::volume::api::enable_multibackend: true
 profile::openstack::compute::hypervisor::manage_libvirt_rbd: true
 
+# If backend != file, you must explicitly define stores in %location/modules/glance.yaml
+profile::openstack::image::api::backend: 'rbd'
+
 named_interfaces::config:
   mgmt:
      - eth0

--- a/hieradata/dev01/modules/glance.yaml
+++ b/hieradata/dev01/modules/glance.yaml
@@ -1,0 +1,3 @@
+glance::api::known_stores:
+ - glance.store.rbd.Store
+ - glance.store.http.Store


### PR DESCRIPTION
These changes allows the glance api to be integrated with a rbd backend. If not explicitly defined, a simple file backend will be provided.