### PR TITLE
Add IPv6 and NAT (for private IPv4) to test02

### DIFF
--- a/hieradata/nodes/test02/test02-controller-00.yaml
+++ b/hieradata/nodes/test02/test02-controller-00.yaml
@@ -18,6 +18,9 @@ network::interfaces_hash:
     ipaddress:    '129.240.121.146'
     netmask:      '255.255.255.0'
     gateway:      '129.240.121.1'
+    ipv6init:     'yes'
+    ipv6addr:     '2001:700:100:121::146/64'
+    ipv6_defaultgw: '2001:700:100:121::1'
     defroute:     'yes'
     dns1:         "%{hiera('mgmt__address__proxy')}"
     domain:       'test.iaas.uio.no'
@@ -44,13 +47,17 @@ network::interfaces_hash:
     type:         'Bridge'
     ipaddress:    '192.168.122.1'
     netmask:      '255.255.255.0'
+    ipv6init:     'yes'
+    ipv6addr:     'fd30::1/64'
     defroute:     'no'
     bridge_stp:   'off'
 
 # NAT
-profile::network::nat::enable_snat: true
-profile::network::nat::source:      "%{hiera('netcfg_public_netpart')}.0/%{hiera('netcfg_public_netmask')}"
-profile::network::nat::outiface:    'em4'
+profile::network::nat::enable_snat:  true
+profile::network::nat::source:       "%{hiera('netcfg_public_netpart')}.0/%{hiera('netcfg_public_netmask')}"
+profile::network::nat::enable_snat6: true
+profile::network::nat::source6:      "%{hiera('netcfg_public_netpart6')}::/%{hiera('netcfg_public_netmask6')}"
+profile::network::nat::outiface:     'em4'
 
 # On this host sdd is the OS disk
 lvm::volume_groups:
@@ -64,10 +71,23 @@ lvm::volume_groups:
 
 # route to public net via leaf-01
 # (test02 is a special case since leaf runs inside this node)
-network::mroutes_hash:
+profile::base::network::mroute:
   br2:
     routes:
       10.100.200.0/24:  192.168.122.2
+
+# Can not use this together with above without (simple) patch to himlar-network::route
+# (not patched due to cowardice and no time for extensive testing)
+# Additionally code below can not be used simultaneously with an IPv4 route as
+# that will all be put into a route46-<if> file instead of route6- and route-<if> ditto
+#
+#profile::base::network::routes:
+#  'br2':
+#    'ipaddress': [ 'fd34::', ]
+#    'netmask':   [ '0', ]
+#    'gateway':   [ 'fd30::2', ]
+#    'table':     [ 'main', ]
+#    'family':    [ '6', ]
 
 named_interfaces::config:
   mgmt:

--- a/hieradata/nodes/test02/test02-leaf-01.yaml
+++ b/hieradata/nodes/test02/test02-leaf-01.yaml
@@ -36,6 +36,7 @@ profile::base::network::cumulus_interfaces:
     'ipv6': [ 'fd32::1/64', ]
   'bridge.101':
     'ipv4': [ '192.168.122.2/24', ]
+    'ipv6': [ 'fd30::2/64', ]
 
 # Add default route for management VRF
 profile::base::network::routes:
@@ -54,9 +55,12 @@ quagga::quagga::zebra_interfaces:
   'swp2':
     - 'link-detect'
 
+quagga::quagga::zebra_ip6_routes:
+  - '::/0 fd30::1'
 quagga::quagga::zebra_ip_routes:
   - '0.0.0.0/0 192.168.122.1'
   - '10.0.0.0/8 Null0'
+  - '10.100.200.248/32 172.30.32.26'
   - '10.100.200.250/32 172.30.32.86'
   - '10.100.200.251/32 172.30.32.61'
   - '10.100.200.252/32 172.30.32.56'
@@ -82,7 +86,6 @@ quagga::quagga::bgp_options:
 
 quagga::quagga::bgp_networks:
   - '0.0.0.0/0'
-  - '10.100.200.0/24'
   - '172.30.32.0/24'
 quagga::quagga::bgp_networks6:
   - '::/0'
@@ -114,11 +117,11 @@ quagga::quagga::bgp_neighbor_groups:
 quagga::quagga::bgp_accesslist:
   '10':
     - 'permit 10.100.200.0 0.0.0.255'
-    - 'permit 10.18.0.0 0.0.15.255'
+    - 'permit 10.0.244.0 0.0.0.255'
     - 'permit 172.30.32.0 0.0.0.255'
   '20':
     - 'deny 10.100.200.0 0.0.0.255'
-    - 'deny 10.18.0.0 0.0.15.255'
+    - 'deny 10.0.244.0 0.0.0.255'
     - 'deny 172.30.32.0 0.0.0.255'
     - 'permit any'
 

--- a/hieradata/nodes/test02/test02-nat-linux-01.yaml
+++ b/hieradata/nodes/test02/test02-nat-linux-01.yaml
@@ -1,0 +1,21 @@
+---
+network::interfaces_hash:
+  'eth0':
+    ipaddress: "%{hiera('netcfg_mgmt_netpart')}.26"
+    netmask:   "%{hiera('netcfg_mgmt_netmask')}"
+    mtu:       '1500'
+    peerdns:   'yes'
+    dns1:      "%{hiera('netcfg_dns_server1')}"
+    dns2:      "%{hiera('netcfg_dns_server2')}"
+    domain:    "%{hiera('netcfg_dns_search')}"
+    defroute:  'no'
+  'eth1':
+    ipaddress: "%{hiera('netcfg_trp_netpart')}.26"
+    netmask:   "%{hiera('netcfg_trp_netmask')}"
+    gateway:   "%{hiera('netcfg_trp_gateway')}"
+    srcaddr:   "%{hiera('netcfg_pub_natgw')}"
+    defroute:  'yes'
+  'dummy0':
+    ipaddress: "%{hiera('netcfg_pub_natgw')}"
+    netmask:   '255.255.255.255'
+    defroute:  'no'

--- a/hieradata/nodes/test02/test02-proxy-01.yaml
+++ b/hieradata/nodes/test02/test02-proxy-01.yaml
@@ -14,8 +14,22 @@ network::interfaces_hash:
     netmask:   "%{hiera('netcfg_trp_netmask')}"
     gateway:   "%{hiera('netcfg_trp_gateway')}"
     srcaddr:   "%{hiera('netcfg_public_netpart')}.253"
+    ipv6init:  'yes'
+    ipv6addr:  "%{hiera('netcfg_trp_netpart6')}::12/%{hiera('netcfg_trp_netmask6')}"
     defroute:  'yes'
   'dummy0':
     ipaddress: "%{hiera('netcfg_public_netpart')}.253"
     netmask:   '255.255.255.255'
+    ipv6init:  'yes'
+    ipv6addr:  "%{hiera('netcfg_public_netpart6')}::12"
     defroute:  'no'
+
+profile::base::network::routes:
+  'eth1':
+    'ipaddress': [ '::', ]
+    'netmask':   [ '0', ]
+    'gateway':   [ 'fd32::1', ]
+    'source':    [ "%{hiera('netcfg_public_netpart6')}::12", ]
+    'table':     [ 'main', ]
+    'family':    [ '6', ]
+

--- a/hieradata/test02/common.yaml
+++ b/hieradata/test02/common.yaml
@@ -30,6 +30,8 @@ netcfg_dns_server2:     '129.240.2.40'
 netcfg_dns_search:      "%{hiera('domain_mgmt')} %{hiera('domain_trp')} %{hiera('domain_mgmt')}"
 netcfg_public_netpart:  '10.100.200'
 netcfg_public_netmask:  '255.255.255.0'
+netcfg_public_netpart6: 'fd34'
+netcfg_public_netmask6: '64'
 
 netcfg_priv_gateway:    '172.30.32.26'
 netcfg_priv_network:    '10.0.244.0/24'
@@ -174,23 +176,83 @@ profile::network::services::dns_options:
 #--------------------------------------------------------------
 
 profile::openstack::resource::networks:
-  public:
-    name: 'public'
+  dualStack:
+    name: 'dualStack'
     admin_state_up: true
     shared: true
     tenant_name: 'openstack'
     provider_network_type: 'local'
+  IPv6:
+    name: 'IPv6'
+    admin_state_up: true
+    shared: true
+    tenant_name: 'openstack'
+    provider_network_type: 'local'
+  imagebuilder:
+    name: 'imagebuilder'
+    admin_state_up: true
+    shared: false
+    tenant_name: 'imagebuilder'
+    provider_network_type: 'local'
 
 profile::openstack::resource::subnets:
-  public:
-    name: 'public'
+  public1_IPv4:
+    name: 'public1_IPv4'
     cidr: '10.100.200.0/24'
     ip_version: '4'
     allocation_pools:
-      - 'start=10.100.200.2,end=10.100.200.245'
+      - 'start=10.100.200.2,end=10.100.200.243'
     gateway_ip: '10.100.200.1'
     dns_nameservers:
       - '129.240.2.40'
       - '129.240.2.3'
-    network_name: 'public'
+    network_name: 'dualStack'
     tenant_name: 'openstack'
+  private1_IPv4:
+    name: 'private1_IPv4'
+    cidr: '10.0.244.0/24'
+    ip_version: '4'
+    allocation_pools:
+      - 'start=10.0.244.10,end=10.0.244.250'
+    gateway_ip: '10.0.244.1'
+    dns_nameservers:
+      - '129.240.2.40'
+      - '129.240.2.3'
+    network_name: 'IPv6'
+    tenant_name: 'openstack'
+  public1_ipv6:
+    name: 'public1_IPv6'
+    cidr: 'fd34::/64'
+    ip_version: '6'
+    allocation_pools:
+      - 'start=fd34::1000,end=fd34::3fff'
+    gateway_ip: 'fd34::1'
+    dns_nameservers:
+      - '2001:700:100:2::3'
+      - '2001:700:100:425::40'
+    network_name: 'IPv6'
+    tenant_name: 'openstack'
+  public2_ipv6:
+    name: 'public2_IPv6'
+    cidr: 'fd34::/64'
+    ip_version: '6'
+    allocation_pools:
+      - 'start=fd34::f:1000,end=fd34::f:3fff'
+    gateway_ip: 'fd34::1'
+    dns_nameservers:
+      - '2001:700:100:2::3'
+      - '2001:700:100:425::40'
+    network_name: 'dualStack'
+    tenant_name: 'openstack'
+  public3_IPv4:
+    name: 'public3_IPv4'
+    cidr: '10.100.200.0/24'
+    ip_version: '4'
+    allocation_pools:
+      - 'start=10.100.200.244,end=10.100.200.245'
+    gateway_ip: '10.100.200.1'
+    dns_nameservers:
+      - '129.240.2.40'
+      - '129.240.2.3'
+    network_name: 'imagebuilder'
+    tenant_name: 'imagebuilder'

--- a/hieradata/test02/roles/compute.yaml
+++ b/hieradata/test02/roles/compute.yaml
@@ -26,7 +26,7 @@ puppet::cron_cmd: "if [ -e /root/proxy.sh ] ; then source /root/proxy.sh ; fi ; 
 
 # Add custom routing table for private network to NAT
 profile::base::network::routes:
-  'bond1':
+  'em1':
     'ipaddress': [ '0.0.0.0', ]
     'netmask':   [ '0.0.0.0', ]
     'gateway':   [ "%{hiera('netcfg_priv_gateway')}", ]
@@ -35,7 +35,7 @@ profile::base::network::routing_tables:
   'private':
     'table_id':  '240'
 profile::base::network::rules:
-  'bond1':
+  'em1':
     iprule: [ "from %{hiera('netcfg_priv_network')} lookup private", ]
 
 ################ TEMP DATA - SHOULD BE FIXED IN COMMON #########################


### PR DESCRIPTION
Statisk IPv6-rute på br2 på test02-controller-00 settes foreløpig manuelt da dette ikke kan fikses via puppet uten patching i ekstern(e) modul(er):

[test02-controller-00 ~]$ cat /etc/sysconfig/network-scripts/route6-br2 
fd34::/64 via fd30::2 dev br2 table main
