### PR TITLE
Upgrade nova from mitaka to newton

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -147,7 +147,7 @@ mod 'rabbitmq', :ref => '8527f20',                 :git => github + 'puppetlabs/
 mod 'glance', :ref => '9.6.0',                   :git => github + 'openstack/puppet-glance'
 mod 'cinder', :ref => '9.5.0',                   :git => github + 'openstack/puppet-cinder'
 mod 'neutron', :ref => '9.5.0',                  :git => github + 'openstack/puppet-neutron'
-mod 'nova', :ref => '8.2.0',                     :git => github + 'openstack/puppet-nova'
+mod 'nova', :ref => '9.6.0',                     :git => github + 'openstack/puppet-nova'
 mod 'horizon', :ref => 'norcams-mitaka',         :git => github + 'norcams/puppet-horizon'
 mod 'keystone', :ref => 'norcams/newton',        :git => github + 'norcams/puppet-keystone'
 

--- a/hieradata/common/modules/nova.yaml
+++ b/hieradata/common/modules/nova.yaml
@@ -1,10 +1,11 @@
 ---
 # Shared config (nodes: novactrl, compute)
-nova::db::database_connection:     "mysql://nova:%{hiera('nova::db::mysql::password')}@%{hiera('service__address__mysql')}/nova"
-nova::db::api_database_connection: "mysql://nova_api:%{hiera('nova::db::mysql_api::password')}@%{hiera('service__address__mysql')}/nova_api"
-nova::glance_api_servers:          "%{hiera('endpoint__image__internal')}"
-nova::cinder_catalog_info:         'volumev2:cinderv2:internalURL'
-nova::os_region_name:              "%{location}"
+nova::db::database_connection:           "mysql://nova:%{hiera('nova::db::mysql::password')}@%{hiera('service__address__mysql')}/nova"
+nova::db::api_database_connection:       "mysql://nova_api:%{hiera('nova::db::mysql_api::password')}@%{hiera('service__address__mysql')}/nova_api"
+nova::db::placement_database_connection: "mysql://nova_placement:%{hiera('nova::db::mysql_placement::password')}@%{hiera('service__address__mysql')}/nova_placement"
+nova::glance_api_servers:                "%{hiera('endpoint__image__internal')}"
+nova::cinder_catalog_info:               'volumev2:cinderv2:internalURL'
+nova::os_region_name:                    "%{location}"
 
 # logging
 nova::use_syslog:           true
@@ -23,6 +24,9 @@ nova::db::mysql::allowed_hosts:
   - "%{netpart_transport1}.%"
   - "compute.%{hiera('domain_trp')}"
 nova::db::mysql_api::allowed_hosts:
+  - "%{netpart_transport1}.%"
+  - "compute.%{hiera('domain_trp')}"
+nova::db::mysql_placement::allowed_hosts:
   - "%{netpart_transport1}.%"
   - "compute.%{hiera('domain_trp')}"
 

--- a/hieradata/common/modules/nova.yaml
+++ b/hieradata/common/modules/nova.yaml
@@ -33,9 +33,9 @@ nova::db::mysql_placement::allowed_hosts:
 # keystone auth (node: identity)
 nova::keystone::auth::region:           "%{location}"
 nova::keystone::auth::password:         "%{hiera('nova_api_password')}"
-nova::keystone::auth::public_url:       "%{hiera('endpoint__compute__public')}/v2.1"
-nova::keystone::auth::admin_url:        "%{hiera('endpoint__compute__admin')}/v2.1"
-nova::keystone::auth::internal_url:     "%{hiera('endpoint__compute__internal')}/v2.1"
+nova::keystone::auth::public_url:       "%{hiera('endpoint__compute__public')}/v2.1/"
+nova::keystone::auth::admin_url:        "%{hiera('endpoint__compute__admin')}/v2.1/"
+nova::keystone::auth::internal_url:     "%{hiera('endpoint__compute__internal')}/v2.1/"
 
 # api (node: novactrl)
 nova::api::enabled_apis:                [ 'osapi_compute', ]

--- a/hieradata/common/modules/nova.yaml
+++ b/hieradata/common/modules/nova.yaml
@@ -29,9 +29,10 @@ nova::db::mysql_api::allowed_hosts:
 # keystone auth (node: identity)
 nova::keystone::auth::region:           "%{location}"
 nova::keystone::auth::password:         "%{hiera('nova_api_password')}"
-nova::keystone::auth::public_url:       "%{hiera('endpoint__compute__public')}/v3"
-nova::keystone::auth::admin_url:        "%{hiera('endpoint__compute__admin')}/v3"
-nova::keystone::auth::internal_url:     "%{hiera('endpoint__compute__internal')}/v3"
+nova::keystone::auth::public_url:       "%{hiera('endpoint__compute__public')}/v2.1/%(tenant_id)s"
+nova::keystone::auth::admin_url:        "%{hiera('endpoint__compute__admin')}/v2.1/%(tenant_id)s"
+nova::keystone::auth::internal_url:     "%{hiera('endpoint__compute__internal')}/2.1/%(tenant_id)s"
+
 
 # api (node: novactrl)
 nova::api::enabled_apis:                [ 'osapi_compute', ]

--- a/hieradata/common/modules/nova.yaml
+++ b/hieradata/common/modules/nova.yaml
@@ -43,6 +43,8 @@ nova::api::enabled_apis:                [ 'osapi_compute', ]
 nova::api::enabled:                     true
 nova::api::api_bind_address:            "%{ipaddress_transport1}"
 
+nova::cells::enabled: false
+
 nova::keystone::authtoken::username:    'nova'
 nova::keystone::authtoken::password:    "%{hiera('nova_api_password')}"
 nova::keystone::authtoken::auth_url:    "%{hiera('endpoint__identity__admin')}"

--- a/hieradata/common/modules/nova.yaml
+++ b/hieradata/common/modules/nova.yaml
@@ -33,9 +33,9 @@ nova::db::mysql_placement::allowed_hosts:
 # keystone auth (node: identity)
 nova::keystone::auth::region:           "%{location}"
 nova::keystone::auth::password:         "%{hiera('nova_api_password')}"
-nova::keystone::auth::public_url:       "%{hiera('endpoint__compute__public')}/v2.1/%(tenant_id)s"
-nova::keystone::auth::admin_url:        "%{hiera('endpoint__compute__admin')}/v2.1/%(tenant_id)s"
-nova::keystone::auth::internal_url:     "%{hiera('endpoint__compute__internal')}/2.1/%(tenant_id)s"
+nova::keystone::auth::public_url:       "%{hiera('endpoint__compute__public')}/v2.1"
+nova::keystone::auth::admin_url:        "%{hiera('endpoint__compute__admin')}/v2.1"
+nova::keystone::auth::internal_url:     "%{hiera('endpoint__compute__internal')}/2.1"
 
 
 # api (node: novactrl)

--- a/hieradata/common/modules/nova.yaml
+++ b/hieradata/common/modules/nova.yaml
@@ -35,7 +35,7 @@ nova::keystone::auth::region:           "%{location}"
 nova::keystone::auth::password:         "%{hiera('nova_api_password')}"
 nova::keystone::auth::public_url:       "%{hiera('endpoint__compute__public')}/v2.1"
 nova::keystone::auth::admin_url:        "%{hiera('endpoint__compute__admin')}/v2.1"
-nova::keystone::auth::internal_url:     "%{hiera('endpoint__compute__internal')}/2.1"
+nova::keystone::auth::internal_url:     "%{hiera('endpoint__compute__internal')}/v2.1"
 
 # api (node: novactrl)
 nova::api::enabled_apis:                [ 'osapi_compute', ]

--- a/hieradata/common/modules/nova.yaml
+++ b/hieradata/common/modules/nova.yaml
@@ -12,12 +12,10 @@ nova::use_syslog:           true
 nova::log_facility:         'LOG_LOCAL0'
 
 # rabbit mq (for rabbit_password see secrets)
-nova::rabbit_userid:        'nova'
-nova::rabbit_virtual_host:  'nova'
-nova::rabbit_hosts:
-  - "%{hiera('service__address__rabbitmq_01')}:5672"
-  - "%{hiera('service__address__rabbitmq_02')}:5672"
-  - "%{hiera('service__address__rabbitmq_03')}:5672"
+nova::default_transport_url:
+  "rabbit://nova:%{hiera('nova::rabbit_password')}@%{hiera('service__address__rabbitmq_01')}:5672,\
+  nova:%{hiera('nova::rabbit_password')}@%{hiera('service__address__rabbitmq_02')}:5672,\
+  nova:%{hiera('nova::rabbit_password')}@%{hiera('service__address__rabbitmq_03')}:5672/nova"
 
 # mysql database (node: db)
 nova::db::mysql::allowed_hosts:

--- a/hieradata/common/modules/nova.yaml
+++ b/hieradata/common/modules/nova.yaml
@@ -94,14 +94,15 @@ nova::config::nova_config:
     value: 'rsync'
 
 # compute (node: compute)
-nova::compute::enabled:                         true
-nova::compute::allow_resize_to_same_host:       true
-nova::compute::rbd::libvirt_rbd_user:           'cinder'
-nova::compute::rbd::libvirt_rbd_secret_uuid:    '363cb82c-793f-4aff-93f5-3332376c4369'
-nova::compute::rbd::libvirt_images_rbd_pool:    'volumes'
-nova::compute::rbd::rbd_keyring:                'client.cinder'
-nova::compute::rbd::ephemeral_storage:          false
-nova::compute::rbd::manage_ceph_client:         false
+nova::compute::enabled:                          true
+nova::compute::allow_resize_to_same_host:        true
+nova::compute::resume_guests_state_on_host_boot: true
+nova::compute::rbd::libvirt_rbd_user:            'cinder'
+nova::compute::rbd::libvirt_rbd_secret_uuid:     '363cb82c-793f-4aff-93f5-3332376c4369'
+nova::compute::rbd::libvirt_images_rbd_pool:     'volumes'
+nova::compute::rbd::rbd_keyring:                 'client.cinder'
+nova::compute::rbd::ephemeral_storage:           false
+nova::compute::rbd::manage_ceph_client:          false
 
 # set image properties hw_scsi_model=virtio-scsi and hw_disk_bus=scsi to enable
 nova::compute::libvirt::libvirt_hw_disk_discard: 'unmap'

--- a/hieradata/common/modules/nova.yaml
+++ b/hieradata/common/modules/nova.yaml
@@ -29,20 +29,20 @@ nova::db::mysql_api::allowed_hosts:
 # keystone auth (node: identity)
 nova::keystone::auth::region:           "%{location}"
 nova::keystone::auth::password:         "%{hiera('nova_api_password')}"
-nova::keystone::auth::public_url:       "%{hiera('endpoint__compute__public')}/v2/%(tenant_id)s"
-nova::keystone::auth::public_url_v3:    "%{hiera('endpoint__compute__public')}/v3"
-nova::keystone::auth::admin_url:        "%{hiera('endpoint__compute__admin')}/v2/%(tenant_id)s"
-nova::keystone::auth::admin_url_v3:     "%{hiera('endpoint__compute__admin')}/v3"
-nova::keystone::auth::internal_url:     "%{hiera('endpoint__compute__internal')}/v2/%(tenant_id)s"
-nova::keystone::auth::internal_url_v3:  "%{hiera('endpoint__compute__internal')}/v3"
+nova::keystone::auth::public_url:       "%{hiera('endpoint__compute__public')}/v3"
+nova::keystone::auth::admin_url:        "%{hiera('endpoint__compute__admin')}/v3"
+nova::keystone::auth::internal_url:     "%{hiera('endpoint__compute__internal')}/v3"
 
 # api (node: novactrl)
-nova::api::enabled_apis:                [ 'ec2', 'osapi_compute' ]
+nova::api::enabled_apis:                [ 'osapi_compute', ]
 nova::api::enabled:                     true
 nova::api::api_bind_address:            "%{ipaddress_transport1}"
-nova::api::admin_password:              "%{hiera('nova_api_password')}"
-nova::api::auth_uri:                    "%{hiera('endpoint__identity__internal')}"
-nova::api::identity_uri:                "%{hiera('endpoint__identity__admin')}"
+
+nova::keystone::authtoken::username:    'nova'
+nova::keystone::authtoken::password:    "%{hiera('nova_api_password')}"
+nova::keystone::authtoken::auth_url:    "%{hiera('endpoint__identity__admin')}"
+nova::keystone::authtoken::auth_uri:    "%{hiera('endpoint__identity__internal')}"
+nova::keystone::authtoken::region_name: "%{::location}"
 
 # scheduler (node: novactrl)
 nova::scheduler::enabled:                           true

--- a/hieradata/common/modules/nova.yaml
+++ b/hieradata/common/modules/nova.yaml
@@ -37,7 +37,6 @@ nova::keystone::auth::public_url:       "%{hiera('endpoint__compute__public')}/v
 nova::keystone::auth::admin_url:        "%{hiera('endpoint__compute__admin')}/v2.1"
 nova::keystone::auth::internal_url:     "%{hiera('endpoint__compute__internal')}/2.1"
 
-
 # api (node: novactrl)
 nova::api::enabled_apis:                [ 'osapi_compute', ]
 nova::api::enabled:                     true
@@ -91,7 +90,6 @@ nova::network::neutron::neutron_auth_url:       "%{hiera('endpoint__identity__ad
 nova::network::neutron::neutron_region_name:    "%{::location}"
 nova::network::neutron::neutron_password:       "%{hiera('neutron_api_password')}"
 
-# remove need for confirmation when move or resize instance (node: compute and novactrl)
 # Use rsync, not ssh for migrate transport to support sparse images
 nova::config::nova_config:
   libvirt/remote_filesystem_transport:

--- a/hieradata/common/modules/nova.yaml
+++ b/hieradata/common/modules/nova.yaml
@@ -2,7 +2,6 @@
 # Shared config (nodes: novactrl, compute)
 nova::db::database_connection:           "mysql://nova:%{hiera('nova::db::mysql::password')}@%{hiera('service__address__mysql')}/nova"
 nova::db::api_database_connection:       "mysql://nova_api:%{hiera('nova::db::mysql_api::password')}@%{hiera('service__address__mysql')}/nova_api"
-nova::db::placement_database_connection: "mysql://nova_placement:%{hiera('nova::db::mysql_placement::password')}@%{hiera('service__address__mysql')}/nova_placement"
 nova::glance_api_servers:                "%{hiera('endpoint__image__internal')}"
 nova::cinder_catalog_info:               'volumev2:cinderv2:internalURL'
 nova::os_region_name:                    "%{location}"
@@ -22,9 +21,6 @@ nova::db::mysql::allowed_hosts:
   - "%{netpart_transport1}.%"
   - "compute.%{hiera('domain_trp')}"
 nova::db::mysql_api::allowed_hosts:
-  - "%{netpart_transport1}.%"
-  - "compute.%{hiera('domain_trp')}"
-nova::db::mysql_placement::allowed_hosts:
   - "%{netpart_transport1}.%"
   - "compute.%{hiera('domain_trp')}"
 

--- a/hieradata/common/modules/nova.yaml
+++ b/hieradata/common/modules/nova.yaml
@@ -88,8 +88,6 @@ nova::network::neutron::neutron_password:       "%{hiera('neutron_api_password')
 # remove need for confirmation when move or resize instance (node: compute and novactrl)
 # Use rsync, not ssh for migrate transport to support sparse images
 nova::config::nova_config:
-  DEFAULT/resize_confirm_window:
-    value: "1"
   libvirt/remote_filesystem_transport:
     value: 'rsync'
 
@@ -97,6 +95,7 @@ nova::config::nova_config:
 nova::compute::enabled:                          true
 nova::compute::allow_resize_to_same_host:        true
 nova::compute::resume_guests_state_on_host_boot: true
+nova::compute::resize_confirm_window:            '1'
 nova::compute::rbd::libvirt_rbd_user:            'cinder'
 nova::compute::rbd::libvirt_rbd_secret_uuid:     '363cb82c-793f-4aff-93f5-3332376c4369'
 nova::compute::rbd::libvirt_images_rbd_pool:     'volumes'

--- a/hieradata/common/roles/compute.yaml
+++ b/hieradata/common/roles/compute.yaml
@@ -155,3 +155,5 @@ ceph::profile::params::client_keys:
     group: 'nova'
     cap_mon: 'allow r'
     cap_osd: 'allow class-read object_prefix rbd_children, allow rwx pool=volumes, allow rwx pool=vms, allow rwx pool=images'
+
+openstack_version: 'newton' #FIXME: remove after full upgrade

--- a/hieradata/common/roles/compute.yaml
+++ b/hieradata/common/roles/compute.yaml
@@ -21,8 +21,6 @@ include:
 neutron::use_syslog:    true
 neutron::log_facility:  'LOG_LOCAL5'
 
-profile::openstack::compute::hypervisor::manage_resume_guests_state:  true
-
 # Manage default availability zone
 profile::openstack::compute::manage_az:            true
 

--- a/hieradata/common/roles/novactrl.yaml
+++ b/hieradata/common/roles/novactrl.yaml
@@ -28,3 +28,5 @@ profile::base::common::packages:
 profile::base::yumrepo::repo_hash:
   rdo-release:
     ensure: present
+
+openstack_version: 'newton' #FIXME: remove after full upgrade

--- a/hieradata/nodes/bgo/bgo-db-02.yaml
+++ b/hieradata/nodes/bgo/bgo-db-02.yaml
@@ -19,3 +19,4 @@ profile::openstack::database::sql::glance_enabled:    true
 profile::openstack::database::sql::nova_enabled:      true
 profile::openstack::database::sql::neutron_enabled:   true
 profile::openstack::database::sql::cinder_enabled:    true
+profile::openstack::database::sql::create_cell0:      true # FIXME in ocata

--- a/hieradata/nodes/local1/local1-db-02.yaml
+++ b/hieradata/nodes/local1/local1-db-02.yaml
@@ -28,3 +28,4 @@ profile::openstack::database::sql::glance_enabled:    true
 profile::openstack::database::sql::nova_enabled:      true
 profile::openstack::database::sql::neutron_enabled:   true
 profile::openstack::database::sql::cinder_enabled:    true
+profile::openstack::database::sql::create_cell0:      true # FIXME in ocata

--- a/hieradata/nodes/local2/local2-db-02.yaml
+++ b/hieradata/nodes/local2/local2-db-02.yaml
@@ -28,3 +28,4 @@ profile::openstack::database::sql::glance_enabled:    true
 profile::openstack::database::sql::nova_enabled:      true
 profile::openstack::database::sql::neutron_enabled:   true
 profile::openstack::database::sql::cinder_enabled:    true
+profile::openstack::database::sql::create_cell0:      true # FIXME in ocata

--- a/hieradata/nodes/osl/osl-db-02.yaml
+++ b/hieradata/nodes/osl/osl-db-02.yaml
@@ -19,3 +19,4 @@ profile::openstack::database::sql::glance_enabled:    true
 profile::openstack::database::sql::nova_enabled:      true
 profile::openstack::database::sql::neutron_enabled:   true
 profile::openstack::database::sql::cinder_enabled:    true
+profile::openstack::database::sql::create_cell0:      true # FIXME in ocata

--- a/hieradata/nodes/test01/test01-db-02.yaml
+++ b/hieradata/nodes/test01/test01-db-02.yaml
@@ -20,3 +20,4 @@ profile::openstack::database::sql::glance_enabled:    true
 profile::openstack::database::sql::nova_enabled:      true
 profile::openstack::database::sql::neutron_enabled:   true
 profile::openstack::database::sql::cinder_enabled:    true
+profile::openstack::database::sql::create_cell0:      true # FIXME in ocata

--- a/hieradata/nodes/test02/test02-db-02.yaml
+++ b/hieradata/nodes/test02/test02-db-02.yaml
@@ -19,3 +19,4 @@ profile::openstack::database::sql::glance_enabled:    true
 profile::openstack::database::sql::nova_enabled:      true
 profile::openstack::database::sql::neutron_enabled:   true
 profile::openstack::database::sql::cinder_enabled:    true
+profile::openstack::database::sql::create_cell0:      true # FIXME in ocata

--- a/profile/manifests/openstack/compute/hypervisor.pp
+++ b/profile/manifests/openstack/compute/hypervisor.pp
@@ -3,7 +3,6 @@ class profile::openstack::compute::hypervisor (
   $manage_libvirt_rbd = false,
   $manage_telemetry = true,
   $manage_firewall = true,
-  $manage_resume_guests_state = false, #FIXME - this will be in nova module for newton
   $fix_snapshot_loc = false, # FIXME - Should probably be removed for newton release
   $firewall_extras = {},
 ) {
@@ -36,13 +35,6 @@ class profile::openstack::compute::hypervisor (
     profile::firewall::rule{ '224 migration accept tcp':
       port   => ['16509', '49152-49215'],
       extras => $firewall_extras,
-    }
-  }
-
-  #FIXME - this will be in nova module for newton
-  if $manage_resume_guests_state {
-    nova_config { 'DEFAULT/resume_guests_state_on_host_boot' :
-      value => true,
     }
   }
 

--- a/profile/manifests/openstack/database/sql.pp
+++ b/profile/manifests/openstack/database/sql.pp
@@ -6,6 +6,7 @@ class profile::openstack::database::sql (
   $heat_enabled     = false,
   $trove_enabled    = false,
   $cinder_enabled   = false,
+  $create_cell0     = false,
   $database         = 'mariadb',
 ) {
 
@@ -26,6 +27,30 @@ class profile::openstack::database::sql (
   if $nova_enabled {
     include ::nova::db::mysql
     include ::nova::db::mysql_api
+
+    #FIXME nova puppet module creates database in ocata
+    if $create_cell0 {
+
+      $addr1 = hiera('netcfg_trp_netpart')
+      $addr2 = hiera('domain_trp')
+
+      mysql_database { 'nova_cell0':
+        ensure    => present,
+        charset   => 'utf8',
+      }
+      mysql_grant { "nova@$addr1.%/*.*":
+        ensure    => present,
+        privileges => ['ALL'],
+        table    => '*.*',
+        user     => "nova@$addr1.%",
+      }
+      mysql_grant { "nova@compute.$addr2/*.*":
+        ensure    => present,
+        privileges => ['ALL'],
+        table    => '*.*',
+        user     => "nova@compute.$addr2",
+      }
+    }
   }
 
   if $cinder_enabled {

--- a/profile/manifests/openstack/database/sql.pp
+++ b/profile/manifests/openstack/database/sql.pp
@@ -38,17 +38,17 @@ class profile::openstack::database::sql (
         ensure    => present,
         charset   => 'utf8',
       }
-      mysql_grant { "nova@$addr1.%/*.*":
+      mysql_grant { "nova@${addr1}.%/*.*":
         ensure    => present,
         privileges => ['ALL'],
         table    => '*.*',
-        user     => "nova@$addr1.%",
+        user     => "nova@${addr1}.%",
       }
-      mysql_grant { "nova@compute.$addr2/*.*":
+      mysql_grant { "nova@compute.${addr2}/*.*":
         ensure    => present,
         privileges => ['ALL'],
         table    => '*.*',
-        user     => "nova@compute.$addr2",
+        user     => "nova@compute.${addr2}",
       }
     }
   }


### PR DESCRIPTION
These changes upgrades nova to newton release, including compute. To test:

- Stop puppet on all nodes for good measure
- Deploy code, delete nova puppet module, update modules

On node identity:
- run puppet
- delete all novav3 endpoints

On node db-02:
- run puppet
- run puppet again

On node novactrl:
- stop openstack services (api, conductor, consoleauth, scheduler)
- do a facter=kickstart puppet run 
- yum update -y
- uninstall openstack-nova-common and openstack-nova-api
- rm -rf /etc/nova/
- rm -rf /var/lib/puppet/lib
- run puppet
- run puppet again

Later, on computes:
- stop openstack services
- do a facter=kickstart puppet run
- yum update -y
- uninstall openstack-nova-common and openstack-nova-api
- rm -rf /etc/nova/
- rm -rf /var/lib/puppet/lib
- run puppet
- run puppet again

Better still, create an ansible job doing all the above.

Test, enable puppet.