### PR TITLE
Updated neutron module and set default domain to lowercase

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -145,7 +145,7 @@ mod 'rabbitmq', :ref => '8527f20',                 :git => github + 'puppetlabs/
 #
 mod 'glance', :ref => '8.2.0',                   :git => github + 'openstack/puppet-glance'
 mod 'cinder', :ref => '8.2.0',                   :git => github + 'openstack/puppet-cinder'
-mod 'neutron', :ref => '8.2.0',                  :git => github + 'openstack/puppet-neutron'
+mod 'neutron', :ref => '8.3.0',                  :git => github + 'openstack/puppet-neutron'
 mod 'nova', :ref => '8.2.0',                     :git => github + 'openstack/puppet-nova'
 mod 'horizon', :ref => 'norcams-mitaka',         :git => github + 'norcams/puppet-horizon'
 mod 'keystone', :ref => 'norcams-mitaka',        :git => github + 'norcams/puppet-keystone'

--- a/hieradata/common/modules/neutron.yaml
+++ b/hieradata/common/modules/neutron.yaml
@@ -9,6 +9,8 @@ neutron::server::database_connection: "mysql://neutron:%{hiera('neutron::db::mys
 neutron::server::username: 'neutron'
 neutron::server::password: "%{hiera('neutron_api_password')}"
 neutron::server::region_name: "%{::location}"
+neutron::server::user_domain_id:  'default'
+neutron::server::project_domain_id:  'default'
 
 neutron::server::notifications::notify_nova_on_port_status_changes: true
 neutron::server::notifications::notify_nova_on_port_data_changes:   true


### PR DESCRIPTION
Default domain needs to be 'default' and not 'Default' for keystone auth to work in neutron