### PR TITLE
Implement BFD protocol on compute nodes

### DIFF
--- a/hieradata/bgo/common.yaml
+++ b/hieradata/bgo/common.yaml
@@ -6,6 +6,8 @@ domain_public: 'iaas.uib.no'
 domain_trp:    'trp.iaas.intern'
 domain_mgmt:   'mgmt.iaas.intern'
 
+netcfg_trp_gateway: '172.18.0.1'
+
 #
 # Networks
 # See http://iaas.readthedocs.io/en/latest/installation/ip.html

--- a/hieradata/local1/common.yaml
+++ b/hieradata/local1/common.yaml
@@ -10,6 +10,7 @@ domain_public:        'local.iaas.intern'
 domain_trp:           'trp.local.iaas.intern'
 domain_mgmt:          'mgmt.local.iaas.intern'
 
+netcfg_trp_gateway: '172.31.12.1'
 
 # These should only be used to configure network in nodes!
 netcfg_netpart_trp:     '172.31.12'

--- a/hieradata/local3/common.yaml
+++ b/hieradata/local3/common.yaml
@@ -6,6 +6,8 @@ domain_public: 'local.iaas.intern'
 domain_trp:    'trp.local.iaas.intern'
 domain_mgmt:   'mgmt.local.iaas.intern'
 
+netcfg_trp_gateway: '172.31.12.1'
+
 # These should only be used to configure network in nodes!
 netcfg_netpart_trp:     '172.31.12'
 netcfg_netmask_trp:     '255.255.255.0'

--- a/hieradata/osl/common.yaml
+++ b/hieradata/osl/common.yaml
@@ -10,6 +10,8 @@ domain_public: 'iaas.uio.no'
 domain_trp:    '%{::domain}' #FIXME
 domain_mgmt:   'iaas.uio.no'
 
+netcfg_trp_gateway: '172.18.32.1'
+
 #
 # Networks
 # See http://iaas.readthedocs.io/en/latest/installation/ip.html

--- a/hieradata/test01/common.yaml
+++ b/hieradata/test01/common.yaml
@@ -10,6 +10,8 @@ domain_public: 'iaas.uib.no'
 domain_trp:    'trp.test.iaas.intern'
 domain_mgmt:   'mgmt.test.iaas.intern'
 
+netcfg_trp_gateway: '172.30.0.1'
+
 # Service address
 service__address__rabbitmq_01:       '172.30.0.31'
 service__address__rabbitmq_02:       '172.30.0.31'

--- a/hieradata/test02/common.yaml
+++ b/hieradata/test02/common.yaml
@@ -10,6 +10,8 @@ domain_public: 'test.iaas.uio.no'
 domain_trp:    'test.iaas.uio.no'
 domain_mgmt:   'test.iaas.uio.no'
 
+netcfg_trp_gateway: '172.30.32.1'
+
 location_dns1: '129.240.2.3'
 location_dns2: '129.240.2.40'
 

--- a/profile/manifests/openstack/network/calico.pp
+++ b/profile/manifests/openstack/network/calico.pp
@@ -39,6 +39,11 @@ class profile::openstack::network::calico(
         sport => ['67','68'],
       }
     }
+    profile::firewall::rule { '912 bird allow bfd':
+      proto  => 'udp',
+      port   => ['3784','3785','4784','4785'],
+      source => hiera('netcfg_trp_gateway')
+    }
     # Per https://github.com/projectcalico/calico/blob/master/rpm/calico.spec#L43-L48
     profile::firewall::rule { '911 calico - mangle checksum for dhcp':
       proto => 'udp',

--- a/profile/templates/bird/bird.conf.erb
+++ b/profile/templates/bird/bird.conf.erb
@@ -33,6 +33,10 @@ protocol kernel {
   export all;     # Default is export none
 }
 
+protocol bfd {
+  neighbor <%= scope.function_hiera(['netcfg_trp_gateway']) %>;
+}
+
 # Watch interface up/down events.
 protocol device {
   scan time 2;    # Scan interfaces every 2 seconds


### PR DESCRIPTION
Bidirectional Forwarding Detection (BFD) in conjunction with BGP enables rapid link failure detection in our L3 routing scheme. While rather useless in our single uplink, single router environment for the time being, it will be very useful once we enable more routers, uplinks.

These changes are non-destructive, i.e. bird will not break if leafs are unconfigured. Only thing needed is the location spesific netcfg_trp_gateway variable. No default is provided by purpose.

BFD is already configured on existing leaf nodes.