### PR TITLE
Moved api proxy away from dashboard profile

### DIFF
--- a/hieradata/common/roles/dashboard.yaml
+++ b/hieradata/common/roles/dashboard.yaml
@@ -2,6 +2,7 @@
 include:
   default:
     - profile::openstack::dashboard
+    - profile::openstack::api
 
 profile::base::network::manage_dummy: true
 
@@ -17,53 +18,31 @@ profile::base::common::packages:
   - python-oslo-log
   - python-openstackclient
 
-profile::openstack::dashboard::vhost_definition:
+profile::openstack::api::default_vhost_config:
+  servername:           "%{hiera('service__address__horizon')}"
+  vhost_name:           "%{hiera('service__address__horizon')}"
+  ip:                   "%{::ipaddress_public1}"
+  docroot:              '/var/www/html'
+  manage_docroot:       false
+
+profile::openstack::api::vhosts:
   keystone_api:
-    vhost_name:         "%{hiera('service__address__horizon')}"
-    servername:         "%{hiera('service__address__horizon')}"
     port:               '5000'
-    ip:                 "%{::ipaddress_public1}"
-    docroot:            '/var/www/html'
-    manage_docroot:     false
     proxy_dest:         "http://%{hiera('service__address__keystone')}:5000"
-    proxy_preserve_host: true
+    extra:
+      proxy_preserve_host:  true
   nova_ec2_api:
-    vhost_name:         "%{hiera('service__address__horizon')}"
-    servername:         "%{hiera('service__address__horizon')}"
     port:               '8773'
-    ip:                 "%{::ipaddress_public1}"
-    docroot:            '/var/www/html'
-    manage_docroot:     false
     proxy_dest:         "http://%{hiera('service__address__nova_api')}:8773"
   nova_api:
-    vhost_name:         "%{hiera('service__address__horizon')}"
-    servername:         "%{hiera('service__address__horizon')}"
     port:               '8774'
-    ip:                 "%{::ipaddress_public1}"
-    docroot:            '/var/www/html'
-    manage_docroot:     false
     proxy_dest:         "http://%{hiera('service__address__nova_api')}:8774"
   cinder_api:
-    vhost_name:         "%{hiera('service__address__horizon')}"
-    servername:         "%{hiera('service__address__horizon')}"
     port:               '8776'
-    ip:                 "%{::ipaddress_public1}"
-    docroot:            '/var/www/html'
-    manage_docroot:     false
     proxy_dest:         "http://%{hiera('service__address__cinder_api')}:8776"
   glance_api:
-    vhost_name:         "%{hiera('service__address__horizon')}"
-    servername:         "%{hiera('service__address__horizon')}"
     port:               '9292'
-    ip:                 "%{::ipaddress_public1}"
-    docroot:            '/var/www/html'
-    manage_docroot:     false
     proxy_dest:         "http://%{hiera('service__address__glance_api')}:9292"
   neutron_server:
-    vhost_name:         "%{hiera('service__address__horizon')}"
-    servername:         "%{hiera('service__address__horizon')}"
     port:               '9696'
-    ip:                 "%{::ipaddress_public1}"
-    docroot:            '/var/www/html'
-    manage_docroot:     false
     proxy_dest:         "http://%{hiera('service__address__neutron_server')}:9696"

--- a/profile/manifests/openstack/api.pp
+++ b/profile/manifests/openstack/api.pp
@@ -1,0 +1,9 @@
+# Profile for the public api service
+class profile::openstack::api(
+  $vhosts,
+  $default_vhost_config = {}
+) {
+
+  create_resources('profile::openstack::api::proxy', $vhosts)
+
+}

--- a/profile/manifests/openstack/api/proxy.pp
+++ b/profile/manifests/openstack/api/proxy.pp
@@ -1,0 +1,19 @@
+#
+define profile::openstack::api::proxy(
+  $port,
+  $proxy_dest,
+  $extra = {},
+  $defaults = $profile::openstack::api::default_vhost_config,
+) {
+
+  $basic = {
+    servername => $servername,
+    port => $port,
+    proxy_dest => $proxy_dest
+  }
+
+  $config = merge($defaults, merge($basic, $extra))
+
+  create_resources('::apache::vhost', { "${title}" => $config })
+
+}

--- a/profile/manifests/openstack/dashboard.pp
+++ b/profile/manifests/openstack/dashboard.pp
@@ -1,8 +1,7 @@
 class profile::openstack::dashboard(
   $manage_ssl_cert = true,
   $manage_firewall = true,
-  $firewall_extras = {},
-  $vhost_definition = {}
+  $firewall_extras = {}
 ) {
   include ::horizon
 
@@ -20,8 +19,5 @@ class profile::openstack::dashboard(
       extras  => $firewall_extras,
     }
   }
-
-  # Used for API proxy
-  create_resources('::apache::vhost', $vhost_definition)
 
 }


### PR DESCRIPTION
Allow for easier management of the api proxy. All vhosts should be the same as before.