### PR TITLE
Updated firewall rules for ssh

### DIFF
--- a/hieradata/common/common.yaml
+++ b/hieradata/common/common.yaml
@@ -9,6 +9,9 @@ include:
     - profile::base::common
     - profile::base::firewall
 
+profile::firewall::pre::ssh_settings:
+  source: "%{::network_mgmt1}/%{::netmask_mgmt1}"
+
 #
 # Location metadata
 #

--- a/hieradata/common/roles/login.yaml
+++ b/hieradata/common/roles/login.yaml
@@ -10,6 +10,9 @@ profile::base::firewall::manage_firewall: false
 profile::network::services::manage_nat: true
 puppet::runmode: 'none'
 
+profile::firewall::pre::ssh_settings:
+  source: "0.0.0.0/0"
+
 accounts::accounts:
   'hege':
     ensure: present

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -22,6 +22,9 @@ allow_from_network:
 
 endpoint_protocol: 'https'
 
+profile::firewall::pre::ssh_settings:
+  source: "0.0.0.0/0"
+
 #
 # Openstack services
 #


### PR DESCRIPTION
Make sure ssh by default is only allowed from mgmt net. Except login and vagrant where access is global.