### PR TITLE
Updated puppet network module from upstream

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -20,7 +20,7 @@ mod 'lvm', :ref => '689d42a16c',                 :git => github + 'puppetlabs/pu
 mod 'firewall', :ref => '1.8.2',                 :git => github + 'puppetlabs/puppetlabs-firewall'
 mod 'kmod', :ref => '2.1.0',                     :git => github + 'camptocamp/puppet-kmod'
 mod 'named_interfaces', :ref => '88ce713994',    :git => github + 'norcams/puppet-named_interfaces'
-mod 'network', :ref => '10e6e1f140',             :git => github + 'norcams/puppet-network'
+mod 'network', :ref => 'e739f24fa3',             :git => github + 'norcams/puppet-network'
 mod 'ipmi', :ref => 'c4309504fd',                :git => github + 'norcams/puppet-ipmi'
 mod 'lldp', :ref => '06523de010',                :git => github + 'norcams/puppet-lldp'
 mod 'apt', :ref => '2.2.2',                      :git => github + 'puppetlabs/puppetlabs-apt'

--- a/hieradata/nodes/bgo/bgo-compute-01.yaml
+++ b/hieradata/nodes/bgo/bgo-compute-01.yaml
@@ -24,7 +24,7 @@ network::interfaces_hash:
     netmask:       '255.255.248.0'
     defroute:      'no'
     devicetype:    'Team'
-    team_cfg: >-
+    team_config: >-
                    { "runner" : {  "name" : "lacp",  "active": true, "fast_rate" : true,
                    "tx_hash": ["eth", "ipv4", "ipv6"], "tx_balancer": { "name": "basic" } },
                    "link_watch" : {  "name" : "ethtool" } }

--- a/hieradata/nodes/bgo/bgo-compute-02.yaml
+++ b/hieradata/nodes/bgo/bgo-compute-02.yaml
@@ -24,7 +24,7 @@ network::interfaces_hash:
     netmask:       '255.255.248.0'
     defroute:      'no'
     devicetype:    'Team'
-    team_cfg: >-
+    team_config: >-
                    { "runner" : {  "name" : "lacp",  "active": true, "fast_rate" : true,
                    "tx_hash": ["eth", "ipv4", "ipv6"], "tx_balancer": { "name": "basic" } },
                    "link_watch" : {  "name" : "ethtool" } }

--- a/hieradata/nodes/bgo/bgo-compute-03.yaml
+++ b/hieradata/nodes/bgo/bgo-compute-03.yaml
@@ -24,7 +24,7 @@ network::interfaces_hash:
     netmask:       '255.255.248.0'
     defroute:      'no'
     devicetype:    'Team'
-    team_cfg: >-
+    team_config: >-
                    { "runner" : {  "name" : "lacp",  "active": true, "fast_rate" : true,
                    "tx_hash": ["eth", "ipv4", "ipv6"], "tx_balancer": { "name": "basic" } },
                    "link_watch" : {  "name" : "ethtool" } }

--- a/hieradata/nodes/bgo/bgo-compute-04.yaml
+++ b/hieradata/nodes/bgo/bgo-compute-04.yaml
@@ -24,7 +24,7 @@ network::interfaces_hash:
     netmask:       '255.255.248.0'
     defroute:      'no'
     devicetype:    'Team'
-    team_cfg: >-
+    team_config: >-
                    { "runner" : {  "name" : "lacp",  "active": true, "fast_rate" : true,
                    "tx_hash": ["eth", "ipv4", "ipv6"], "tx_balancer": { "name": "basic" } },
                    "link_watch" : {  "name" : "ethtool" } }

--- a/hieradata/nodes/bgo/bgo-compute-05.yaml
+++ b/hieradata/nodes/bgo/bgo-compute-05.yaml
@@ -24,7 +24,7 @@ network::interfaces_hash:
     netmask:       '255.255.248.0'
     defroute:      'no'
     devicetype:    'Team'
-    team_cfg: >-
+    team_config: >-
                    { "runner" : {  "name" : "lacp",  "active": true, "fast_rate" : true,
                    "tx_hash": ["eth", "ipv4", "ipv6"], "tx_balancer": { "name": "basic" } },
                    "link_watch" : {  "name" : "ethtool" } }

--- a/hieradata/nodes/bgo/bgo-compute-06.yaml
+++ b/hieradata/nodes/bgo/bgo-compute-06.yaml
@@ -24,7 +24,7 @@ network::interfaces_hash:
     netmask:       '255.255.248.0'
     defroute:      'no'
     devicetype:    'Team'
-    team_cfg: >-
+    team_config: >-
                    { "runner" : {  "name" : "lacp",  "active": true, "fast_rate" : true,
                    "tx_hash": ["eth", "ipv4", "ipv6"], "tx_balancer": { "name": "basic" } },
                    "link_watch" : {  "name" : "ethtool" } }

--- a/hieradata/nodes/bgo/bgo-controller-01.yaml
+++ b/hieradata/nodes/bgo/bgo-controller-01.yaml
@@ -17,7 +17,7 @@ network::interfaces_hash:
     onboot:        'yes'
     bridge:        'br1'
     devicetype:    'Team'
-    team_cfg: >-
+    team_config: >-
                    { "runner" : {  "name" : "lacp",  "active": true, "fast_rate" : true,
                    "tx_hash": ["eth", "ipv4", "ipv6"], "tx_balancer": { "name": "basic" } },
                    "link_watch" : {  "name" : "ethtool" } }

--- a/hieradata/nodes/bgo/bgo-controller-02.yaml
+++ b/hieradata/nodes/bgo/bgo-controller-02.yaml
@@ -17,7 +17,7 @@ network::interfaces_hash:
     onboot:        'yes'
     bridge:        'br1'
     devicetype:    'Team'
-    team_cfg: >-
+    team_config: >-
                    { "runner" : {  "name" : "lacp",  "active": true, "fast_rate" : true,
                    "tx_hash": ["eth", "ipv4", "ipv6"], "tx_balancer": { "name": "basic" } },
                    "link_watch" : {  "name" : "ethtool" } }

--- a/hieradata/nodes/bgo/bgo-controller-03.yaml
+++ b/hieradata/nodes/bgo/bgo-controller-03.yaml
@@ -17,7 +17,7 @@ network::interfaces_hash:
     onboot:        'yes'
     bridge:        'br1'
     devicetype:    'Team'
-    team_cfg: >-
+    team_config: >-
                    { "runner" : {  "name" : "lacp",  "active": true, "fast_rate" : true,
                    "tx_hash": ["eth", "ipv4", "ipv6"], "tx_balancer": { "name": "basic" } },
                    "link_watch" : {  "name" : "ethtool" } }

--- a/hieradata/nodes/bgo/bgo-controller-04.yaml
+++ b/hieradata/nodes/bgo/bgo-controller-04.yaml
@@ -17,7 +17,7 @@ network::interfaces_hash:
     onboot:        'yes'
     bridge:        'br1'
     devicetype:    'Team'
-    team_cfg: >-
+    team_config: >-
                    { "runner" : {  "name" : "lacp",  "active": true, "fast_rate" : true,
                    "tx_hash": ["eth", "ipv4", "ipv6"], "tx_balancer": { "name": "basic" } },
                    "link_watch" : {  "name" : "ethtool" } }

--- a/hieradata/nodes/bgo/bgo-storage-01.yaml
+++ b/hieradata/nodes/bgo/bgo-storage-01.yaml
@@ -25,7 +25,7 @@ network::interfaces_hash:
     netmask:       '255.255.248.0'
     defroute:      'no'
     devicetype:    'Team'
-    team_cfg: >-
+    team_config: >-
                    { "runner" : {  "name" : "lacp",  "active": true, "fast_rate" : true,
                    "tx_hash": ["eth", "ipv4", "ipv6"], "tx_balancer": { "name": "basic" } },
                    "link_watch" : {  "name" : "ethtool" } }

--- a/hieradata/nodes/bgo/bgo-storage-02.yaml
+++ b/hieradata/nodes/bgo/bgo-storage-02.yaml
@@ -25,7 +25,7 @@ network::interfaces_hash:
     netmask:       '255.255.248.0'
     defroute:      'no'
     devicetype:    'Team'
-    team_cfg: >-
+    team_config: >-
                    { "runner" : {  "name" : "lacp",  "active": true, "fast_rate" : true,
                    "tx_hash": ["eth", "ipv4", "ipv6"], "tx_balancer": { "name": "basic" } },
                    "link_watch" : {  "name" : "ethtool" } }

--- a/hieradata/nodes/bgo/bgo-storage-03.yaml
+++ b/hieradata/nodes/bgo/bgo-storage-03.yaml
@@ -25,7 +25,7 @@ network::interfaces_hash:
     netmask:       '255.255.248.0'
     defroute:      'no'
     devicetype:    'Team'
-    team_cfg: >-
+    team_config: >-
                    { "runner" : {  "name" : "lacp",  "active": true, "fast_rate" : true,
                    "tx_hash": ["eth", "ipv4", "ipv6"], "tx_balancer": { "name": "basic" } },
                    "link_watch" : {  "name" : "ethtool" } }

--- a/hieradata/nodes/bgo/bgo-storage-04.yaml
+++ b/hieradata/nodes/bgo/bgo-storage-04.yaml
@@ -25,7 +25,7 @@ network::interfaces_hash:
     netmask:       '255.255.248.0'
     defroute:      'no'
     devicetype:    'Team'
-    team_cfg: >-
+    team_config: >-
                    { "runner" : {  "name" : "lacp",  "active": true, "fast_rate" : true,
                    "tx_hash": ["eth", "ipv4", "ipv6"], "tx_balancer": { "name": "basic" } },
                    "link_watch" : {  "name" : "ethtool" } }

--- a/hieradata/nodes/bgo/bgo-storage-05.yaml
+++ b/hieradata/nodes/bgo/bgo-storage-05.yaml
@@ -25,7 +25,7 @@ network::interfaces_hash:
     netmask:       '255.255.248.0'
     defroute:      'no'
     devicetype:    'Team'
-    team_cfg: >-
+    team_config: >-
                    { "runner" : {  "name" : "lacp",  "active": true, "fast_rate" : true,
                    "tx_hash": ["eth", "ipv4", "ipv6"], "tx_balancer": { "name": "basic" } },
                    "link_watch" : {  "name" : "ethtool" } }

--- a/hieradata/nodes/osl/osl-compute-01.yaml
+++ b/hieradata/nodes/osl/osl-compute-01.yaml
@@ -24,7 +24,7 @@ network::interfaces_hash:
     netmask:       '255.255.248.0'
     defroute:      'no'
     devicetype:    'Team'
-    team_cfg: >-
+    team_config: >-
                    { "runner" : {  "name" : "lacp",  "active": true, "fast_rate" : true,
                    "tx_hash": ["eth", "ipv4", "ipv6"], "tx_balancer": { "name": "basic" } },
                    "link_watch" : {  "name" : "ethtool" } }

--- a/hieradata/nodes/osl/osl-compute-02.yaml
+++ b/hieradata/nodes/osl/osl-compute-02.yaml
@@ -24,7 +24,7 @@ network::interfaces_hash:
     netmask:       '255.255.248.0'
     defroute:      'no'
     devicetype:    'Team'
-    team_cfg: >-
+    team_config: >-
                    { "runner" : {  "name" : "lacp",  "active": true, "fast_rate" : true,
                    "tx_hash": ["eth", "ipv4", "ipv6"], "tx_balancer": { "name": "basic" } },
                    "link_watch" : {  "name" : "ethtool" } }

--- a/hieradata/nodes/osl/osl-compute-03.yaml
+++ b/hieradata/nodes/osl/osl-compute-03.yaml
@@ -24,7 +24,7 @@ network::interfaces_hash:
     netmask:       '255.255.248.0'
     defroute:      'no'
     devicetype:    'Team'
-    team_cfg: >-
+    team_config: >-
                    { "runner" : {  "name" : "lacp",  "active": true, "fast_rate" : true,
                    "tx_hash": ["eth", "ipv4", "ipv6"], "tx_balancer": { "name": "basic" } },
                    "link_watch" : {  "name" : "ethtool" } }

--- a/hieradata/nodes/osl/osl-compute-04.yaml
+++ b/hieradata/nodes/osl/osl-compute-04.yaml
@@ -24,7 +24,7 @@ network::interfaces_hash:
     netmask:       '255.255.248.0'
     defroute:      'no'
     devicetype:    'Team'
-    team_cfg: >-
+    team_config: >-
                    { "runner" : {  "name" : "lacp",  "active": true, "fast_rate" : true,
                    "tx_hash": ["eth", "ipv4", "ipv6"], "tx_balancer": { "name": "basic" } },
                    "link_watch" : {  "name" : "ethtool" } }

--- a/hieradata/nodes/osl/osl-compute-05.yaml
+++ b/hieradata/nodes/osl/osl-compute-05.yaml
@@ -24,7 +24,7 @@ network::interfaces_hash:
     netmask:       '255.255.248.0'
     defroute:      'no'
     devicetype:    'Team'
-    team_cfg: >-
+    team_config: >-
                    { "runner" : {  "name" : "lacp",  "active": true, "fast_rate" : true,
                    "tx_hash": ["eth", "ipv4", "ipv6"], "tx_balancer": { "name": "basic" } },
                    "link_watch" : {  "name" : "ethtool" } }

--- a/hieradata/nodes/osl/osl-compute-06.yaml
+++ b/hieradata/nodes/osl/osl-compute-06.yaml
@@ -24,7 +24,7 @@ network::interfaces_hash:
     netmask:       '255.255.248.0'
     defroute:      'no'
     devicetype:    'Team'
-    team_cfg: >-
+    team_config: >-
                    { "runner" : {  "name" : "lacp",  "active": true, "fast_rate" : true,
                    "tx_hash": ["eth", "ipv4", "ipv6"], "tx_balancer": { "name": "basic" } },
                    "link_watch" : {  "name" : "ethtool" } }

--- a/hieradata/nodes/osl/osl-controller-01.yaml
+++ b/hieradata/nodes/osl/osl-controller-01.yaml
@@ -17,7 +17,7 @@ network::interfaces_hash:
     onboot:        'yes'
     bridge:        'br1'
     devicetype:    'Team'
-    team_cfg: >-
+    team_config: >-
                    { "runner" : {  "name" : "lacp",  "active": true, "fast_rate" : true,
                    "tx_hash": ["eth", "ipv4", "ipv6"], "tx_balancer": { "name": "basic" } },
                    "link_watch" : {  "name" : "ethtool" } }

--- a/hieradata/nodes/osl/osl-controller-02.yaml
+++ b/hieradata/nodes/osl/osl-controller-02.yaml
@@ -17,7 +17,7 @@ network::interfaces_hash:
     onboot:        'yes'
     bridge:        'br1'
     devicetype:    'Team'
-    team_cfg: >-
+    team_config: >-
                    { "runner" : {  "name" : "lacp",  "active": true, "fast_rate" : true,
                    "tx_hash": ["eth", "ipv4", "ipv6"], "tx_balancer": { "name": "basic" } },
                    "link_watch" : {  "name" : "ethtool" } }

--- a/hieradata/nodes/osl/osl-controller-03.yaml
+++ b/hieradata/nodes/osl/osl-controller-03.yaml
@@ -17,7 +17,7 @@ network::interfaces_hash:
     onboot:        'yes'
     bridge:        'br1'
     devicetype:    'Team'
-    team_cfg: >-
+    team_config: >-
                    { "runner" : {  "name" : "lacp",  "active": true, "fast_rate" : true,
                    "tx_hash": ["eth", "ipv4", "ipv6"], "tx_balancer": { "name": "basic" } },
                    "link_watch" : {  "name" : "ethtool" } }

--- a/hieradata/nodes/osl/osl-controller-04.yaml
+++ b/hieradata/nodes/osl/osl-controller-04.yaml
@@ -17,7 +17,7 @@ network::interfaces_hash:
     onboot:        'yes'
     bridge:        'br1'
     devicetype:    'Team'
-    team_cfg: >-
+    team_config: >-
                    { "runner" : {  "name" : "lacp",  "active": true, "fast_rate" : true,
                    "tx_hash": ["eth", "ipv4", "ipv6"], "tx_balancer": { "name": "basic" } },
                    "link_watch" : {  "name" : "ethtool" } }

--- a/hieradata/nodes/osl/osl-storage-01.yaml
+++ b/hieradata/nodes/osl/osl-storage-01.yaml
@@ -25,7 +25,7 @@ network::interfaces_hash:
     netmask:       '255.255.248.0'
     defroute:      'no'
     devicetype:    'Team'
-    team_cfg: >-
+    team_config: >-
                    { "runner" : {  "name" : "lacp",  "active": true, "fast_rate" : true,
                    "tx_hash": ["eth", "ipv4", "ipv6"], "tx_balancer": { "name": "basic" } },
                    "link_watch" : {  "name" : "ethtool" } }

--- a/hieradata/nodes/osl/osl-storage-02.yaml
+++ b/hieradata/nodes/osl/osl-storage-02.yaml
@@ -25,7 +25,7 @@ network::interfaces_hash:
     netmask:       '255.255.248.0'
     defroute:      'no'
     devicetype:    'Team'
-    team_cfg: >-
+    team_config: >-
                    { "runner" : {  "name" : "lacp",  "active": true, "fast_rate" : true,
                    "tx_hash": ["eth", "ipv4", "ipv6"], "tx_balancer": { "name": "basic" } },
                    "link_watch" : {  "name" : "ethtool" } }

--- a/hieradata/nodes/osl/osl-storage-03.yaml
+++ b/hieradata/nodes/osl/osl-storage-03.yaml
@@ -25,7 +25,7 @@ network::interfaces_hash:
     netmask:       '255.255.248.0'
     defroute:      'no'
     devicetype:    'Team'
-    team_cfg: >-
+    team_config: >-
                    { "runner" : {  "name" : "lacp",  "active": true, "fast_rate" : true,
                    "tx_hash": ["eth", "ipv4", "ipv6"], "tx_balancer": { "name": "basic" } },
                    "link_watch" : {  "name" : "ethtool" } }

--- a/hieradata/nodes/osl/osl-storage-04.yaml
+++ b/hieradata/nodes/osl/osl-storage-04.yaml
@@ -25,7 +25,7 @@ network::interfaces_hash:
     netmask:       '255.255.248.0'
     defroute:      'no'
     devicetype:    'Team'
-    team_cfg: >-
+    team_config: >-
                    { "runner" : {  "name" : "lacp",  "active": true, "fast_rate" : true,
                    "tx_hash": ["eth", "ipv4", "ipv6"], "tx_balancer": { "name": "basic" } },
                    "link_watch" : {  "name" : "ethtool" } }

--- a/hieradata/nodes/osl/osl-storage-05.yaml
+++ b/hieradata/nodes/osl/osl-storage-05.yaml
@@ -25,7 +25,7 @@ network::interfaces_hash:
     netmask:       '255.255.248.0'
     defroute:      'no'
     devicetype:    'Team'
-    team_cfg: >-
+    team_config: >-
                    { "runner" : {  "name" : "lacp",  "active": true, "fast_rate" : true,
                    "tx_hash": ["eth", "ipv4", "ipv6"], "tx_balancer": { "name": "basic" } },
                    "link_watch" : {  "name" : "ethtool" } }


### PR DESCRIPTION
Merged changes from upstream with support for NIC teaming. Upstream had chosen another variable name, these changes harmonizes with upstream.

For BGO and OSL location, the puppet modules must be updated when deploying code, otherwise team configuration will fail for new physical nodes.