### PR TITLE
Base nodeset and role

### DIFF
--- a/nodes.yaml
+++ b/nodes.yaml
@@ -56,6 +56,8 @@ nodesets:
     - role: "logger"
       cpus:   1
       memory: 2048
+  base:
+    - role: "base"
   access:
     - role: "db"
       cpus:   1


### PR DESCRIPTION
Add a base nodeset to ease simple testing and expose only the config present in the base profile