### PR TITLE
Syslog update

### DIFF
--- a/hieradata/common/modules/haproxy.yaml
+++ b/hieradata/common/modules/haproxy.yaml
@@ -1,16 +1,10 @@
 ---
 haproxy::merge_options: true
 haproxy::global_options:
-  log:                        "localhost local7 info"
+  log:                        "%{hiera('mgmt__address__logger')} local6 info"
   crt-base:                   '/etc/pki/tls/certs'
   tune.ssl.default-dh-param:  2048
   ssl-default-bind-options:   'no-sslv3 no-tls-tickets'
   ssl-default-bind-ciphers:   'ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:RSA+AESGCM:RSA+AES:!aNULL:!MD5:!DSS'
   ssl-default-server-options: 'no-sslv3 no-tls-tickets'
   ssl-default-server-ciphers: 'ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:RSA+AESGCM:RSA+AES:!aNULL:!MD5:!DSS'
-
-haproxy::defaults_options:
-  mode:         'http'
-  option:       [ 'redispatch', 'forwardfor', 'http-server-close' ]
-  balance:      'roundrobin'
-  errorfile:    '503 /etc/haproxy/sorry.http'

--- a/hieradata/common/modules/rsyslog.yaml
+++ b/hieradata/common/modules/rsyslog.yaml
@@ -14,6 +14,8 @@ rsyslog::server::log_templates:
     template: "%TIMESTAMP:::date-rfc3339% %syslogpriority-text% %HOSTNAME% %syslogtag%%msg:::drop-last-lf%\\n"
   - name:     'SyslogFileFormat'
     template: "%TIMESTAMP:::date-rfc3339% %pri-text% %HOSTNAME% %syslogtag%%msg:::drop-last-lf%\\n"
+  - name:     'NorcamsFileFormat'
+    template: "%TIMESTAMP:::date-rfc3339% %pri-text% %HOSTNAME% %syslogtag%%msg:::drop-last-lf%\\n"
 #  - name:     'HorizonFile'
 #    template: '/opt/log/%hostname%/horizon.log'
   - name:     'HorizonAll'
@@ -38,8 +40,9 @@ rsyslog::server::log_templates:
 #    template: '/opt/log/%hostname%/nova.log'
   - name:     'NovaAll'
     template: '/opt/log/nova.log'
-  - name:     'RabbitmqAll'
-    template: '/opt/log/rabbitmq.log'
+    # All custom logs for local6 uses this
+  - name:     'NorcamsAll'
+    template: '/opt/log/norcams.log'
 
 rsyslog::client::server:              "%{hiera('mgmt__address__logger')}"
 rsyslog::client::port:                '514'

--- a/hieradata/common/roles/api.yaml
+++ b/hieradata/common/roles/api.yaml
@@ -24,6 +24,13 @@ profile::highavailability::loadbalancing::haproxy::manage_firewall: true
 profile::highavailability::loadbalancing::haproxy::firewall_extras:
   dport: ['5000', '8774', '8776', '9292', '9696', '80', '443']
 
+# HAproxy
+haproxy::defaults_options:
+  mode:         'http'
+  option:       [ 'redispatch', 'forwardfor', 'http-server-close', 'httplog' ]
+  balance:      'roundrobin'
+  errorfile:    '503 /etc/haproxy/sorry.http'
+
 star_api_ssl_pem: "star.api.%{hiera('domain_public')}.pem"
 api_ssl_pem:      "api.%{hiera('domain_public')}.pem"
 status_ssl_pem:   "status.%{hiera('domain_public')}.pem"

--- a/profile/manifests/messaging/rabbitmq.pp
+++ b/profile/manifests/messaging/rabbitmq.pp
@@ -17,7 +17,8 @@ class profile::messaging::rabbitmq (
   $policy           = {},
   $manage_rsyslog   = false,
   $manage_firewall  = true,
-  $firewall_extras  = {}
+  $firewall_extras  = {},
+  $rsyslog_facility = 'local6'
 ) {
 
   #Class['rabbitmq'] -> Rabbitmq_vhost <<| |>>
@@ -61,7 +62,7 @@ class profile::messaging::rabbitmq (
     rsyslog::imfile { 'rabbitmq':
       file_name     => "/var/log/rabbitmq/rabbit@${::hostname}.log",
       file_tag      => 'rabbitmq',
-      file_facility => 'local7',
+      file_facility => $rsyslog_facility,
     }
   }
 

--- a/profile/templates/logging/rsyslog/server.conf.erb
+++ b/profile/templates/logging/rsyslog/server.conf.erb
@@ -11,18 +11,12 @@ $Template dynAllMessages,"<%= scope.lookupvar('rsyslog::server::server_dir') -%>
 
 # Rules
 local0.*            ?NovaAll;OpenstackFileFormat
-local0.*            ?NovaFile;OpenstackFileFormat
 local1.*            ?HorizonAll;OpenstackFileFormat
-local1.*            ?HorizonFile;OpenstackFileFormat
 local2.*            ?KeystoneAll;OpenstackFileFormat
-local2.*            ?KeystoneFile;OpenstackFileFormat
 local3.*            ?GlanceAll;OpenstackFileFormat
-local3.*            ?GlanceFile;OpenstackFileFormat
 local4.*            ?CinderAll;OpenstackFileFormat
-local4.*            ?CinderFile;OpenstackFileFormat
 local5.*            ?NeutronAll;OpenstackFileFormat
-local5.*            ?NeutronFile;OpenstackFileFormat
-local7.*            ?RabbitmqAll;SyslogFileFormat
+local6.*            ?NorcamsAll;NorcamsFileFormat
 *.*                 -?dynAllMessages;SyslogFileFormat
 
 <% # Common footer across all templates -%>


### PR DESCRIPTION
Change use of syslog facitly and use local6 for all custom facilities. Rabbitmq and haproxy now uses local6 and will log to /opt/log/norcams.log on logger-01.