### PR TITLE
Collect and parse /opt/log/*/messages (again)

### DIFF
--- a/profile/templates/logging/logstash/openstack.conf.erb
+++ b/profile/templates/logging/logstash/openstack.conf.erb
@@ -42,6 +42,13 @@ input {
     start_position => beginning
   }
 
+  file {
+    path => "/opt/log/*/messages"
+    type => "syslog"
+    start_position => beginning
+  }
+
+
 }
 
 filter {
@@ -53,7 +60,7 @@ filter {
       ]
       add_tag => "rabbitmq_logs"
     }
-  } else {
+  } else if [type] =~ /^(nova|glance|neutron|cinder|keystone|horzion)$/ {
     grok {
       break_on_match => true
       match => [
@@ -61,6 +68,17 @@ filter {
         "message", "%{TIMESTAMP_ISO8601:timestamp} %{LOGLEVEL:loglevel} %{HOSTNAME:hostname} %{DATA:component} %{GREEDYDATA:message}"
       ]
       add_tag => "openstack_logs"
+    }
+  } else if [type] == "syslog" {
+    if [message] =~ /(?i)nova|glance|neutron|cinder|keystone|horzion|calico|etcd/ {
+        drop{}
+    }
+    grok {
+      break_on_match => true
+      match => [
+        "message", "%{TIMESTAMP_ISO8601:timestamp} %{WORD:syslog_type}.%{WORD:loglevel} %{HOSTNAME:hostname} %{GREEDYDATA:message}"
+      ]
+      add_tag => "system_logs"
     }
   }
 }


### PR DESCRIPTION
_Last pull request was merged by mistake and has been reverted. Let's try again._

This isn't very pretty, but will do for now; we're basically dropping any message containing the words nova|glance|neutron|cinder|keystone|horzion|calico|etcd
if type is syslog, which is a little drastic, but keeps us from drowning in duplicates and unnecessary messages.

Also a simple grok pattern for the more inconsistent syslog type.