### PR TITLE
Change snapshot save location

### DIFF
--- a/hieradata/common/roles/compute.yaml
+++ b/hieradata/common/roles/compute.yaml
@@ -64,6 +64,8 @@ profile::monitoring::sensu::agent::checks:
     interval:     30
     subscribers:  ['checks']
 
+profile::openstack::compute::hypervisor::fix_snapshot_loc: tru # FIXME - Should probably be removed for newton release
+
 calico::compute: true
 etcd::mode: 'proxy'
 

--- a/hieradata/common/roles/compute.yaml
+++ b/hieradata/common/roles/compute.yaml
@@ -64,7 +64,7 @@ profile::monitoring::sensu::agent::checks:
     interval:     30
     subscribers:  ['checks']
 
-profile::openstack::compute::hypervisor::fix_snapshot_loc: tru # FIXME - Should probably be removed for newton release
+profile::openstack::compute::hypervisor::fix_snapshot_loc: true # FIXME - Should probably be removed for newton release
 
 calico::compute: true
 etcd::mode: 'proxy'

--- a/profile/manifests/openstack/compute/hypervisor.pp
+++ b/profile/manifests/openstack/compute/hypervisor.pp
@@ -3,6 +3,7 @@ class profile::openstack::compute::hypervisor (
   $manage_libvirt_rbd = false,
   $manage_telemetry = true,
   $manage_firewall = true,
+  $fix_snapshot_loc = false, # FIXME - Should probably be removed for newton release
   $firewall_extras = {},
 ) {
   include ::profile::openstack::compute
@@ -34,6 +35,20 @@ class profile::openstack::compute::hypervisor (
     profile::firewall::rule{ '224 migration accept tcp':
       port   => ['16509', '49152-49215'],
       extras => $firewall_extras,
+    }
+  }
+
+  # FIXME - Should probably be removed for newton release
+  if $fix_snapshot_loc {
+    file { '/var/lib/nova/instances/save':
+      ensure => 'directory',
+      owner  => 'nova',
+      group  => 'nova',
+    } ->
+    file { '/var/lib/libvirt/qemu/save':
+      ensure => 'link',
+      target => '/var/lib/nova/instances/save',
+      force  => true,
     }
   }
 }

--- a/profile/manifests/openstack/compute/hypervisor.pp
+++ b/profile/manifests/openstack/compute/hypervisor.pp
@@ -42,8 +42,6 @@ class profile::openstack::compute::hypervisor (
   if $fix_snapshot_loc {
     file { '/var/lib/nova/instances/save':
       ensure => 'directory',
-      owner  => 'nova',
-      group  => 'nova',
     } ->
     file { '/var/lib/libvirt/qemu/save':
       ensure => 'link',


### PR DESCRIPTION
Move snapshot temp save location to the instance disk. These changes will forcefully move the location, so any snapshot being taken at puppet run time will fail. Implement with caution and coordinate puppet runs on the hypervisors accordingly.