### PR TITLE
Upgrade from calico 1.3 to calico 1.4

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -38,7 +38,7 @@ mod 'quagga', :ref => '0e3a7a16bb',              :git => github + 'norcams/puppe
 # profile::network::
 #
 mod 'bird', :ref => 'master',                    :git => github + 'norcams/puppet-bird'
-mod 'calico', :ref => 'reflector_fix',           :git => github + 'raykrist/puppet-calico'
+mod 'calico', :ref => 'calico-dhcp',             :git => github + 'norcams/puppet-calico'
 mod 'dnsmasq', :ref => 'v1.2.0',                 :git => github + 'saz/puppet-dnsmasq'
 mod 'ipcalc', :ref => '1.2.2',                   :git => github + 'inkblot/puppet-ipcalc'
 mod 'tinyproxy', :ref => 'bc56e3ecc2',           :git => github + 'earsdown/puppet-tinyproxy'

--- a/hieradata/common/modules/calico.yaml
+++ b/hieradata/common/modules/calico.yaml
@@ -25,3 +25,6 @@ calico::compute::peer_defaults:
 #calico::compute::peers:
 #  rr1:
 #    peer_ipv4: '10.4.0.11'
+
+# New dhcp agent with the 1.4 release of calico
+calico::compute::compute_dhcp_agent: 'calico'

--- a/hieradata/common/modules/neutron.yaml
+++ b/hieradata/common/modules/neutron.yaml
@@ -18,6 +18,7 @@ neutron::server::notifications::nova_admin_auth_url: "http://%{hiera('service__a
 neutron::server::notifications::nova_url: "http://%{hiera('service__address__nova_api')}:8774/v2"
 neutron::server::notifications::nova_admin_username: nova
 
+neutron::agents::dhcp::enabled: false
 # Uncomment for calico v1.3 and older
 #neutron::agents::dhcp::interface_driver: networking_calico.agent.linux.interface.RoutedInterfaceDriver
 #neutron::agents::dhcp::dhcp_driver: networking_calico.agent.linux.dhcp.DnsmasqRouted

--- a/hieradata/common/modules/neutron.yaml
+++ b/hieradata/common/modules/neutron.yaml
@@ -1,11 +1,5 @@
 neutron::bind_host: "%{ipaddress_transport1}"
-#neutron::core_plugin: neutron.plugins.ml2.plugin.Ml2Plugin
 neutron::core_plugin: 'calico'
-#neutron::service_plugins:
-#  - neutron.services.l3_router.l3_router_plugin.L3RouterPlugin
-
-## http://docs.projectcalico.org/en/stable/configuration.html#neutron-server-etc-neutron-neutron-conf
-#neutron::dhcp_agents_per_network: '9999'
 
 neutron::server::auth_host: "%{hiera('service__address__keystone_admin')}"
 neutron::server::auth_uri: "http://%{hiera('service__address__keystone')}:5000/"
@@ -19,19 +13,6 @@ neutron::server::notifications::nova_url: "http://%{hiera('service__address__nov
 neutron::server::notifications::nova_admin_username: nova
 
 neutron::agents::dhcp::enabled: false
-# Uncomment for calico v1.3 and older
-#neutron::agents::dhcp::interface_driver: networking_calico.agent.linux.interface.RoutedInterfaceDriver
-#neutron::agents::dhcp::dhcp_driver: networking_calico.agent.linux.dhcp.DnsmasqRouted
-#neutron::agents::dhcp::use_namespaces: false
-
-# Uncomment for calico v1.3 and older
-#neutron::plugins::ml2::type_drivers:
-#  - local
-#  - flat
-#neutron::plugins::ml2::tenant_network_types:
-#  - local
-#neutron::plugins::ml2::mechanism_drivers:
-#  - calico
 
 neutron::db::mysql::allowed_hosts:
   - "%{ipaddress_service1}"

--- a/hieradata/common/modules/neutron.yaml
+++ b/hieradata/common/modules/neutron.yaml
@@ -1,10 +1,11 @@
 neutron::bind_host: "%{ipaddress_transport1}"
-neutron::core_plugin: neutron.plugins.ml2.plugin.Ml2Plugin
-neutron::service_plugins:
-  - neutron.services.l3_router.l3_router_plugin.L3RouterPlugin
+#neutron::core_plugin: neutron.plugins.ml2.plugin.Ml2Plugin
+neutron::core_plugin: 'calico'
+#neutron::service_plugins:
+#  - neutron.services.l3_router.l3_router_plugin.L3RouterPlugin
 
-# http://docs.projectcalico.org/en/stable/configuration.html#neutron-server-etc-neutron-neutron-conf
-neutron::dhcp_agents_per_network: '9999'
+## http://docs.projectcalico.org/en/stable/configuration.html#neutron-server-etc-neutron-neutron-conf
+#neutron::dhcp_agents_per_network: '9999'
 
 neutron::server::auth_host: "%{hiera('service__address__keystone_admin')}"
 neutron::server::auth_uri: "http://%{hiera('service__address__keystone')}:5000/"
@@ -17,20 +18,20 @@ neutron::server::notifications::nova_admin_auth_url: "http://%{hiera('service__a
 neutron::server::notifications::nova_url: "http://%{hiera('service__address__nova_api')}:8774/v2"
 neutron::server::notifications::nova_admin_username: nova
 
-neutron::agents::dhcp::interface_driver: networking_calico.agent.linux.interface.RoutedInterfaceDriver
-neutron::agents::dhcp::dhcp_driver: networking_calico.agent.linux.dhcp.DnsmasqRouted
-neutron::agents::dhcp::use_namespaces: false
+#neutron::agents::dhcp::interface_driver: networking_calico.agent.linux.interface.RoutedInterfaceDriver
+#neutron::agents::dhcp::dhcp_driver: networking_calico.agent.linux.dhcp.DnsmasqRouted
+#neutron::agents::dhcp::use_namespaces: false
 neutron::agents::metadata::auth_url: "http://%{hiera('service__address__keystone_admin')}:35357/v2.0"
 neutron::agents::metadata::metadata_ip: "%{hiera('service__address__nova_api_metadata')}"
 neutron::agents::metadata::auth_region: "%{location}"
 
-neutron::plugins::ml2::type_drivers:
-  - local
-  - flat
-neutron::plugins::ml2::tenant_network_types:
-  - local
-neutron::plugins::ml2::mechanism_drivers:
-  - calico
+#neutron::plugins::ml2::type_drivers:
+#  - local
+#  - flat
+#neutron::plugins::ml2::tenant_network_types:
+#  - local
+#neutron::plugins::ml2::mechanism_drivers:
+#  - calico
 
 neutron::db::mysql::allowed_hosts:
   - "%{ipaddress_service1}"

--- a/hieradata/common/modules/neutron.yaml
+++ b/hieradata/common/modules/neutron.yaml
@@ -18,13 +18,16 @@ neutron::server::notifications::nova_admin_auth_url: "http://%{hiera('service__a
 neutron::server::notifications::nova_url: "http://%{hiera('service__address__nova_api')}:8774/v2"
 neutron::server::notifications::nova_admin_username: nova
 
+# Uncomment for calico v1.3 and older
 #neutron::agents::dhcp::interface_driver: networking_calico.agent.linux.interface.RoutedInterfaceDriver
 #neutron::agents::dhcp::dhcp_driver: networking_calico.agent.linux.dhcp.DnsmasqRouted
 #neutron::agents::dhcp::use_namespaces: false
+
 neutron::agents::metadata::auth_url: "http://%{hiera('service__address__keystone_admin')}:35357/v2.0"
 neutron::agents::metadata::metadata_ip: "%{hiera('service__address__nova_api_metadata')}"
 neutron::agents::metadata::auth_region: "%{location}"
 
+# Uncomment for calico v1.3 and older
 #neutron::plugins::ml2::type_drivers:
 #  - local
 #  - flat

--- a/hieradata/common/modules/neutron.yaml
+++ b/hieradata/common/modules/neutron.yaml
@@ -24,10 +24,6 @@ neutron::agents::dhcp::enabled: false
 #neutron::agents::dhcp::dhcp_driver: networking_calico.agent.linux.dhcp.DnsmasqRouted
 #neutron::agents::dhcp::use_namespaces: false
 
-neutron::agents::metadata::auth_url: "http://%{hiera('service__address__keystone_admin')}:35357/v2.0"
-neutron::agents::metadata::metadata_ip: "%{hiera('service__address__nova_api_metadata')}"
-neutron::agents::metadata::auth_region: "%{location}"
-
 # Uncomment for calico v1.3 and older
 #neutron::plugins::ml2::type_drivers:
 #  - local

--- a/hieradata/common/modules/profile.yaml
+++ b/hieradata/common/modules/profile.yaml
@@ -119,10 +119,10 @@ profile::base::yumrepo::repo_hash:
   calico:
     ensure:         absent
     descr:          'Calico Repository'
-    baseurl:        'http://binaries.projectcalico.org/rpm_stable/'
+    baseurl:        'http://binaries.projectcalico.org/rpm_calico-1.4/'
     enabled:        1
     gpgcheck:       1
-    gpgkey:         'http://binaries.projectcalico.org/rpm/key'
+    gpgkey:         'http://binaries.projectcalico.org/rpm_calico-1.4/key'
     priority:       15
   ceph:
     ensure:         absent

--- a/hieradata/common/roles/compute.yaml
+++ b/hieradata/common/roles/compute.yaml
@@ -30,7 +30,6 @@ profile::base::common::packages:
   'python-etcd': {}
   'posix-spawn': {}
   'networking-calico': {}
-  'calico-dhcp-agent': {}
 
 calico::compute: true
 etcd::mode: 'proxy'

--- a/hieradata/common/roles/compute.yaml
+++ b/hieradata/common/roles/compute.yaml
@@ -26,6 +26,7 @@ profile::base::common::manage_lvm: true
 dnsmasq::package_ensure: '2.72_calico1.0.0-1.el7'
 
 profile::openstack::network::plugin: calico
+
 profile::base::common::packages:
   'python-etcd': {}
   'posix-spawn': {}

--- a/hieradata/common/roles/compute.yaml
+++ b/hieradata/common/roles/compute.yaml
@@ -31,6 +31,7 @@ profile::base::common::packages:
   'python-etcd': {}
   'posix-spawn': {}
   'networking-calico': {}
+  'calico-dhcp-agent': {}
 
 calico::compute: true
 etcd::mode: 'proxy'

--- a/hieradata/common/roles/compute.yaml
+++ b/hieradata/common/roles/compute.yaml
@@ -4,7 +4,6 @@ include:
     - profile::openstack::compute::hypervisor
     - profile::openstack::volume
     - profile::openstack::network
-    - profile::openstack::network::metadata
     - profile::logging::rsyslog::client
   kickstart:
     - profile::base::lvm

--- a/hieradata/common/roles/compute.yaml
+++ b/hieradata/common/roles/compute.yaml
@@ -26,7 +26,7 @@ profile::base::common::manage_lvm: true
 
 dnsmasq::package_ensure: '2.72_calico1.0.0-1.el7'
 
-profile::openstack::network::l2_driver: calico
+profile::openstack::network::plugin: calico
 profile::base::common::packages:
   'python-etcd': {}
   'posix-spawn': {}

--- a/profile/manifests/openstack/network.pp
+++ b/profile/manifests/openstack/network.pp
@@ -6,6 +6,10 @@ class profile::openstack::network(
 ){
   include ::neutron
 
+# Use value ml2 for plugin and calico driver for calico v1.3 and older
+# then set neutron::core_plugin to neutron.plugins.ml2.plugin.Ml2Plugin
+# Use value calico for plugin for calico v1.4 and newer. l2_driver flag will be ignored
+# then set neutron::core_plugin to calico
   case $plugin {
     'ml2': {
       include "::neutron::plugins::${plugin}"
@@ -18,6 +22,10 @@ class profile::openstack::network(
         }
       }
     }
+    'calico':{
+      include ::profile::openstack::network::calico
+    }
+
     default: {
       include "::neutron::plugins::${plugin}"
       include "::neutron::agents::${plugin}"


### PR DESCRIPTION
These changes upgrades calico to version 1.4. While new installations are fine, upgrading from version 1.3 demands a few manual steps.

On the network node:
1) Update yum repos:
FACTER_RUNMODE=kickstart puppet agent -t
2) Then update
yum update -y
3) remove old config files
rm -rf /etc/neutron/*
4) reinstall packages
yum reinstall -y openstack-neutron openstack-neutron-common openstack-neutron-ml2
5) Run puppet agent
puppet agent -t

Then, on compute nodes:
1) Update yum repos:
FACTER_RUNMODE=kickstart puppet agent -t
2) stop and disable neutron-dhcp-agent and neutron-metadata-api
systemctl stop neutron-dhcp-agent
systemctl disable neutron-dhcp-agent
systemctl stop neutron-metadata-agent
systemctl disable neutron-metadata-agent
3) Then update
yum update -y
4) remove old config files
rm -rf /etc/neutron/*
5) reinstall packages
yum reinstall -y openstack-neutron openstack-neutron-common openstack-neutron-ml2
6) Run puppet agent
puppet agent -t

Then, on the dashboard node:
1) list all neutron dhcp and metadata agents and delete them
neutron agent-list
neutron agent-delete 2309487120rhasdf3...

Only calico-felix agents show show after deletions.