### PR TITLE
Update the foreman puppet modules

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -73,18 +73,18 @@ mod 'gitolite', :ref => '1.0',                   :git => github + 'uib/puppet-gi
 # profile::application::foreman
 #
 mod 'zack/r10k', '2.5.2'                         # forge
-mod 'theforeman/foreman', :ref => '5.2.2',       :git => github + 'theforeman/puppet-foreman.git'
-mod 'theforeman/concat_native', '1.3.1'          # forge
-mod 'theforeman/tftp', '1.8.1'                   # forge
-mod 'theforeman/puppet', :ref => '5.0.0',        :git => github + 'theforeman/puppet-puppet.git'
-mod 'theforeman/dns', '3.3.1'                    # forge
+mod 'theforeman/foreman', :ref => '6.0.0',       :git => github + 'theforeman/puppet-foreman.git'
+mod 'theforeman/concat_native', '1.5.0'          # forge
+mod 'theforeman/tftp', '1.8.2'                   # forge
+mod 'theforeman/puppet', :ref => '6.0.1',        :git => github + 'theforeman/puppet-puppet.git'
+mod 'theforeman/dns', '3.4.1'                    # forge
 mod 'theforeman/dhcp', :ref => '2.3.2-norcams',  :git => github + 'norcams/puppet-dhcp.git'
-mod 'theforeman/foreman_proxy', '3.0.1'          # forge
-mod 'theforeman/git', '1.4.0'                    # forge
+mod 'theforeman/foreman_proxy', '4.0.3'          # forge
+mod 'theforeman/git', '1.6.0'                    # forge
 mod 'adrien/alternatives', '0.3.0'               # forge
 mod 'voxpupuli/extlib', :ref => 'v0.11.3',      :git => github + 'voxpupuli/puppet-extlib.git'
-mod 'puppetlabs/ruby', '0.4.0'                   # forge
-mod 'puppetlabs/xinetd', '1.4.0'                 # forge
+mod 'puppetlabs/ruby', '0.5.0'                   # forge
+mod 'puppetlabs/xinetd', '2.0.0'                 # forge
 mod 'eyaml', :ref => 'v0.3.0',                   :git => github + 'ghoneycutt/puppet-module-eyaml'
 mod 'bind', :ref => 'keyfile_resource_record',   :git => github + 'norcams/puppet-bind'
 


### PR DESCRIPTION
These updates are necessary for foreman 1.13 to work. They work with foreman 1.12.