### PR TITLE
Upgrade neutron to newton release

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -146,7 +146,7 @@ mod 'rabbitmq', :ref => '8527f20',                 :git => github + 'puppetlabs/
 #
 mod 'glance', :ref => '9.6.0',                   :git => github + 'openstack/puppet-glance'
 mod 'cinder', :ref => '9.5.0',                   :git => github + 'openstack/puppet-cinder'
-mod 'neutron', :ref => '8.3.0',                  :git => github + 'openstack/puppet-neutron'
+mod 'neutron', :ref => '9.5.0',                  :git => github + 'openstack/puppet-neutron'
 mod 'nova', :ref => '8.2.0',                     :git => github + 'openstack/puppet-nova'
 mod 'horizon', :ref => 'norcams-mitaka',         :git => github + 'norcams/puppet-horizon'
 mod 'keystone', :ref => 'norcams/newton',        :git => github + 'norcams/puppet-keystone'

--- a/hieradata/common/modules/neutron.yaml
+++ b/hieradata/common/modules/neutron.yaml
@@ -2,15 +2,16 @@
 neutron::bind_host:   "%{ipaddress_trp1}"
 neutron::core_plugin: 'calico'
 
-neutron::server::auth_uri: "%{hiera('endpoint__identity__internal')}"
-neutron::server::auth_url: "%{hiera('endpoint__identity__admin')}"
 neutron::server::sync_db: true
 neutron::server::database_connection: "mysql://neutron:%{hiera('neutron::db::mysql::password')}@%{hiera('service__address__mysql')}/neutron"
-neutron::server::username: 'neutron'
-neutron::server::password: "%{hiera('neutron_api_password')}"
-neutron::server::region_name: "%{::location}"
-neutron::server::user_domain_id:  'default'
-neutron::server::project_domain_id:  'default'
+
+neutron::keystone::authtoken::auth_uri:            "%{hiera('endpoint__identity__internal')}"
+neutron::keystone::authtoken::auth_url:            "%{hiera('endpoint__identity__admin')}"
+neutron::keystone::authtoken::username:            'neutron'
+neutron::keystone::authtoken::password:            "%{hiera('neutron_api_password')}"
+neutron::keystone::authtoken::region_name:         "%{::location}"
+neutron::keystone::authtoken::project_domain_name: 'default'
+neutron::keystone::authtoken::user_domain_name:    'default'
 
 neutron::server::notifications::notify_nova_on_port_status_changes: true
 neutron::server::notifications::notify_nova_on_port_data_changes:   true

--- a/hieradata/common/roles/network.yaml
+++ b/hieradata/common/roles/network.yaml
@@ -40,3 +40,5 @@ profile::base::yumrepo::repo_hash:
     ensure: present
   calico22:
     ensure: present
+
+openstack_version: 'newton' #FIXME: remove after full upgrade


### PR DESCRIPTION
These changes upgrades neutron to newton release.

To test:
    Check out code and branch
    Update puppet modules on admin node
    Remove neutron packages and /etc/neutron
    Run puppet on network node

or better, run the ansible upgrade job