### PR TITLE
Controller routing

### DIFF
--- a/hieradata/dev01/modules/calico.yaml
+++ b/hieradata/dev01/modules/calico.yaml
@@ -22,6 +22,10 @@ calico::reflector::clients:
     peer_ipv4: '172.31.34.104'
   c6:
     peer_ipv4: '172.31.34.105'
+  c7:
+    peer_ipv4: '172.31.34.5'
+  c8:
+    peer_ipv4: '172.31.34.6'
 
 # compute node settings
 calico::compute::peer_defaults:

--- a/hieradata/dev01/roles/controller.yaml
+++ b/hieradata/dev01/roles/controller.yaml
@@ -8,3 +8,48 @@ foreman_bootstrap::virt_install:
     install_ip:      '172.31.1.11'
     install_netmask: '255.255.255.0'
     install_gateway: '172.31.1.1'
+
+include:
+  default:
+    - profile::virtualization::libvirt
+    - foreman_bootstrap::instances
+    - calico
+    - calico::compute
+    - profile::network::bird
+
+calico::compute::manage_dhcp_agent: false
+calico::compute::manage_metadata_service: false
+calico::compute::felix_enable: false
+calico::compute::manage_qemu_settings: false
+
+libvirt::qemu_cgroup_device_acl:
+  - "/dev/null"
+  - "/dev/full"
+  - "/dev/zero"
+  - "/dev/random"
+  - "/dev/urandom"
+  - "/dev/ptmx"
+  - "/dev/kvm"
+  - "/dev/kqemu"
+  - "/dev/rtc"
+  - "/dev/hpet"
+  - "/dev/net/tun"
+libvirt::qemu_user: 'root'
+libvirt::qemu_group: 'root'
+libvirt::qemu_clear_emulator_capabilities: '0'
+
+profile::base::network::manage_dummy: true
+profile::base::network::no_of_dummies: 2
+profile::base::network::remove_route: true
+profile::base::network::remove_route_ifs:
+  - dummy0
+  - dummy1
+
+named_interfaces::config:
+  mgmt:
+     - br0
+  transport:
+     - eth1_912
+     - eth1_913
+  service:
+     - eth1_912

--- a/hieradata/dev01/roles/controller.yaml
+++ b/hieradata/dev01/roles/controller.yaml
@@ -21,7 +21,7 @@ calico::compute::manage_dhcp_agent: false
 calico::compute::manage_metadata_service: false
 calico::compute::felix_enable: false
 calico::compute::manage_qemu_settings: false
-calico::compute::peer_template: 'profile/bird/bird.conf.erb'
+calico::compute::bird_template: 'profile/bird/bird.conf.erb'
 
 libvirt::qemu_cgroup_device_acl:
   - "/dev/null"

--- a/hieradata/dev01/roles/controller.yaml
+++ b/hieradata/dev01/roles/controller.yaml
@@ -41,6 +41,7 @@ libvirt::qemu_clear_emulator_capabilities: '0'
 
 profile::base::network::manage_dummy: true
 profile::base::network::no_of_dummies: 2
+profile::base::network::l3_router: true
 profile::base::network::remove_route: true
 profile::base::network::remove_route_ifs:
   - dummy0

--- a/hieradata/dev01/roles/controller.yaml
+++ b/hieradata/dev01/roles/controller.yaml
@@ -21,6 +21,7 @@ calico::compute::manage_dhcp_agent: false
 calico::compute::manage_metadata_service: false
 calico::compute::felix_enable: false
 calico::compute::manage_qemu_settings: false
+calico::compute::peer_template: 'profile/bird/bird.conf.erb'
 
 libvirt::qemu_cgroup_device_acl:
   - "/dev/null"

--- a/hieradata/nodes/dev01-controller-01.yaml
+++ b/hieradata/nodes/dev01-controller-01.yaml
@@ -1,10 +1,9 @@
 ---
 network::interfaces_hash:
-  'bond0':
-    onboot:       'yes'
-    mtu:          '9000'
-    bonding_opts: 'balance-alb miimon=100'
-    bridge:       'br0'
+  'eth0':
+    onboot:     'yes'
+    mtu:        '9000'
+    bridge:     'br0'
   'br0':
     onboot:     'yes'
     mtu:        '9000'

--- a/hieradata/nodes/dev01-controller-01.yaml
+++ b/hieradata/nodes/dev01-controller-01.yaml
@@ -10,15 +10,14 @@ network::interfaces_hash:
     type:       'Bridge'
     ipaddress:  '172.31.1.5'
     netmask:    '255.255.255.0'
-    gateway:    '172.31.1.1'
-    defroute:   'yes'
+    defroute:   'no'
     bridge_stp: 'off'
   'eth1.912':
     ipaddress: '172.31.34.5'
     netmask:   '255.255.255.0'
     gateway:   '172.31.34.1'
-    defroute:  'yes'
     vlan:      'yes'
+    defroute:  'no'
   'eth1.913':
     ipaddress: '172.31.35.5'
     netmask:   '255.255.255.0'

--- a/hieradata/nodes/dev01-controller-01.yaml
+++ b/hieradata/nodes/dev01-controller-01.yaml
@@ -14,14 +14,26 @@ network::interfaces_hash:
     gateway:    '172.31.1.1'
     defroute:   'yes'
     bridge_stp: 'off'
-  'eth0':
-    onboot:    'yes'
-    mtu:       '9000'
-    master:    'bond0'
-    slave:     'yes'
-  'eth1':
-    onboot:    'yes'
-    mtu:       '9000'
+  'eth1.912':
+    ipaddress: '172.31.34.5'
+    netmask:   '255.255.255.0'
+    gateway:   '172.31.34.1'
+    defroute:  'yes'
+    vlan:      'yes'
+  'eth1.913':
+    ipaddress: '172.31.35.5'
+    netmask:   '255.255.255.0'
+    gateway:   '172.31.35.1'
+    vlan:      'yes'
+    defroute:  'no'
+  'dummy0':
+    ipaddress: '129.177.31.97'
+    netmask:   '255.255.255.224'
+    defroute:  'no'
+  'dummy1':
+    ipaddress: '172.31.16.1'
+    netmask:   '255.255.255.0'
+    defroute:  'no'
 
 lvm::volume_groups:
   vg_root:

--- a/hieradata/nodes/dev01-controller-02.yaml
+++ b/hieradata/nodes/dev01-controller-02.yaml
@@ -10,15 +10,14 @@ network::interfaces_hash:
     type:       'Bridge'
     ipaddress:  '172.31.1.6'
     netmask:    '255.255.255.0'
-    gateway:    '172.31.1.1'
-    defroute:   'yes'
+    defroute:   'no'
     bridge_stp: 'off'
   'eth1.912':
     ipaddress: '172.31.34.6'
     netmask:   '255.255.255.0'
     gateway:   '172.31.34.1'
-    defroute:  'yes'
     vlan:      'yes'
+    defroute:  'no'
   'eth1.913':
     ipaddress: '172.31.35.6'
     netmask:   '255.255.255.0'
@@ -46,6 +45,7 @@ lvm::volume_groups:
   vg_root:
     physical_volumes:
       - /dev/sda2
+      - /dev/sda3
     logical_volumes:
       lv_libvirt:
         fs_type:   xfs

--- a/hieradata/nodes/dev01-controller-02.yaml
+++ b/hieradata/nodes/dev01-controller-02.yaml
@@ -1,10 +1,9 @@
 ---
 network::interfaces_hash:
-  'bond0':
-    onboot:       'yes'
-    mtu:          '9000'
-    bonding_opts: 'balance-alb miimon=100'
-    bridge:       'br0'
+  'eth0':
+    onboot:     'yes'
+    mtu:        '9000'
+    bridge:     'br0'
   'br0':
     onboot:     'yes'
     mtu:        '9000'
@@ -14,20 +13,39 @@ network::interfaces_hash:
     gateway:    '172.31.1.1'
     defroute:   'yes'
     bridge_stp: 'off'
-  'eth0':
+  'eth1.912':
+    ipaddress: '172.31.34.6'
+    netmask:   '255.255.255.0'
+    gateway:   '172.31.34.1'
+    defroute:  'yes'
+    vlan:      'yes'
+  'eth1.913':
+    ipaddress: '172.31.35.6'
+    netmask:   '255.255.255.0'
+    gateway:   '172.31.35.1'
+    vlan:      'yes'
+    defroute:  'no'
+  'dummy0':
+    ipaddress: '129.177.31.97'
+    netmask:   '255.255.255.224'
+    defroute:  'no'
+  'dummy1':
+    ipaddress: '172.31.16.1'
+    netmask:   '255.255.255.0'
+    defroute:  'no'
+  'tap-dev01dashboard01':
+    bootproto: 'none'
+    type:      'Tap'
     onboot:    'yes'
-    mtu:       '9000'
-    master:    'bond0'
-    slave:     'yes'
-  'eth1':
+  'tap-dev01dpapp01':
+    bootproto: 'none'
+    type:      'Tap'
     onboot:    'yes'
-    mtu:       '9000'
 
 lvm::volume_groups:
   vg_root:
     physical_volumes:
       - /dev/sda2
-      - /dev/sda3
     logical_volumes:
       lv_libvirt:
         fs_type:   xfs

--- a/hieradata/nodes/dev01-controller-02.yaml
+++ b/hieradata/nodes/dev01-controller-02.yaml
@@ -32,14 +32,20 @@ network::interfaces_hash:
     ipaddress: '172.31.16.1'
     netmask:   '255.255.255.0'
     defroute:  'no'
-  'tap-dev01dashboard01':
+  'atap-dboard01':
     bootproto: 'none'
     type:      'Tap'
     onboot:    'yes'
-  'tap-dev01dpapp01':
+  'atap-dpapp01':
     bootproto: 'none'
     type:      'Tap'
     onboot:    'yes'
+
+profile::base::network::mroute:
+  'dummy0':
+    routes:
+      '129.177.31.125/32': 'atap-dpapp01'
+      '129.177.31.126/32': 'atap-dboard01'
 
 lvm::volume_groups:
   vg_root:

--- a/hieradata/nodes/dev01-dashboard-01.yaml
+++ b/hieradata/nodes/dev01-dashboard-01.yaml
@@ -6,12 +6,7 @@ network::interfaces_hash:
     mtu:       '1500'
     defroute:  'no'
   'eth1':
-    ipaddress: '172.31.34.22'
-    netmask:   '255.255.255.0'
-    gateway:   '172.31.34.1'
-    srcaddr:   '129.177.31.126'
-    defroute:  'yes'
-  'dummy0':
     ipaddress: '129.177.31.126'
-    netmask:   '255.255.255.255'
-    defroute:  'no'
+    netmask:   '255.255.255.224'
+    gateway:   '129.177.31.97'
+    defroute:  'yes'

--- a/hieradata/nodes/dev01-dpapp-01.yaml
+++ b/hieradata/nodes/dev01-dpapp-01.yaml
@@ -6,12 +6,7 @@ network::interfaces_hash:
     mtu:       '1500'
     defroute:  'no'
   'eth1':
-    ipaddress: '172.31.34.19'
-    netmask:   '255.255.255.0'
-    gateway:   '172.31.34.1'
-    srcaddr:   '129.177.31.125'
-    defroute:  'yes'
-  'dummy0':
     ipaddress: '129.177.31.125'
-    netmask:   '255.255.255.255'
-    defroute:  'no'
+    netmask:   '255.255.255.224'
+    gateway:   '129.177.31.97'
+    defroute:  'yes'

--- a/profile/manifests/base/network.pp
+++ b/profile/manifests/base/network.pp
@@ -6,6 +6,7 @@ class profile::base::network(
   $http_proxy       = undef,
   $remove_route     = false,
   $remove_route_ifs = undef,
+  $l3_router        = false,
 ) {
 
   # Set up extra logical fact names for network facts
@@ -40,6 +41,16 @@ class profile::base::network(
       group   => 'root',
       mode    => '754',
       content => template("${module_name}/network/ifup-local.erb"),
+    }
+  }
+
+  # In order to route to tap interfaces, ip forwarding must be enabled
+  if $l3_router {
+    sysctl::value { "net.ipv4.ip_forward":
+      value => 1,
+    }
+    sysctl::value { "net.ipv6.conf.all.forwarding":
+      value => 1,
     }
   }
 

--- a/profile/templates/bird/bird.conf.erb
+++ b/profile/templates/bird/bird.conf.erb
@@ -1,0 +1,47 @@
+
+router id <%= @router_id %>;
+
+<% if @debug %>debug protocols all;
+<% end -%>
+# We are only going to export routes from Calico interfaces.
+# Currently, 'tap*' is used by the OpenStack implimentation
+# and 'cali*' is used by the docker implimentation.
+# dummy1 is the interface that bare metal "service" addresses
+# should be bound to if they should be exported.
+# This will need to be updated as we add new interface names.
+#
+# Also filter out default, just in case.
+#
+# We should automate the build of this out of variables when
+# we have time.
+
+filter export_bgp {
+  if ( (ifname ~ "tap*") || (ifname ~ "cali*") || (ifname ~ "dummy1") ) then {
+    if  net != 0.0.0.0/0 then accept;
+  }
+  reject;
+}
+
+# Configure synchronization between BIRD's routing tables and the
+# kernel.
+protocol kernel {
+  learn;          # Learn all alien routes from the kernel
+  persist;        # Don't remove routes on bird shutdown
+  scan time 2;    # Scan kernel routing table every 2 seconds
+  import all;
+  graceful restart;
+  export all;     # Default is export none
+}
+
+# Watch interface up/down events.
+protocol device {
+  scan time 2;    # Scan interfaces every 2 seconds
+}
+
+protocol direct {
+   debug all;
+   interface "-dummy*", "eth*", "em*", "en*", "br-mgmt";
+}
+
+# Include
+include "/etc/bird/bird.conf.d/*.conf";

--- a/profile/templates/bird/bird6.conf.erb
+++ b/profile/templates/bird/bird6.conf.erb
@@ -1,0 +1,47 @@
+
+router id <%= @router_id %>;
+
+<% if @debug %>debug protocols all;
+<% end -%>
+# We are only going to export routes from Calico interfaces.
+# Currently, 'tap*' is used by the OpenStack implimentation
+# and 'cali*' is used by the docker implimentation.
+# dummy1 is the interface that bare metal "service" addresses
+# should be bound to if they should be exported.
+# This will need to be updated as we add new interface names.
+#
+# Also filter out default, just in case.
+#
+# We should automate the build of this out of variables when
+# we have time.
+
+filter export_bgp {
+  if ( (ifname ~ "tap*") || (ifname ~ "cali*") || (ifname ~ "dummy1") ) then {
+    if  net != ::/0 then accept;
+  }
+  reject;
+}
+
+# Configure synchronization between BIRD's routing tables and the
+# kernel.
+protocol kernel {
+  learn;          # Learn all alien routes from the kernel
+  persist;        # Don't remove routes on bird shutdown
+  scan time 2;    # Scan kernel routing table every 2 seconds
+  import all;
+  graceful restart;
+  export all;     # Default is export none
+}
+
+# Watch interface up/down events.
+protocol device {
+  scan time 2;    # Scan interfaces every 2 seconds
+}
+
+protocol direct {
+   debug all;
+   interface "-dummy*", "eth*", "em*", "en*";
+}
+
+# Include
+include "/etc/bird/bird6.conf.d/*.conf";


### PR DESCRIPTION
Necessary changes for implementing l3 routing for kvm. In addition, new releases of puppet-calico and norcams/puppet-libvirt are required for these changes to work.

In short, this creates a calico-like networking environment, although routes and devices must be created manually (or in code).