### PR TITLE
Specify cpu model for instance migration

### DIFF
--- a/hieradata/bgo/modules/nova.yaml
+++ b/hieradata/bgo/modules/nova.yaml
@@ -11,3 +11,7 @@ nova::compute::rbd::libvirt_images_rbd_pool:      'vms'
 # Optimize cache mode for ceph
 nova::compute::libvirt::libvirt_disk_cachemodes:
   - '"network=writeback"'
+
+# set lowest common denominator for live migration compat
+nova::compute::libvirt::libvirt_cpu_mode:  'custom'
+nova::compute::libvirt::libvirt_cpu_model: 'Haswell-noTSX'

--- a/hieradata/osl/modules/nova.yaml
+++ b/hieradata/osl/modules/nova.yaml
@@ -1,3 +1,4 @@
+---
 # Use ceph cluster for instance disk
 nova::compute::rbd::ephemeral_storage:            true
 nova::compute::rbd::libvirt_images_rbd_pool:      'vms'
@@ -6,3 +7,7 @@ nova::compute::rbd::libvirt_images_rbd_pool:      'vms'
 # Optimize cache mode for ceph
 nova::compute::libvirt::libvirt_disk_cachemodes:
   - '"network=writeback"'
+
+# set lowest common denominator for live migration compat
+nova::compute::libvirt::libvirt_cpu_mode:  'custom'
+nova::compute::libvirt::libvirt_cpu_model: 'Haswell-noTSX'

--- a/hieradata/test01/modules/nova.yaml
+++ b/hieradata/test01/modules/nova.yaml
@@ -7,3 +7,7 @@ nova::compute::rbd::libvirt_images_rbd_pool:      'vms'
 # Optimize cache mode for ceph
 nova::compute::libvirt::libvirt_disk_cachemodes:
   - '"network=writeback"'
+
+# set lowest common denominator for live migration compat
+nova::compute::libvirt::libvirt_cpu_mode:  'custom'
+nova::compute::libvirt::libvirt_cpu_model: 'Westmere'


### PR DESCRIPTION
We must specify cpu model for the instances in order for live migration to work. For the production sites the haswell generation is the lowest common denominator. 