### PR TITLE
Ceph cleanup and preps for instance storage on ceph

### DIFF
--- a/hieradata/common/modules/ceph.yaml
+++ b/hieradata/common/modules/ceph.yaml
@@ -54,7 +54,7 @@ ceph::profile::params::client_keys:
     user: 'cinder'
     group: 'cinder'
     cap_mon: 'allow r'
-    cap_osd: 'allow class-read object_prefix rbd_children, allow rwx pool=volumes, allow rwx pool=vms, allow rx pool=images'
+    cap_osd: 'allow class-read object_prefix rbd_children, allow rwx pool=volumes, allow rwx pool=vms, allow rwx pool=images'
 #ceph::profile::params::osds:
 #  '/var/osd1':
 #    journal: '/var/osd1-journal'

--- a/hieradata/common/roles/compute.yaml
+++ b/hieradata/common/roles/compute.yaml
@@ -137,8 +137,16 @@ profile::base::yumrepo::repo_hash:
   ceph-jewel:
     ensure: present
 
-# Compute nodes need only cinder keys
+# Compute nodes need only admin and cinder keys
 ceph::profile::params::client_keys:
+  'client.admin':
+    secret: "%{hiera('client.admin::secret')}"
+    mode: '0600'
+    user: 'ceph'
+    group: 'ceph'
+    cap_mon: 'allow *'
+    cap_osd: 'allow *'
+    cap_mds: 'allow *'
   'client.cinder':
     secret: "%{hiera('client.cinder::secret')}"
     mode: '0600'

--- a/hieradata/common/roles/compute.yaml
+++ b/hieradata/common/roles/compute.yaml
@@ -111,26 +111,7 @@ named_interfaces::config:
   service: #FIXME
     - team1
 
-
 sudo::purge: false
-
-accounts::users:
-  'cinder':
-    ensure: present
-  'glance':
-    ensure: present
-
-accounts::usergroups:
-  'cinder':
-    - 'cinder'
-  'glance':
-    - 'glance'
-
-accounts::accounts:
-  'cinder':
-    ensure: present
-  'glance':
-    ensure: present
 
 profile::base::lvm::physical_volume:
   '/dev/sda3':
@@ -155,3 +136,13 @@ profile::base::yumrepo::repo_hash:
     exclude: 'calico-dhcp-agent' #FIXME
   ceph-jewel:
     ensure: present
+
+# Compute nodes need only cinder keys
+ceph::profile::params::client_keys:
+  'client.cinder':
+    secret: "%{hiera('client.cinder::secret')}"
+    mode: '0600'
+    user: 'nova'
+    group: 'nova'
+    cap_mon: 'allow r'
+    cap_osd: 'allow class-read object_prefix rbd_children, allow rwx pool=volumes, allow rwx pool=vms, allow rwx pool=images'

--- a/hieradata/common/roles/image.yaml
+++ b/hieradata/common/roles/image.yaml
@@ -12,21 +12,19 @@ profile::openstack::openrc::password:     "%{hiera('glance_api_password')}"
 profile::openstack::openrc::username:     'glance'
 profile::openstack::openrc::project_name: 'services'
 
-accounts::users:
-  'cinder':
-    ensure: present
-
-accounts::usergroups:
-  'cinder':
-    - 'cinder'
-
-accounts::accounts:
-  'cinder':
-    ensure: present
-
 # Enable extra yum repo
 profile::base::yumrepo::repo_hash:
   rdo-release:
     ensure: present
   ceph-jewel:
     ensure: present
+
+# Image nodes need only glance key
+ceph::profile::params::client_keys:
+  'client.glance':
+    secret: "%{hiera('client.glance::secret')}"
+    mode: '0600'
+    user: 'glance'
+    group: 'glance'
+    cap_mon: 'allow r'
+    cap_osd: 'allow class-read object_prefix rbd_children, allow rwx pool=images'

--- a/hieradata/common/roles/storage.yaml
+++ b/hieradata/common/roles/storage.yaml
@@ -49,6 +49,10 @@ profile::storage::cephpool::pools:
     ensure: present
     pg_num: 512
     pgp_num: 512
+  'vms':
+    ensure: present
+    pg_num: 2048
+    pgp_num: 2048
 
 # Enable extra yum repo
 profile::base::yumrepo::repo_hash:

--- a/hieradata/common/roles/storage.yaml
+++ b/hieradata/common/roles/storage.yaml
@@ -51,8 +51,8 @@ profile::storage::cephpool::pools:
     pgp_num: 512
   'vms':
     ensure: present
-    pg_num: 2048
-    pgp_num: 2048
+    pg_num: 1024
+    pgp_num: 1024
 
 # Enable extra yum repo
 profile::base::yumrepo::repo_hash:

--- a/hieradata/common/roles/volume.yaml
+++ b/hieradata/common/roles/volume.yaml
@@ -42,23 +42,19 @@ cinder::backends::enabled_backends:
 # load backend drivers
 sudo::purge: false
 
-# Add glance user for ceph client config defined in
-# common::modules::ceph
-accounts::users:
-  'glance':
-    ensure: present
-
-accounts::usergroups:
-  'glance':
-    - 'glance'
-
-accounts::accounts:
-  'glance':
-    ensure: present
-
 # Enable extra yum repo
 profile::base::yumrepo::repo_hash:
   rdo-release:
     ensure: present
   ceph-jewel:
     ensure: present
+
+# Volume nodes need only cinder keys
+ceph::profile::params::client_keys:
+  'client.cinder':
+    secret: "%{hiera('client.cinder::secret')}"
+    mode: '0600'
+    user: 'cinder'
+    group: 'cinder'
+    cap_mon: 'allow r'
+    cap_osd: 'allow class-read object_prefix rbd_children, allow rwx pool=volumes, allow rwx pool=vms, allow rwx pool=images'

--- a/hieradata/test01/modules/nova.yaml
+++ b/hieradata/test01/modules/nova.yaml
@@ -6,4 +6,5 @@ nova::compute::rbd::libvirt_rbd_user: 'cinder'
 #nova::compute::rbd::libvirt_images_rbd_ceph_conf: '/etc/ceph/ceph.conf'
 
 # Optimize cache mode for ceph
-nova::compute::libvirt::libvirt_disk_cachemodes:  'network=writeback'
+nova::compute::libvirt::libvirt_disk_cachemodes:
+  - network: writeback

--- a/hieradata/test01/modules/nova.yaml
+++ b/hieradata/test01/modules/nova.yaml
@@ -1,0 +1,3 @@
+---
+# Use ceph cluster for instance disk
+nova::compute::rbd::ephemeral_storage: true

--- a/hieradata/test01/modules/nova.yaml
+++ b/hieradata/test01/modules/nova.yaml
@@ -2,7 +2,6 @@
 # Use ceph cluster for instance disk
 nova::compute::rbd::ephemeral_storage:            true
 nova::compute::rbd::libvirt_images_rbd_pool:      'vms'
-nova::compute::rbd::libvirt_rbd_user: 'cinder'
 #nova::compute::rbd::libvirt_images_rbd_ceph_conf: '/etc/ceph/ceph.conf'
 
 # Optimize cache mode for ceph

--- a/hieradata/test01/modules/nova.yaml
+++ b/hieradata/test01/modules/nova.yaml
@@ -7,4 +7,4 @@ nova::compute::rbd::libvirt_rbd_user: 'cinder'
 
 # Optimize cache mode for ceph
 nova::compute::libvirt::libvirt_disk_cachemodes:
-  - network: writeback
+  - '"network=writeback"'

--- a/hieradata/test01/modules/nova.yaml
+++ b/hieradata/test01/modules/nova.yaml
@@ -1,3 +1,9 @@
 ---
 # Use ceph cluster for instance disk
-nova::compute::rbd::ephemeral_storage: true
+nova::compute::rbd::ephemeral_storage:            true
+nova::compute::rbd::libvirt_images_rbd_pool:      'vms'
+nova::compute::rbd::libvirt_rbd_user: 'cinder'
+#nova::compute::rbd::libvirt_images_rbd_ceph_conf: '/etc/ceph/ceph.conf'
+
+# Optimize cache mode for ceph
+nova::compute::libvirt::libvirt_disk_cachemodes:  'network=writeback'


### PR DESCRIPTION
1) Roles volume, image and compute need only a subset of ceph keys. These changes cleans up a bit, specifying witch keys are distributed where.

2) Implements central ceph storage for location test01

3) Creates a new pool in ceph clusters, "vms", where future instance disks will be located

These changes should be non destructive. To test:
Either delete all keys /etc/ceph/ceph.client.* and run puppet on volume, image and compute, or better:
Reinstall volume and image nodes, and one or more compute nodes.