### PR TITLE
Add ability to create cumulus acl files

### DIFF
--- a/profile/manifests/network/leaf.pp
+++ b/profile/manifests/network/leaf.pp
@@ -4,7 +4,53 @@ class profile::network::leaf(
   $manage_license     = false,
   $cumulus_license    = "user@example.com|00000000000000000000000000000000000000000000000000\n",
   $manage_quagga      = false,
+  $manage_acls        = false,
+  $acls               = {},
 ) {
+
+  # Define: profile::network::leaf::acl
+  # 
+  # Create cumulus acl files.
+  # Pass a hash of filenames with arrays of rules. All rules are optional,
+  # but filename must be in the format of 10myrules.rules in order to
+  # be meaningful. The two starting digits should be between 01-98, and
+  # only files ending with .rules are applied. By passing an array of
+  # rule_vars in format of VARIABLE = value you may reuse those variables
+  # in the rule arrays.
+  define acl (
+    $rule_vars        = [],
+    $iptables         = [],
+    $ip6tables        = [],
+    $ebtables         = [],
+    $execpath         = '/usr/cumulus/bin',
+    $cumulus_acls_dir = '/etc/cumulus/acl/policy.d/',
+  ) {
+    # Validate arrays
+    validate_array($rule_vars)
+    validate_array($iptables)
+    validate_array($ip6tables)
+    validate_array($ebtables)
+
+    file { "${name}":
+      ensure   => present,
+      mode     => '644',
+      owner    => 'root',
+      group    => 'root',
+      path     => "${cumulus_acls_dir}/${name}",
+      content  => template("${module_name}/network/cumulus-acls.erb"),
+      notify   => Exec["update-acls-${name}"],
+    }
+
+    exec { "update-acls-${name}":
+      command     => "${execpath}/cl-acltool -i -n -P ${cumulus_acls_dir}",
+      #subscribe   => "${cumulus_acls_dir}/${name}",
+      refreshonly => true,
+    }
+  }
+
+  if $manage_acls {
+    create_resources(profile::network::leaf::acl, hiera_hash('profile::network::leaf::acls', {}))
+  }
 
   if $manage_license {
     file { '/tmp/licfile':
@@ -20,5 +66,9 @@ class profile::network::leaf(
 
   if $manage_quagga {
     include quagga
+  }
+
+  if $manage_acls {
+
   }
 }

--- a/profile/manifests/network/leaf.pp
+++ b/profile/manifests/network/leaf.pp
@@ -8,46 +8,6 @@ class profile::network::leaf(
   $acls               = {},
 ) {
 
-  # Define: profile::network::leaf::acl
-  # 
-  # Create cumulus acl files.
-  # Pass a hash of filenames with arrays of rules. All rules are optional,
-  # but filename must be in the format of 10myrules.rules in order to
-  # be meaningful. The two starting digits should be between 01-98, and
-  # only files ending with .rules are applied. By passing an array of
-  # rule_vars in format of VARIABLE = value you may reuse those variables
-  # in the rule arrays.
-  define acl (
-    $rule_vars        = [],
-    $iptables         = [],
-    $ip6tables        = [],
-    $ebtables         = [],
-    $execpath         = '/usr/cumulus/bin',
-    $cumulus_acls_dir = '/etc/cumulus/acl/policy.d/',
-  ) {
-    # Validate arrays
-    validate_array($rule_vars)
-    validate_array($iptables)
-    validate_array($ip6tables)
-    validate_array($ebtables)
-
-    file { "${name}":
-      ensure   => present,
-      mode     => '644',
-      owner    => 'root',
-      group    => 'root',
-      path     => "${cumulus_acls_dir}/${name}",
-      content  => template("${module_name}/network/cumulus-acls.erb"),
-      notify   => Exec["update-acls-${name}"],
-    }
-
-    exec { "update-acls-${name}":
-      command     => "${execpath}/cl-acltool -i -n -P ${cumulus_acls_dir}",
-      #subscribe   => "${cumulus_acls_dir}/${name}",
-      refreshonly => true,
-    }
-  }
-
   if $manage_acls {
     create_resources(profile::network::leaf::acl, hiera_hash('profile::network::leaf::acls', {}))
   }

--- a/profile/manifests/network/leaf.pp
+++ b/profile/manifests/network/leaf.pp
@@ -5,7 +5,6 @@ class profile::network::leaf(
   $cumulus_license    = "user@example.com|00000000000000000000000000000000000000000000000000\n",
   $manage_quagga      = false,
   $manage_acls        = false,
-  $acls               = {},
 ) {
 
   if $manage_acls {
@@ -26,9 +25,5 @@ class profile::network::leaf(
 
   if $manage_quagga {
     include quagga
-  }
-
-  if $manage_acls {
-
   }
 }

--- a/profile/manifests/network/leaf/acl.pp
+++ b/profile/manifests/network/leaf/acl.pp
@@ -1,0 +1,39 @@
+  # Define: profile::network::leaf::acl
+  # 
+  # Create cumulus acl files.
+  # Pass a hash of filenames with arrays of rules. All rules are optional,
+  # but filename must be in the format of 10myrules.rules in order to
+  # be meaningful. The two starting digits should be between 01-98, and
+  # only files ending with .rules are applied. By passing an array of
+  # rule_vars in format of VARIABLE = value you may reuse those variables
+  # in the rule arrays.
+  define profile::network::leaf::acl (
+    $rule_vars        = [],
+    $iptables         = [],
+    $ip6tables        = [],
+    $ebtables         = [],
+    $execpath         = '/usr/cumulus/bin',
+    $cumulus_acls_dir = '/etc/cumulus/acl/policy.d/',
+  ) {
+    # Validate arrays
+    validate_array($rule_vars)
+    validate_array($iptables)
+    validate_array($ip6tables)
+    validate_array($ebtables)
+
+    file { "${name}":
+      ensure   => present,
+      mode     => '644',
+      owner    => 'root',
+      group    => 'root',
+      path     => "${cumulus_acls_dir}/${name}",
+      content  => template("${module_name}/network/cumulus-acls.erb"),
+      notify   => Exec["update-acls-${name}"],
+    }
+
+    exec { "update-acls-${name}":
+      command     => "${execpath}/cl-acltool -i -n -P ${cumulus_acls_dir}",
+      #subscribe   => "${cumulus_acls_dir}/${name}",
+      refreshonly => true,
+    }
+  }

--- a/profile/manifests/network/leaf/acl.pp
+++ b/profile/manifests/network/leaf/acl.pp
@@ -21,7 +21,7 @@
     validate_array($ip6tables)
     validate_array($ebtables)
 
-    file { "${name}":
+    file { $name:
       ensure   => present,
       mode     => '0644',
       owner    => 'root',

--- a/profile/manifests/network/leaf/acl.pp
+++ b/profile/manifests/network/leaf/acl.pp
@@ -23,7 +23,7 @@
 
     file { "${name}":
       ensure   => present,
-      mode     => '644',
+      mode     => '0644',
       owner    => 'root',
       group    => 'root',
       path     => "${cumulus_acls_dir}/${name}",

--- a/profile/manifests/network/leaf/acl.pp
+++ b/profile/manifests/network/leaf/acl.pp
@@ -32,8 +32,7 @@
     }
 
     exec { "update-acls-${name}":
-      command     => "${execpath}/cl-acltool -i -n -P ${cumulus_acls_dir}",
-      #subscribe   => "${cumulus_acls_dir}/${name}",
+      command     => "${execpath}/cl-acltool -i -P ${cumulus_acls_dir}",
       refreshonly => true,
     }
   }

--- a/profile/templates/network/cumulus-acls.erb
+++ b/profile/templates/network/cumulus-acls.erb
@@ -1,0 +1,14 @@
+# File managed by Puppet - do not edit
+
+<% @rule_vars.each do |rulevar| -%><%= rulevar %>
+<% end -%>
+
+[iptables]
+<% @iptables.each do |rule| -%><%= rule %>
+<% end -%>
+[ip6tables]
+<% @ip6tables.each do |rule| -%><%= rule %>
+<% end -%>
+[ebtables]
+<% @ebtables.each do |rule| -%><%= rule %>
+<% end -%>


### PR DESCRIPTION
We need a method for passing ACLs to our cumulus boxes. For this to work properly, we must use the custom cl-acltool in cumulus linux, which ensures that the rules are installed in ASIC. These changes adds the ability to create rule files and update the running ACLs.