### PR TITLE
Upgrade calico plugin from 1.4 to 2.2 for neutron

### DIFF
--- a/hieradata/common/modules/profile.yaml
+++ b/hieradata/common/modules/profile.yaml
@@ -142,6 +142,13 @@ profile::base::yumrepo::repo_hash:
     enabled:        1
     gpgcheck:       1
     gpgkey:         "%{hiera('yum_base_mirror')}/calico/key"
+  calico22:
+    ensure:         absent
+    descr:          'Calico22 Repository'
+    baseurl:        "%{hiera('yum_base_mirror')}/calico22/"
+    enabled:        1
+    gpgcheck:       1
+    gpgkey:         "%{hiera('yum_base_mirror')}/calico22/key"
   ceph:
     ensure:         absent
     descr:          'Ceph packages'

--- a/hieradata/common/roles/compute.yaml
+++ b/hieradata/common/roles/compute.yaml
@@ -131,7 +131,7 @@ profile::base::lvm::logical_volume:
 profile::base::yumrepo::repo_hash:
   rdo-release:
     ensure: present
-  calico:
+  calico22:
     ensure: present
     exclude: 'calico-dhcp-agent' #FIXME
   ceph-jewel:

--- a/hieradata/common/roles/network.yaml
+++ b/hieradata/common/roles/network.yaml
@@ -38,5 +38,5 @@ sudo::purge: false
 profile::base::yumrepo::repo_hash:
   rdo-release:
     ensure: present
-  calico:
+  calico22:
     ensure: present


### PR DESCRIPTION
This upgrade is mostly trivial and applies to network node and computes. To test (already implemented in test01):

1) Delete the old calico repository in /etc/yum.repos.d/
2) Do a FACTER_RUNMODE=kickstart puppet run
3) Clean yum cache with yum clean all
4) Upgrade packages with yum update -y \*calico\*

5a) On network node:
- systemctl restart neutron-server.service
5b) On computes:
- Kill existing dnsmasq processes
- systemctl restart calico-felix.service
- systemctl restart calico-dhcp-agent.service

6) Start instances and observe a new dnsmasq process, route creation and network connectivity for instance
