### PR TITLE
Cumulus configuration

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -19,7 +19,7 @@ mod 'lvm', :ref => '689d42a16c',                 :git => github + 'puppetlabs/pu
 mod 'firewall', :ref => '1.5.0',                 :git => github + 'puppetlabs/puppetlabs-firewall'
 mod 'kmod', :ref => '2.1.0',                     :git => github + 'camptocamp/puppet-kmod'
 mod 'named_interfaces', :ref => '0.2.0',         :git => github + 'norcams/puppet-named_interfaces'
-mod 'network', :ref => '4fb822167c',             :git => github + 'norcams/puppet-network'
+mod 'network', :ref => '123980c67f',             :git => github + 'norcams/puppet-network'
 mod 'ipmi', :ref => 'c4309504fd',                :git => github + 'norcams/puppet-ipmi'
 mod 'lldp', :ref => '06523de010',                :git => github + 'norcams/puppet-lldp'
 mod 'apt', :ref => '2.2.2',                      :git => github + 'puppetlabs/puppetlabs-apt'

--- a/Puppetfile
+++ b/Puppetfile
@@ -19,7 +19,7 @@ mod 'lvm', :ref => '689d42a16c',                 :git => github + 'puppetlabs/pu
 mod 'firewall', :ref => '1.5.0',                 :git => github + 'puppetlabs/puppetlabs-firewall'
 mod 'kmod', :ref => '2.1.0',                     :git => github + 'camptocamp/puppet-kmod'
 mod 'named_interfaces', :ref => '0.2.0',         :git => github + 'norcams/puppet-named_interfaces'
-mod 'network', :ref => '123980c67f',             :git => github + 'norcams/puppet-network'
+mod 'network', :ref => '0529e7b415',             :git => github + 'norcams/puppet-network'
 mod 'ipmi', :ref => 'c4309504fd',                :git => github + 'norcams/puppet-ipmi'
 mod 'lldp', :ref => '06523de010',                :git => github + 'norcams/puppet-lldp'
 mod 'apt', :ref => '2.2.2',                      :git => github + 'puppetlabs/puppetlabs-apt'

--- a/hieradata/common/roles/leaf.yaml
+++ b/hieradata/common/roles/leaf.yaml
@@ -43,3 +43,5 @@ sudo::configs:
       - 'snmp ALL = NOPASSWD: /usr/cumulus/bin/cl-resource-query'
       - 'snmp ALL=(root) NOPASSWD: /sbin/ethtool -S *'
       - 'snmp ALL=(root) NOPASSWD: /sbin/ip'
+
+profile::base::network::cumulus_ifs: true

--- a/hieradata/common/roles/leaf.yaml
+++ b/hieradata/common/roles/leaf.yaml
@@ -15,6 +15,7 @@ profile::base::common::include_virtual:        false
 profile::base::common::include_physical:       false
 profile::base::common::manage_packages:        false
 profile::base::firewall::manage_firewall:      false
+profile::base::network::cumulus_ifs:           true
 
 accounts::groups:
   'wheel':
@@ -42,5 +43,3 @@ sudo::configs:
       - 'snmp ALL = NOPASSWD: /usr/cumulus/bin/cl-resource-query'
       - 'snmp ALL=(root) NOPASSWD: /sbin/ethtool -S *'
       - 'snmp ALL=(root) NOPASSWD: /sbin/ip'
-
-profile::base::network::cumulus_ifs: true

--- a/hieradata/common/roles/leaf.yaml
+++ b/hieradata/common/roles/leaf.yaml
@@ -35,6 +35,7 @@ profile::base::common::packages:
   'bind-utils': { 'ensure': 'absent', }
   'libaugeas-ruby1.9.1': {}
   'augeas-tools': {}
+  'cl-mgmtvrf': {}
 
 sudo::configs:
   snmp:

--- a/hieradata/common/roles/leaf.yaml
+++ b/hieradata/common/roles/leaf.yaml
@@ -44,3 +44,7 @@ sudo::configs:
       - 'snmp ALL = NOPASSWD: /usr/cumulus/bin/cl-resource-query'
       - 'snmp ALL=(root) NOPASSWD: /sbin/ethtool -S *'
       - 'snmp ALL=(root) NOPASSWD: /sbin/ip'
+
+profile::base::network::cumulus_interfaces:
+  'lo':
+    'addr_method': 'loopback'

--- a/hieradata/common/roles/leaf.yaml
+++ b/hieradata/common/roles/leaf.yaml
@@ -11,7 +11,6 @@ profile::base::common::classes:
   - openstack_extras::repo::debian::debian
 
 profile::base::common::manage_keyboard:        false
-profile::base::common::manage_network:         false
 profile::base::common::include_virtual:        false
 profile::base::common::include_physical:       false
 profile::base::common::manage_packages:        false

--- a/hieradata/common/roles/leaf.yaml
+++ b/hieradata/common/roles/leaf.yaml
@@ -15,6 +15,7 @@ profile::base::common::include_virtual:        false
 profile::base::common::include_physical:       false
 profile::base::common::manage_packages:        false
 profile::base::firewall::manage_firewall:      false
+profile::base::network::net_ifnames:           false
 profile::base::network::cumulus_ifs:           true
 
 accounts::groups:

--- a/hieradata/common/roles/leaf.yaml
+++ b/hieradata/common/roles/leaf.yaml
@@ -17,6 +17,7 @@ profile::base::common::manage_packages:        false
 profile::base::firewall::manage_firewall:      false
 profile::base::network::net_ifnames:           false
 profile::base::network::cumulus_ifs:           true
+network::config_file_per_interface:            true
 
 accounts::groups:
   'wheel':

--- a/hieradata/nodes/dev01-leaf-02.yaml
+++ b/hieradata/nodes/dev01-leaf-02.yaml
@@ -27,3 +27,5 @@ profile::base::network::routes:
     'netmask':   [ '0.0.0.0', ]
     'gateway':   [ '172.31.1.1', ]
     'table':     [ 'mgmt', ]
+
+profile::network::leaf::manage_license: true

--- a/hieradata/nodes/dev01-leaf-02.yaml
+++ b/hieradata/nodes/dev01-leaf-02.yaml
@@ -1,7 +1,9 @@
 ---
-profile::base::network::cumulus_interfaces:
+network::interfaces_hash:
   'eth0':
-    'ipv4': [ '172.31.1.9/24', ]
+    'ipaddress': '172.31.1.9/24'
+    'post_up': [ '/etc/network/if-up.d/z90-route-eth0', ]
+    'post_down': [ '/etc/network/if-down.d/z90-route-eth0', ]
 
 # In production environment these should be VLAN aware
 # bridges and actually tagged. This is not possible in
@@ -17,3 +19,11 @@ profile::base::network::cumulus_bridges:
     'ports': [ 'swp2', ]
     'alias_name': 'Transport_2 L2 if'
     'mtu': '1500'
+
+# Add default route for management VRF
+profile::base::network::routes:
+  'eth0':
+    'ipaddress': [ '0.0.0.0', ]
+    'netmask':   [ '0.0.0.0', ]
+    'gateway':   [ '172.31.1.1', ]
+    'table':     [ 'mgmt', ]

--- a/hieradata/nodes/dev01-leaf-02.yaml
+++ b/hieradata/nodes/dev01-leaf-02.yaml
@@ -1,0 +1,19 @@
+---
+profile::base::network::cumulus_interfaces:
+  'eth0':
+    'ipv4': [ '172.31.1.9/24', ]
+
+# In production environment these should be VLAN aware
+# bridges and actually tagged. This is not possible in
+# dev01 environment, though.
+profile::base::network::cumulus_bridges:
+  'br100':
+    'ipv4': [ '172.31.34.2/24', ]
+    'ports': [ 'swp1', ]
+    'alias_name': 'Transport_1 L2 if'
+    'mtu': '1500'
+  'br200':
+    'ipv4': [ '172.31.35.2/24', ]
+    'ports': [ 'swp2', ]
+    'alias_name': 'Transport_2 L2 if'
+    'mtu': '1500'

--- a/profile/manifests/base/network.pp
+++ b/profile/manifests/base/network.pp
@@ -134,5 +134,11 @@ class profile::base::network(
     create_resources(cumulus_interface, hiera_hash('profile::base::network::cumulus_interfaces', {}))
     create_resources(cumulus_bridge, hiera_hash('profile::base::network::cumulus_bridges', {}))
     create_resources(cumulus_bond, hiera_hash('profile::base::network::cumulus_bonds', {}))
+
+    # Check for Cumulus Management VRF, enable if disabled
+    exec { "cl-mgmtvrf --enable":
+      path   => "/usr/bin:/usr/sbin:/bin",
+      unless => "cl-mgmtvrf --status",
+    }
   }
 }

--- a/profile/manifests/base/network.pp
+++ b/profile/manifests/base/network.pp
@@ -139,6 +139,7 @@ class profile::base::network(
     exec { "cl-mgmtvrf --enable":
       path   => "/usr/bin:/usr/sbin:/bin",
       unless => "cl-mgmtvrf --status",
+      onlyif => [ 'test -e /etc/network/interfaces.d/eth0', 'test -e /etc/network/if-up.d/z90-route-eth0' ]
     }
   }
 }

--- a/profile/manifests/base/network.pp
+++ b/profile/manifests/base/network.pp
@@ -120,8 +120,8 @@ class profile::base::network(
   }
 
   if $cumulus_ifs {
-    create_resources(cumulus_interface, hiera_hash('profile::base::network::cumulus_interface', {})))
-    create_resources(cumulus_bridge, hiera_hash('profile::base::network::cumulus_bridge', {})))
-    create_resources(cumulus_bond, hiera_hash('profile::base::network::cumulus_bond', {})))
+    create_resources(cumulus_interface, hiera_hash('profile::base::network::cumulus_interface', {}))
+    create_resources(cumulus_bridge, hiera_hash('profile::base::network::cumulus_bridge', {}))
+    create_resources(cumulus_bond, hiera_hash('profile::base::network::cumulus_bond', {}))
   }
 }

--- a/profile/manifests/base/network.pp
+++ b/profile/manifests/base/network.pp
@@ -9,6 +9,7 @@ class profile::base::network(
   $l3_router        = false,
   $node_multinic    = false,
   $has_servicenet   = false,
+  $cumulus_ifs      = false,
 ) {
 
   # Set up extra logical fact names for network facts
@@ -116,5 +117,11 @@ class profile::base::network(
       target  => $target,
       value   => $http_proxy,
     }
+  }
+
+  if $cumulus_ifs {
+    create_resources(cumulus_interface, hiera_hash('profile::base::network::cumulus_interface', {})))
+    create_resources(cumulus_bridge, hiera_hash('profile::base::network::cumulus_bridge', {})))
+    create_resources(cumulus_bond, hiera_hash('profile::base::network::cumulus_bond', {})))
   }
 }

--- a/profile/manifests/base/network.pp
+++ b/profile/manifests/base/network.pp
@@ -1,6 +1,7 @@
 #
 class profile::base::network(
   $manage_dummy     = false,
+  $net_ifnames      = true,
   $no_of_dummies    = 1,
   $manage_httpproxy = false,
   $http_proxy       = undef,
@@ -20,9 +21,11 @@ class profile::base::network(
 
   # - Set ifnames=0 and use old ifnames, e.g 'eth0'
   # - Use biosdevname on physical servers, e.g 'em1'
-  kernel_parameter { "net.ifnames":
-    ensure => present,
-    value  => "0",
+  if $net_ifnames {
+    kernel_parameter { "net.ifnames":
+      ensure => present,
+      value  => "0",
+    }
   }
 
   # Persistently install dummy module

--- a/profile/manifests/base/network.pp
+++ b/profile/manifests/base/network.pp
@@ -120,8 +120,8 @@ class profile::base::network(
   }
 
   if $cumulus_ifs {
-    create_resources(cumulus_interface, hiera_hash('profile::base::network::cumulus_interface', {}))
-    create_resources(cumulus_bridge, hiera_hash('profile::base::network::cumulus_bridge', {}))
-    create_resources(cumulus_bond, hiera_hash('profile::base::network::cumulus_bond', {}))
+    create_resources(cumulus_interface, hiera_hash('profile::base::network::cumulus_interfaces', {}))
+    create_resources(cumulus_bridge, hiera_hash('profile::base::network::cumulus_bridges', {}))
+    create_resources(cumulus_bond, hiera_hash('profile::base::network::cumulus_bonds', {}))
   }
 }

--- a/profile/manifests/base/network.pp
+++ b/profile/manifests/base/network.pp
@@ -123,6 +123,14 @@ class profile::base::network(
   }
 
   if $cumulus_ifs {
+    # For cumulus interfaces to work, we need a non default interfaces config file
+    file { '/etc/network/interfaces':
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0754',
+      content => template("${module_name}/network/cl-interfaces.erb"),
+    }
+
     create_resources(cumulus_interface, hiera_hash('profile::base::network::cumulus_interfaces', {}))
     create_resources(cumulus_bridge, hiera_hash('profile::base::network::cumulus_bridges', {}))
     create_resources(cumulus_bond, hiera_hash('profile::base::network::cumulus_bonds', {}))

--- a/profile/manifests/network/leaf.pp
+++ b/profile/manifests/network/leaf.pp
@@ -1,7 +1,15 @@
 #
 #
-class profile::network::leaf
-{
+class profile::network::leaf(
+  $manage_license     = false,
+  $cumulus_license    = "user@example.com|00000000000000000000000000000000000000000000000000\n",
+) {
   include quagga
 
+  if $manage_license {
+    file { '/tmp/licfile':
+      ensure  => file,
+      content => $cumulus_license,
+    }
+  }
 }

--- a/profile/manifests/network/leaf.pp
+++ b/profile/manifests/network/leaf.pp
@@ -10,6 +10,10 @@ class profile::network::leaf(
     file { '/tmp/licfile':
       ensure  => file,
       content => $cumulus_license,
+    } ->
+    cumulus_license { 'cumulus_license':
+      src => '/tmp/licfile',
+      notify => Service['switchd']
     }
   }
 }

--- a/profile/templates/network/cl-interfaces.erb
+++ b/profile/templates/network/cl-interfaces.erb
@@ -5,8 +5,4 @@
 # This file describes the network interfaces available on your system
 # and how to activate them. For more information, see interfaces(5).
 
-# The loopback network interface
-auto lo
-iface lo inet loopback
-
 source /etc/network/interfaces.d/*

--- a/profile/templates/network/cl-interfaces.erb
+++ b/profile/templates/network/cl-interfaces.erb
@@ -1,0 +1,12 @@
+#
+# This file is managed by puppet!
+#
+
+# This file describes the network interfaces available on your system
+# and how to activate them. For more information, see interfaces(5).
+
+# The loopback network interface
+auto lo
+iface lo inet loopback
+
+source /etc/network/interfaces.d/*


### PR DESCRIPTION
These changes provides more mechanisms for configuring a Cumulus leaf node:
- sudo config
- network management for switch ports and bridges
- management VRF for eth0
- installation of license file

For this to work, puppet modules must be refreshed (cumulus interface module, cumulus license module, general networking module).