### PR TITLE
Upgrade cinder to newton

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -145,7 +145,7 @@ mod 'rabbitmq', :ref => '8527f20',                 :git => github + 'puppetlabs/
 # profile::openstack::*
 #
 mod 'glance', :ref => '9.6.0',                   :git => github + 'openstack/puppet-glance'
-mod 'cinder', :ref => '8.2.0',                   :git => github + 'openstack/puppet-cinder'
+mod 'cinder', :ref => '9.5.0',                   :git => github + 'openstack/puppet-cinder'
 mod 'neutron', :ref => '8.3.0',                  :git => github + 'openstack/puppet-neutron'
 mod 'nova', :ref => '8.2.0',                     :git => github + 'openstack/puppet-nova'
 mod 'horizon', :ref => 'norcams-mitaka',         :git => github + 'norcams/puppet-horizon'

--- a/hieradata/common/modules/cinder.yaml
+++ b/hieradata/common/modules/cinder.yaml
@@ -9,15 +9,17 @@ cinder::db::mysql::allowed_hosts:
   - "volume.%{hiera('domain_trp')}"
 
 # cinder api (node: volume)
-cinder::api::keystone_user:      'cinder'
-cinder::api::keystone_enabled:   true
-cinder::api::keystone_password:  "%{hiera('cinder_api_password')}"
-cinder::api::auth_uri:           "%{hiera('endpoint__identity__internal')}/v3"
-cinder::api::identity_uri:       "%{hiera('endpoint__identity__admin')}"
-cinder::api::os_region_name:     "%{::location}"
-cinder::api::bind_host:          "%{::ipaddress_trp1}"
+cinder::api::keystone_enabled:            true
+cinder::api::os_region_name:              "%{::location}"
+cinder::api::bind_host:                   "%{::ipaddress_trp1}"
 
-cinder::volume::iscsi::iscsi_ip_address:        "%{hiera('service__address__cinder_ip')}"
+cinder::keystone::authtoken::username:    'cinder'
+cinder::keystone::authtoken::password:    "%{hiera('cinder_api_password')}"
+cinder::keystone::authtoken::auth_uri:    "%{hiera('endpoint__identity__internal')}"
+cinder::keystone::authtoken::auth_url:    "%{hiera('endpoint__identity__admin')}"
+cinder::keystone::authtoken::region_name: "%{::location}"
+
+cinder::volume::iscsi::iscsi_ip_address:  "%{hiera('service__address__cinder_ip')}"
 
 # default qoutas (node: volume)
 cinder::quota::quota_volumes:    '4'

--- a/hieradata/common/roles/volume.yaml
+++ b/hieradata/common/roles/volume.yaml
@@ -58,3 +58,5 @@ ceph::profile::params::client_keys:
     group: 'cinder'
     cap_mon: 'allow r'
     cap_osd: 'allow class-read object_prefix rbd_children, allow rwx pool=volumes, allow rwx pool=vms, allow rwx pool=images'
+
+openstack_version: 'newton' #FIXME: remove after full upgrade


### PR DESCRIPTION
These changes upgrades glance to newton release.

To test:
- Check out code and branch
- Update puppet modules on admin node
- Remove cinder packages and /etc/cinder
- Run puppet on image node

or run the ansible upgrade job