### PR TITLE
Create networks in OpenStack

### DIFF
--- a/hieradata/common/roles/master.yaml
+++ b/hieradata/common/roles/master.yaml
@@ -15,6 +15,7 @@ include:
     - profile::openstack::volume::scheduler
     - profile::openstack::volume::storage
     - profile::openstack::network::controller
+    - profile::openstack::network::createnetworks
 #    - profile::openstack::network::dhcp
 #    - profile::openstack::network::l3
 #    - profile::openstack::network::metadata

--- a/hieradata/common/roles/master.yaml
+++ b/hieradata/common/roles/master.yaml
@@ -15,7 +15,7 @@ include:
     - profile::openstack::volume::scheduler
     - profile::openstack::volume::storage
     - profile::openstack::network::controller
-    - profile::openstack::network::createnetworks
+    - profile::openstack::resource::createnetworks
 #    - profile::openstack::network::dhcp
 #    - profile::openstack::network::l3
 #    - profile::openstack::network::metadata

--- a/hieradata/dev01/roles/master.yaml
+++ b/hieradata/dev01/roles/master.yaml
@@ -15,7 +15,7 @@ profile::openstack::createnetworks::networks:
 profile::openstack::createnetworks::subnets:
   public:
     name: 'public'
-    cidr: '27'
+    cidr: '129.177.31.96/27'
     ip_version: '4'
     allocation_pools:
       - 'start=129.177.31.98,end=129.177.31.123'

--- a/hieradata/dev01/roles/master.yaml
+++ b/hieradata/dev01/roles/master.yaml
@@ -4,15 +4,15 @@
 #    destination: "%{ipaddress_public1}"
 #    source: '172.31.34.0/24'
 
-profile::openstack::createnetworks::networks:
+profile::openstack::resource::networks:
   public:
-    name:                  'public'
-    admin_state_up:        true
-    shared:                true
-    tenant_name:           'openstack'
+    name: 'public'
+    admin_state_up: true
+    shared: true
+    tenant_name: 'openstack'
     provider_network_type: 'local'
 
-profile::openstack::createnetworks::subnets:
+profile::openstack::resource::subnets:
   public:
     name: 'public'
     cidr: '129.177.31.96/27'

--- a/hieradata/dev01/roles/master.yaml
+++ b/hieradata/dev01/roles/master.yaml
@@ -3,3 +3,11 @@
 #  '020 allow all from transport network to public ip':
 #    destination: "%{ipaddress_public1}"
 #    source: '172.31.34.0/24'
+
+profile::openstack::createnetworks::networks:
+  public:
+    name:                  'public'
+    admin_state_up:        true
+    shared:                true
+    tenant_name:           'openstack'
+    provider_network_type: 'local'

--- a/hieradata/dev01/roles/master.yaml
+++ b/hieradata/dev01/roles/master.yaml
@@ -11,3 +11,17 @@ profile::openstack::createnetworks::networks:
     shared:                true
     tenant_name:           'openstack'
     provider_network_type: 'local'
+
+profile::openstack::createnetworks::subnets:
+  public:
+    name: 'public'
+    cidr: '27'
+    ip_version: '4'
+    allocation_pools:
+      - 'start=129.177.31.98,end=129.177.31.123'
+    gateway_ip: '129.177.31.97'
+    dns_nameservers:
+      - '129.177.6.54'
+      - '129.177.12.31'
+    network_name: 'public'
+    tenant_name: 'openstack'

--- a/profile/manifests/openstack/network/createnetworks.pp
+++ b/profile/manifests/openstack/network/createnetworks.pp
@@ -1,8 +1,0 @@
-# Class: profile::openstack::network::createnetworks
-#
-#
-class profile::openstack::network::createnetworks {
-
-  create_resources(neutron_network, hiera('profile::openstack::createnetworks::networks', {}))
-  create_resources(neutron_subnet, hiera('profile::openstack::createnetworks::subnets', {}))
-}

--- a/profile/manifests/openstack/network/createnetworks.pp
+++ b/profile/manifests/openstack/network/createnetworks.pp
@@ -2,7 +2,6 @@
 #
 #
 class profile::openstack::network::createnetworks {
-  include ::lvm
 
   create_resources(neutron_network, hiera('profile::openstack::createnetworks::networks', {}))
   create_resources(neutron_subnet, hiera('profile::openstack::createnetworks::subnets', {}))

--- a/profile/manifests/openstack/network/createnetworks.pp
+++ b/profile/manifests/openstack/network/createnetworks.pp
@@ -1,0 +1,8 @@
+# Class: profile::openstack::network::createnetworks
+#
+#
+class profile::openstack::network::createnetworks {
+  include ::lvm
+
+  create_resources(neutron_network, hiera('profile::openstack::createnetworks::networks', {}))
+}

--- a/profile/manifests/openstack/network/createnetworks.pp
+++ b/profile/manifests/openstack/network/createnetworks.pp
@@ -5,4 +5,5 @@ class profile::openstack::network::createnetworks {
   include ::lvm
 
   create_resources(neutron_network, hiera('profile::openstack::createnetworks::networks', {}))
+  create_resources(neutron_subnet, hiera('profile::openstack::createnetworks::subnets', {}))
 }

--- a/profile/manifests/openstack/resource/createnetworks.pp
+++ b/profile/manifests/openstack/resource/createnetworks.pp
@@ -1,0 +1,8 @@
+# Class: profile::openstack::resource::createnetworks
+#
+#
+class profile::openstack::resource::createnetworks {
+
+  create_resources(neutron_network, hiera_hash('profile::openstack::resource::networks', {}))
+  create_resources(neutron_subnet, hiera_hash('profile::openstack::resource::subnets', {}))
+}


### PR DESCRIPTION
These changes enables the creation (on neutron master) of networks and subnets in OpenStack.