### PR TITLE
An atempt to allow mulitple destination and source in firewall rules

### DIFF
--- a/profile/manifests/firewall/expand_rule.pp
+++ b/profile/manifests/firewall/expand_rule.pp
@@ -1,0 +1,18 @@
+#
+define profile::firewall::expand_rule(
+  $rule,
+  $type,
+  $rule_name
+) {
+
+  # Override $type with $name
+  $with_source = {
+    "$type" => $name
+  }
+
+  $real_rule = merge($rule, $with_source)
+  validate_hash($real_rule)
+
+  create_resources('firewall', { "${rule_name} from ${name}" => $real_rule })
+
+}

--- a/profile/manifests/firewall/rule.pp
+++ b/profile/manifests/firewall/rule.pp
@@ -39,6 +39,21 @@ define profile::firewall::rule (
   $rule = merge($basic, $extras)
   validate_hash($rule)
 
-  create_resources('firewall', { "${title}" => $rule })
+  # We can only expand source or destination, not both!
+  if is_array($source) {
+    profile::firewall::expand_rule { $source:
+      rule => $rule,
+      type => 'source',
+      rule_name => $name
+    }
+  } elsif is_array($destination) {
+    profile::firewall::expand_rule { $destination:
+      rule => $rule,
+      type => 'destination',
+      rule_name => $name
+    }
+  } else {
+    create_resources('firewall', { "${title}" => $rule })
+  }
 
 }


### PR DESCRIPTION
Should not break any existing rules, but if $source or $destination is an array it will expand them and add one rule for each. 