### PR TITLE
Set host request header only when refered from access and dataporten

### DIFF
--- a/hieradata/bgo/roles/dashboard.yaml
+++ b/hieradata/bgo/roles/dashboard.yaml
@@ -11,3 +11,4 @@ profile::openstack::api::default_vhost_config:
   ssl_key:              "/etc/pki/tls/private/dashboard_iaas_uib_no.key"
 
 dpapp_referer: '^http://access\.iaas\.uib\.no/login\?'
+dashboard_referer: '^https://dashboard\.iaas\.uib\.no/dashboard'

--- a/hieradata/bgo/roles/dashboard.yaml
+++ b/hieradata/bgo/roles/dashboard.yaml
@@ -9,3 +9,5 @@ profile::openstack::api::default_vhost_config:
   ssl_ca:               "/etc/pki/tls/certs/DigiCertCA.crt"
   ssl_cert:             "/etc/pki/tls/certs/dashboard_iaas_uib_no.crt"
   ssl_key:              "/etc/pki/tls/private/dashboard_iaas_uib_no.key"
+
+dpapp_referer: '^http://access\.iaas\.uib\.no/login\?'

--- a/hieradata/common/roles/dashboard.yaml
+++ b/hieradata/common/roles/dashboard.yaml
@@ -17,6 +17,8 @@ profile::base::common::packages:
   - python-oslo-log
   - python-openstackclient
 
+dpapp_referer: '^http://access\.'
+
 profile::openstack::api::default_vhost_config:
   servername:           "%{hiera('service__address__horizon')}"
   vhost_name:           "%{hiera('service__address__horizon')}"
@@ -30,7 +32,11 @@ profile::openstack::api::vhosts:
     proxy_dest:         "http://%{hiera('service__address__keystone')}:5000"
     extra:
       proxy_preserve_host:  true
-      request_headers:      'set X-Forwarded-Proto "https"'
+      setenvif:
+        - "Referer '%{hiera('dpapp_referer')}' access_referal"
+      request_headers:
+        - 'set X-Forwarded-Proto "https"'
+        - "set Host '%{hiera('service__address__keystone_public')}' env=access_referal"
   nova_ec2_api:
     port:               '8773'
     proxy_dest:         "http://%{hiera('service__address__nova_api')}:8773"

--- a/hieradata/common/roles/dashboard.yaml
+++ b/hieradata/common/roles/dashboard.yaml
@@ -18,6 +18,7 @@ profile::base::common::packages:
   - python-openstackclient
 
 dpapp_referer: '^http://access\.'
+dashboard_referer: '^https://dashboard\.'
 
 profile::openstack::api::default_vhost_config:
   servername:           "%{hiera('service__address__horizon')}"
@@ -34,9 +35,11 @@ profile::openstack::api::vhosts:
       proxy_preserve_host:  true
       setenvif:
         - "Referer '%{hiera('dpapp_referer')}' access_referal"
+        - "Referer '%{hiera('dashboard_referer')}' dashboard_referal"
       request_headers:
         - 'set X-Forwarded-Proto "https"'
         - "set Host '%{hiera('service__address__keystone_public')}' env=access_referal"
+        - "set Host '%{hiera('service__address__keystone_public')}' env=dashboard_referal"
   nova_ec2_api:
     port:               '8773'
     proxy_dest:         "http://%{hiera('service__address__nova_api')}:8773"

--- a/hieradata/osl/roles/dashboard.yaml
+++ b/hieradata/osl/roles/dashboard.yaml
@@ -9,3 +9,5 @@ profile::openstack::api::default_vhost_config:
   ssl_ca:               "/etc/pki/tls/certs/DigiCertCA.crt"
   ssl_cert:             "/etc/pki/tls/certs/dashboard_iaas_uio_no.crt"
   ssl_key:              "/etc/pki/tls/private/dashboard_iaas_uio_no.key"
+
+dpapp_referer: '^http://access\.iaas\.uio\.no/login\?'

--- a/hieradata/vagrant/modules/keystone.yaml
+++ b/hieradata/vagrant/modules/keystone.yaml
@@ -1,3 +1,8 @@
 ---
 keystone::use_syslog:    true
 keystone::log_facility:  'LOG_LOCAL2'
+
+# Turn on very verbose logging
+keystone::verbose: true
+keystone::debug:   true
+keystone::wsgi::apache::vhost_custom_fragment: "LogLevel trace4"

--- a/hieradata/vagrant/roles/dashboard.yaml
+++ b/hieradata/vagrant/roles/dashboard.yaml
@@ -3,15 +3,13 @@ include:
   default:
     - profile::network::localdns
 
-profile::openstack::adminrc::cacert:      '/opt/himlar/provision/ca/certs/ca-chain.cert.pem'
+profile::openstack::adminrc::cacert:            '/opt/himlar/provision/ca/certs/ca-chain.cert.pem'
 
 profile::openstack::dashboard::manage_ssl_cert: true
-profile::application::sslcert::cert_name: 'vagrant'
+profile::application::sslcert::cert_name:       'vagrant'
+profile::application::sslcert::commonname:      "dashboard.%{domain}"
 
-profile::application::sslcert::commonname: "dashboard.%{domain}"
-#profile::application::sslcert::altnames:
-#  - "DNS.1 = dashboard.%{domain}"
-#  - "DNS.2 = api.%{domain}"
+dpapp_referer: '^http://access\.himlar\.local/login\?'
 
 profile::openstack::api::default_vhost_config:
   servername:           "%{hiera('service__address__keystone_public')}"
@@ -23,26 +21,3 @@ profile::openstack::api::default_vhost_config:
   ssl_ca:               '/opt/himlar/provision/ca/certs/ca-chain.cert.pem'
   ssl_key:              '/etc/pki/tls/private/vagrant.key'
   ssl_cert:             '/etc/pki/tls/certs/vagrant.crt'
-
-profile::openstack::api::vhosts:
-  keystone_api:
-    port:               '5000'
-    proxy_dest:         "http://%{hiera('service__address__keystone')}:5000"
-    extra:
-      proxy_preserve_host:  true
-      request_headers:      'set X-Forwarded-Proto "https"'
-  nova_ec2_api:
-    port:               '8773'
-    proxy_dest:         "http://%{hiera('service__address__nova_api')}:8773"
-  nova_api:
-    port:               '8774'
-    proxy_dest:         "http://%{hiera('service__address__nova_api')}:8774"
-  cinder_api:
-    port:               '8776'
-    proxy_dest:         "http://%{hiera('service__address__cinder_api')}:8776"
-  glance_api:
-    port:               '9292'
-    proxy_dest:         "http://%{hiera('service__address__glance_api')}:9292"
-  neutron_server:
-    port:               '9696'
-    proxy_dest:         "http://%{hiera('service__address__neutron_server')}:9696"


### PR DESCRIPTION
Dette er et hack som vil hindre at oidc vil sette port to ganger i returaddressen som brukes fra Dataporten/Feide Connect. Det skal nå være mulig å komme rett inn i dashboard uten å fikse URL manuelt.