### PR TITLE
Added metric node

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -152,6 +152,7 @@ mod 'neutron', :ref => '9.5.0',                  :git => github + 'openstack/pup
 mod 'nova', :ref => '9.6.0',                     :git => github + 'openstack/puppet-nova'
 mod 'horizon', :ref => 'stable/newton',          :git => github + 'openstack/puppet-horizon'
 mod 'keystone', :ref => 'norcams/newton',        :git => github + 'norcams/puppet-keystone'
+mod 'gnocchi', :ref => '9.5.0',                  :git => github + 'openstack/puppet-gnocchi'
 
 mod 'oslo', :ref => '9.5.0',                     :git => github + 'openstack/puppet-oslo'
 mod 'openstacklib', :ref => '9.5.0',             :git => github + 'openstack/puppet-openstacklib'

--- a/hieradata/common/common.yaml
+++ b/hieradata/common/common.yaml
@@ -126,6 +126,7 @@ service__address__rabbitmq_02:    "mq01.%{hiera('domain_trp')}"
 service__address__rabbitmq_03:    "mq01.%{hiera('domain_trp')}"
 service__address__cinder_ip:      "%{hiera('netcfg_trp_netpart')}.46"
 service__address__consoleproxy:
+service__address__metric:         "metric.%{hiera('domain_trp')}"
 service__address__ns_01:          "%{hiera('netcfg_trp_netpart')}.16"
 service__address__ns_02:          "%{hiera('netcfg_trp_netpart')}.17"
 
@@ -159,6 +160,9 @@ endpoint__image__public:          "https://image.api.%{hiera('domain_public')}:9
 endpoint__network__admin:         "http://network.%{hiera('domain_trp')}:9696"
 endpoint__network__internal:      "http://network.%{hiera('domain_trp')}:9696"
 endpoint__network__public:        "https://network.api.%{hiera('domain_public')}:9696"
+endpoint__metric__admin:          "http://metric.%{hiera('domain_trp')}:8041"
+endpoint__metric__internal:       "http://metric.%{hiera('domain_trp')}:8041"
+endpoint__metric__public:         "https://metric.api.%{hiera('domain_public')}:8041"
 
 #
 # DNS (merge of this and location)
@@ -193,6 +197,7 @@ profile::network::services::dns_records:
     "%{::location}-cephmon-01.%{hiera('domain_mgmt')}":     "%{hiera('netcfg_mgmt_netpart')}.91"
     "%{::location}-cephmon-02.%{hiera('domain_mgmt')}":     "%{hiera('netcfg_mgmt_netpart')}.92"
     "%{::location}-cephmon-03.%{hiera('domain_mgmt')}":     "%{hiera('netcfg_mgmt_netpart')}.93"
+    "%{::location}-metric-01.%{hiera('domain_mgmt')}":      "%{hiera('netcfg_mgmt_netpart')}.96"
     "%{::location}-controller-01.%{hiera('domain_mgmt')}":  "%{hiera('netcfg_mgmt_netpart')}.100"
     "%{::location}-controller-02.%{hiera('domain_mgmt')}":  "%{hiera('netcfg_mgmt_netpart')}.101"
     "%{::location}-controller-03.%{hiera('domain_mgmt')}":  "%{hiera('netcfg_mgmt_netpart')}.102"
@@ -229,6 +234,7 @@ profile::network::services::dns_records:
     "compute.%{hiera('domain_trp')}":                       "%{hiera('netcfg_trp_netpart')}.86"
     "network.%{hiera('domain_trp')}":                       "%{hiera('netcfg_trp_netpart')}.86"
     "identity.%{hiera('domain_trp')}":                      "%{hiera('netcfg_trp_netpart')}.86"
+    "metric.%{hiera('domain_trp')}":                        "%{hiera('netcfg_trp_netpart')}.96"
 
 
 #

--- a/hieradata/common/modules/gnocchi.yaml
+++ b/hieradata/common/modules/gnocchi.yaml
@@ -1,0 +1,27 @@
+---
+# keystone auth (node: metric)
+gnocchi::keystone::auth::password:            "%{hiera('gnocchi::api::keystone_password')}"
+gnocchi::keystone::auth::public_url:          "%{hiera('endpoint__metric__public')}"
+gnocchi::keystone::auth::admin_url:           "%{hiera('endpoint__metric__admin')}"
+gnocchi::keystone::auth::internal_url:        "%{hiera('endpoint__metric__internal')}"
+gnocchi::keystone::auth::region:              "%{::location}"
+gnocchi::keystone::authtoken::password:       "%{hiera('gnocchi::api::keystone_password')}"
+gnocchi::keystone::authtoken::public_url:     "%{hiera('endpoint__metric__public')}"
+gnocchi::keystone::authtoken::auth_uri:       "%{hiera('endpoint__metric__public')}"
+gnocchi::keystone::authtoken::auth_url:       "%{hiera('endpoint__identity__admin')}"
+gnocchi::keystone::authtoken::admin_url:      "%{hiera('endpoint__metric__admin')}"
+gnocchi::keystone::authtoken::internal_url:   "%{hiera('endpoint__metric__internal')}"
+
+# db (node: volume)
+gnocchi::database_connection:      "mysql://gnocchi:%{hiera('gnocchi::db::mysql::password')}@%{hiera('service__address__mysql')}/gnocchi"
+
+gnocchi::db::mysql::dbname:   'gnocchi'
+gnocchi::db::mysql::user:     'gnocchi'
+gnocchi::db::mysql::allowed_hosts:
+  - "%{netpart_trp1}.%"
+
+# statsd
+gnocchi::statsd::resource_id:       577a85b8-1f77-47e7-ac6f-742b475657b9
+gnocchi::statsd::user_id:           'gnocchi'
+gnocchi::statsd::project_id:        'service'
+gnocchi::statsd::flush_delay:       60

--- a/hieradata/common/modules/profile.yaml
+++ b/hieradata/common/modules/profile.yaml
@@ -41,6 +41,7 @@ profile::openstack::database::sql::glance_enabled:   true
 profile::openstack::database::sql::nova_enabled:     true
 profile::openstack::database::sql::neutron_enabled:  true
 profile::openstack::database::sql::cinder_enabled:   true
+profile::openstack::database::sql::gnocchi_enabled:  true
 profile::openstack::database::sql::heat_enabled:     false
 profile::openstack::database::sql::trove_enabled:    false
 
@@ -53,6 +54,7 @@ profile::openstack::identity::cinder_enabled:     true
 profile::openstack::identity::glance_enabled:     true
 profile::openstack::identity::neutron_enabled:    true
 profile::openstack::identity::nova_enabled:       true
+profile::openstack::identity::gnocchi_enabled:    true
 profile::openstack::identity::swift_enabled:      false
 profile::openstack::identity::trove_enabled:      false
 

--- a/hieradata/common/roles/api.yaml
+++ b/hieradata/common/roles/api.yaml
@@ -27,8 +27,8 @@ profile::base::network::manage_dummy:                               true
 profile::highavailability::loadbalancing::haproxy::manage_haproxy:  true
 profile::highavailability::loadbalancing::haproxy::manage_firewall: true
 profile::highavailability::loadbalancing::haproxy::firewall_ports:
-  public:    ['5000', '8774', '8776', '9292', '9696', '80', '443']
-  internal:  ['5000', '8774', '8776', '9292', '9696', '35357']
+  public:    ['5000', '8041', '8774', '8776', '9292', '9696', '80', '443']
+  internal:  ['5000', '8041', '8774', '8776', '9292', '9696', '35357']
   mgmt:      ['9000']
 
 # HAproxy
@@ -58,6 +58,7 @@ profile::highavailability::loadbalancing::haproxy::haproxy_mapfile:
       - "api.%{hiera('domain_frontend')}:5000":         'bk_identity'
       - "identity.api.%{hiera('domain_public')}:5000":  'bk_identity'
       - "network.api.%{hiera('domain_public')}:9696":   'bk_network'
+      - "metric.api.%{hiera('domain_public')}:8041":    'bk_metric'
       - "compute.api.%{hiera('domain_public')}:8774":   'bk_compute'
       - "volume.api.%{hiera('domain_public')}:8776":    'bk_volume'
       - "image.api.%{hiera('domain_public')}:9292":     'bk_image'
@@ -68,6 +69,7 @@ profile::highavailability::loadbalancing::haproxy::haproxy_mapfile:
       - "identity.%{hiera('domain_trp')}:5000":         'bk_identity'
       - "identity.%{hiera('domain_trp')}:35357":        'bk_identity'
       - "network.%{hiera('domain_trp')}:9696":          'bk_network'
+      - "metric.%{hiera('domain_trp')}:8041":           'bk_metric'
       - "compute.%{hiera('domain_trp')}:8774":          'bk_compute'
       - "volume.%{hiera('domain_trp')}:8776":           'bk_volume'
       - "image.%{hiera('domain_trp')}:9292":            'bk_image'
@@ -77,6 +79,7 @@ profile::highavailability::loadbalancing::haproxy::haproxy_frontends:
   frontend_public:
     bind:
       "%{::ipaddress_public1}:5000":  ['ssl', 'crt', "%{hiera('star_api_ssl_pem')}", 'crt', "%{hiera('api_ssl_pem')}"]
+      "%{::ipaddress_public1}:8041":  ['ssl', 'crt', "%{hiera('star_api_ssl_pem')}"]
       "%{::ipaddress_public1}:8774":  ['ssl', 'crt', "%{hiera('star_api_ssl_pem')}"]
       "%{::ipaddress_public1}:8776":  ['ssl', 'crt', "%{hiera('star_api_ssl_pem')}"]
       "%{::ipaddress_public1}:9292":  ['ssl', 'crt', "%{hiera('star_api_ssl_pem')}"]
@@ -94,6 +97,7 @@ profile::highavailability::loadbalancing::haproxy::haproxy_frontends:
     bind:
       "%{::ipaddress_trp1}:35357": [] # keystone-admin
       "%{::ipaddress_trp1}:5000":  [] # keystone
+      "%{::ipaddress_trp1}:8041":  [] # metric
       "%{::ipaddress_trp1}:8774":  [] # compute
       "%{::ipaddress_trp1}:8776":  [] # volume
       "%{::ipaddress_trp1}:9292":  [] # image
@@ -135,6 +139,10 @@ profile::highavailability::loadbalancing::haproxy::haproxy_backends:
     options:
       - option:       'httplog'
       - errorfile:    '503 /etc/haproxy/error.api.http'
+  bk_metric:
+    options:
+      - option:       'httplog'
+      - errorfile:    '503 /etc/haproxy/error.api.http'
   bk_status:
     options:
       - option:       'httplog'
@@ -152,6 +160,12 @@ profile::highavailability::loadbalancing::haproxy::haproxy_balancermembers:
     ports:              9696
     server_names:       ['%{::location}-network-01']
     ipaddresses:        ["%{hiera('netcfg_trp_netpart')}.71"]
+    options:            'check'
+  metric:
+    listening_service:  'bk_metric'
+    server_names:       ['%{::location}-metric-01']
+    ipaddresses:        ["%{hiera('netcfg_trp_netpart')}.96"]
+    ports:              '8041'
     options:            'check'
   compute:
     listening_service:  'bk_compute'

--- a/hieradata/common/roles/metric.yaml
+++ b/hieradata/common/roles/metric.yaml
@@ -1,0 +1,17 @@
+---
+include:
+  default:
+    - profile::openstack::gnocchi
+    - profile::openstack::openrc
+
+
+# Enable extra yum repo
+profile::base::yumrepo::repo_hash:
+  rdo-release:
+    ensure: present
+
+profile::base::common::packages:
+  'python-openstackclient': {}
+
+profile::openstack::gnocchi::manage_firewall:       true
+gnocchi::api::sync_db:                              true

--- a/hieradata/dev/roles/metric.yaml
+++ b/hieradata/dev/roles/metric.yaml
@@ -1,0 +1,4 @@
+---
+profile::database::mariadb::backuptopdir:         '/tmp'
+profile::monitoring::sensu::agent::enable_agent: false
+

--- a/hieradata/nodes/bgo/bgo-db-01.yaml
+++ b/hieradata/nodes/bgo/bgo-db-01.yaml
@@ -66,6 +66,7 @@ profile::openstack::database::sql::glance_enabled:    false
 profile::openstack::database::sql::nova_enabled:      false
 profile::openstack::database::sql::neutron_enabled:   false
 profile::openstack::database::sql::cinder_enabled:    false
+profile::openstack::database::sql::gnocchi_enabled:   false
 
 # sensu
 profile::monitoring::sensu::agent::checks:

--- a/hieradata/nodes/bgo/bgo-db-02.yaml
+++ b/hieradata/nodes/bgo/bgo-db-02.yaml
@@ -19,4 +19,5 @@ profile::openstack::database::sql::glance_enabled:    true
 profile::openstack::database::sql::nova_enabled:      true
 profile::openstack::database::sql::neutron_enabled:   true
 profile::openstack::database::sql::cinder_enabled:    true
+profile::openstack::database::sql::gnocchi_enabled:   true
 profile::openstack::database::sql::create_cell0:      true # FIXME in ocata

--- a/hieradata/nodes/osl/osl-db-01.yaml
+++ b/hieradata/nodes/osl/osl-db-01.yaml
@@ -68,6 +68,7 @@ profile::openstack::database::sql::glance_enabled:    false
 profile::openstack::database::sql::nova_enabled:      false
 profile::openstack::database::sql::neutron_enabled:   false
 profile::openstack::database::sql::cinder_enabled:    false
+profile::openstack::database::sql::gnocchi_enabled:   false
 
 # sensu
 profile::monitoring::sensu::agent::checks:

--- a/hieradata/nodes/osl/osl-db-02.yaml
+++ b/hieradata/nodes/osl/osl-db-02.yaml
@@ -19,4 +19,5 @@ profile::openstack::database::sql::glance_enabled:    true
 profile::openstack::database::sql::nova_enabled:      true
 profile::openstack::database::sql::neutron_enabled:   true
 profile::openstack::database::sql::cinder_enabled:    true
+profile::openstack::database::sql::gnocchi_enabled:   true
 profile::openstack::database::sql::create_cell0:      true # FIXME in ocata

--- a/hieradata/nodes/test01/test01-db-01.yaml
+++ b/hieradata/nodes/test01/test01-db-01.yaml
@@ -24,6 +24,7 @@ profile::openstack::database::sql::glance_enabled:    false
 profile::openstack::database::sql::nova_enabled:      false
 profile::openstack::database::sql::neutron_enabled:   false
 profile::openstack::database::sql::cinder_enabled:    false
+profile::openstack::database::sql::gnocchi_enabled:   false
 
 # sensu
 profile::monitoring::sensu::agent::checks:

--- a/hieradata/nodes/test01/test01-db-02.yaml
+++ b/hieradata/nodes/test01/test01-db-02.yaml
@@ -20,4 +20,5 @@ profile::openstack::database::sql::glance_enabled:    true
 profile::openstack::database::sql::nova_enabled:      true
 profile::openstack::database::sql::neutron_enabled:   true
 profile::openstack::database::sql::cinder_enabled:    true
+profile::openstack::database::sql::gnocchi_enabled:   true
 profile::openstack::database::sql::create_cell0:      true # FIXME in ocata

--- a/hieradata/nodes/test02/test02-db-01.yaml
+++ b/hieradata/nodes/test02/test02-db-01.yaml
@@ -24,6 +24,7 @@ profile::openstack::database::sql::glance_enabled:    false
 profile::openstack::database::sql::nova_enabled:      false
 profile::openstack::database::sql::neutron_enabled:   false
 profile::openstack::database::sql::cinder_enabled:    false
+profile::openstack::database::sql::gnocchi_enabled:   false
 
 # sensu
 profile::monitoring::sensu::agent::checks:

--- a/hieradata/nodes/test02/test02-db-02.yaml
+++ b/hieradata/nodes/test02/test02-db-02.yaml
@@ -19,4 +19,5 @@ profile::openstack::database::sql::glance_enabled:    true
 profile::openstack::database::sql::nova_enabled:      true
 profile::openstack::database::sql::neutron_enabled:   true
 profile::openstack::database::sql::cinder_enabled:    true
+profile::openstack::database::sql::gnocchi_enabled:   true
 profile::openstack::database::sql::create_cell0:      true # FIXME in ocata

--- a/hieradata/nodes/vagrant/vagrant-metric-01.yaml
+++ b/hieradata/nodes/vagrant/vagrant-metric-01.yaml
@@ -1,0 +1,12 @@
+---
+network::interfaces_hash:
+  'eth1':
+    onboot:    'yes'
+    mtu:       '1500'
+    ipaddress: "%{hiera('netcfg_mgmt_netpart')}.96"
+    netmask:   "%{hiera('netcfg_mgmt_netmask')}"
+  'eth2':
+    onboot:    'yes'
+    mtu:       '1500'
+    ipaddress: "%{hiera('netcfg_trp_netpart')}.96"
+    netmask:   "%{hiera('netcfg_trp_netmask')}"

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -120,6 +120,7 @@ profile::network::services::dns_records:
     "compute.api.%{hiera('domain_public')}":              "%{hiera('netcfg_public_netpart')}.250"
     "volume.api.%{hiera('domain_public')}":               "%{hiera('netcfg_public_netpart')}.250"
     "status.%{hiera('domain_frontend')}":                 "%{hiera('netcfg_public_netpart')}.250"
+    "metric.api.%{hiera('domain_frontend')}":             "%{hiera('netcfg_public_netpart')}.250"
   AAAA:
     "ns6.%{hiera('domain_public')}":                       "%{hiera('netcfg_public_netpart6')}::16"
   PTR:
@@ -210,7 +211,7 @@ foreman::admin_password:                            'changeme'
 
 # glance.yaml
 glance::db::mysql::password:                        'glance_pass'
-#glance::notify::rabbitmq::rabbit_password:          'glance_quest'
+#glance::notify::rabbitmq::rabbit_password:         'glance_quest'
 
 # horizon.yaml
 horizon::secret_key:                                'horizon_secret'
@@ -246,6 +247,13 @@ graphite_secret_key:                                'graphite_pass'
 sensu_mysql_password:                               'sensu_pass'
 grafana_admin_password:                             'changeme'
 local_rabbit_password:                              'local'
+
+# telemetry/metrics
+gnocchi::api::keystone_password:                    'gnocchi'
+gnocchi::db::mysql::password:                       'gnocchi_pass'
+ceilometer::keystone::authtoken:                    'ceilometer'
+ceilometer::telemetry_secret:                       'ceilometer'
+ceilometer::rabbit_password:                        'ceilometer'
 
 # The root user password: himlardev
 accounts::root_user::password:                      '$1$vagrant$z3l/WWbF3HllJk0tnqO3i/'

--- a/hieradata/vagrant/roles/metric.yaml
+++ b/hieradata/vagrant/roles/metric.yaml
@@ -1,0 +1,6 @@
+---
+gnocchi::keystone::authtoken::insecure:		true
+keystone::resource::authtoken::insecure:	true
+keystone::service::insecure:			true
+keystone::validate_insecure:			true
+keystone::validate_cacert:			false

--- a/nodes.yaml
+++ b/nodes.yaml
@@ -54,6 +54,7 @@ nodesets:
     #- role:       "proxy"
     #- role:       "login"
     #- role:       "controller"
+    #- role:       "metric"
     #- role:       "logger"
     #  cpus:       1
     #  memory:     2048

--- a/profile/manifests/openstack/database/sql.pp
+++ b/profile/manifests/openstack/database/sql.pp
@@ -6,6 +6,7 @@ class profile::openstack::database::sql (
   $heat_enabled     = false,
   $trove_enabled    = false,
   $cinder_enabled   = false,
+  $gnocchi_enabled  = false,
   $create_cell0     = false,
   $database         = 'mariadb',
 ) {
@@ -67,6 +68,10 @@ class profile::openstack::database::sql (
 
   if $trove_enabled {
     include ::trove::db::mysql
+  }
+
+  if $gnocchi_enabled {
+    include ::gnocchi::db::mysql
   }
 
 }

--- a/profile/manifests/openstack/gnocchi.pp
+++ b/profile/manifests/openstack/gnocchi.pp
@@ -1,0 +1,32 @@
+class profile::openstack::gnocchi (
+  $manage_firewall   = false,
+  $firewall_extras   = {},
+)  {
+
+  include ::gnocchi
+  include ::gnocchi::config
+  include ::gnocchi::api
+  include ::gnocchi::keystone::auth
+
+  # wrappe disse i "manage_"-variabler
+  include ::gnocchi::client
+  include ::gnocchi::metricd
+  include ::gnocchi::storage
+  include ::gnocchi::storage::file
+  include ::gnocchi::statsd
+
+  if $manage_firewall {
+    profile::firewall::rule { '123 metric accept tcp':
+      port        => 8041,
+      proto       => 'tcp',
+      destination => $::ipaddress_trp1,
+      extras      => $firewall_extras,
+    }
+    profile::firewall::rule { '124 metricd accept iudp':
+      port        => 8125,
+      proto       => 'udp',
+      destination => $::ipaddress_trp1,
+      extras      => $firewall_extras,
+    }
+  }
+}

--- a/profile/manifests/openstack/identity.pp
+++ b/profile/manifests/openstack/identity.pp
@@ -7,6 +7,7 @@ class profile::openstack::identity (
   $nova_enabled             = false,
   $swift_enabled            = false,
   $trove_enabled            = false,
+  $gnocchi_enabled          = false,
   $roles_extra              = [],
   $manage_firewall          = true,
   $firewall_extras          = {},
@@ -72,6 +73,10 @@ class profile::openstack::identity (
 
   if $trove_enabled {
     include ::trove::keystone::auth
+  }
+
+  if $gnocchi_enabled {
+    include ::gnocchi::keystone::auth
   }
 
   unless empty($roles_extra) {


### PR DESCRIPTION
Dessuten må det til en patch på metric-noden:

```
--- /usr/bin/gnocchi-api        2017-09-19 20:27:43.000000000 +0200
+++ /tmp/gnocchi-api    2017-11-16 09:01:41.692212476 +0100
@@ -16,7 +16,7 @@
         description=build_wsgi_app.__doc__,
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         usage='%(prog)s [-h] [--port PORT] -- [passed options]')
-    parser.add_argument('--port', '-p', type=int, default=8000,
+    parser.add_argument('--port', '-p', type=int, default=8041,
                         help='TCP port to listen on')
     parser.add_argument('args',
                         nargs=argparse.REMAINDER,
```


