### PR TITLE
add custom volume type, remove deprecated from cinder

### DIFF
--- a/hieradata/common/roles/volume.yaml
+++ b/hieradata/common/roles/volume.yaml
@@ -22,13 +22,13 @@ profile::openstack::openrc::project_name: 'services'
 
 profile::openstack::volume::type:
   rbd:
-    set_key: 'volume_backend_name'
-    set_value: 'rbd-volumes'
-    os_tenant_name: 'services'
-    os_password: "%{hiera('cinder_api_password')}"
-    os_username: 'cinder'
-    os_region_name: "%{location}"
-    os_auth_url: "%{hiera('endpoint__identity__internal')}/v2.0"
+    visibility: "public"
+    properties:
+      - 'volume_backend_name=rbd-volumes'
+#  rbd-ssd:
+#    visibility: "private"
+#    properties:
+#      - 'volume_backend_name=rbd-ssd'
 
 profile::openstack::volume::manage_quotas: true
 

--- a/profile/lib/puppet/provider/cinder.rb
+++ b/profile/lib/puppet/provider/cinder.rb
@@ -1,0 +1,90 @@
+require 'puppet/util/inifile'
+require 'puppet/provider/openstack'
+require 'puppet/provider/openstack/auth'
+require 'puppet/provider/openstack/credentials'
+
+class Puppet::Provider::Cinder < Puppet::Provider::Openstack
+
+  extend Puppet::Provider::Openstack::Auth
+
+  def self.conf_filename
+    '/etc/cinder/cinder.conf'
+  end
+
+  def self.cinder_conf
+    return @cinder_conf if @cinder_conf
+    @cinder_conf = Puppet::Util::IniConfig::File.new
+    @cinder_conf.read(conf_filename)
+    @cinder_conf
+  end
+
+  def self.request(service, action, properties=nil)
+    begin
+      super
+    rescue Puppet::Error::OpenstackAuthInputError, Puppet::Error::OpenstackUnauthorizedError => error
+      cinder_request(service, action, error, properties)
+    end
+  end
+
+  def self.cinder_request(service, action, error, properties=nil)
+    properties ||= []
+    @credentials.username = cinder_credentials['username']
+    @credentials.password = cinder_credentials['password']
+    @credentials.project_name = cinder_credentials['project_name']
+    @credentials.auth_url = auth_endpoint
+    if @credentials.version == '3'
+      @credentials.user_domain_name = cinder_credentials['user_domain_name']
+      @credentials.project_domain_name = cinder_credentials['project_domain_name']
+    end
+    raise error unless @credentials.set?
+    Puppet::Provider::Openstack.request(service, action, properties, @credentials)
+  end
+
+  def self.cinder_credentials
+    @cinder_credentials ||= get_cinder_credentials
+  end
+
+  def cinder_credentials
+    self.class.cinder_credentials
+  end
+
+  def self.get_cinder_credentials
+    auth_keys = ['auth_uri', 'project_name', 'username',
+                 'password']
+    conf = cinder_conf
+    if conf and conf['keystone_authtoken'] and
+        auth_keys.all?{|k| !conf['keystone_authtoken'][k].nil?}
+      creds = Hash[ auth_keys.map \
+                   { |k| [k, conf['keystone_authtoken'][k].strip] } ]
+      if conf['project_domain_name']
+        creds['project_domain_name'] = conf['project_domain_name']
+      else
+        creds['project_domain_name'] = 'Default'
+      end
+      if conf['user_domain_name']
+        creds['user_domain_name'] = conf['user_domain_name']
+      else
+        creds['user_domain_name'] = 'Default'
+      end
+      return creds
+    else
+      raise(Puppet::Error, "File: #{conf_filename} does not contain all " +
+            "required sections. Cinder types will not work if cinder is not " +
+            "correctly configured.")
+    end
+  end
+
+  def self.get_auth_endpoint
+    q = cinder_credentials
+    "#{q['auth_uri']}"
+  end
+
+  def self.auth_endpoint
+    @auth_endpoint ||= get_auth_endpoint
+  end
+
+  def self.reset
+    @cinder_conf = nil
+    @cinder_credentials = nil
+  end
+end

--- a/profile/lib/puppet/provider/cinder_type_norcams/openstack.rb
+++ b/profile/lib/puppet/provider/cinder_type_norcams/openstack.rb
@@ -1,0 +1,73 @@
+require File.join(File.dirname(__FILE__), '..','..','..', 'puppet/provider/cinder')
+
+Puppet::Type.type(:cinder_type_norcams).provide(
+  :openstack,
+  :parent => Puppet::Provider::Cinder
+) do
+
+  desc 'Provider for cinder types.'
+
+  @credentials = Puppet::Provider::Openstack::CredentialsV3.new
+
+  mk_resource_methods
+
+  def create
+    properties = []
+    resource[:properties].each do |item|
+      properties << '--property' << item
+    end
+    if @resource[:visibility]
+      properties << "--#{@resource[:visibility]}"
+    end
+    properties << name
+    self.class.request('volume type', 'create', properties)
+    @property_hash[:ensure] = :present
+    @property_hash[:properties] = resource[:properties]
+    @property_hash[:name] = name
+  end
+
+  def destroy
+    self.class.request('volume type', 'delete', name)
+    @property_hash.clear
+  end
+
+  def exists?
+    @property_hash[:ensure] == :present
+  end
+
+  def properties=(value)
+    properties = []
+    (value - @property_hash[:properties]).each do |item|
+      properties << '--property' << item
+    end
+    unless properties.empty?
+      self.class.request('volume type', 'set', [properties, name])
+      @property_hash[:properties] = value
+    end
+  end
+
+  def self.instances
+    list = request('volume type', 'list', '--long')
+    list.collect do |type|
+      new({
+        :name       => type[:name],
+        :ensure     => :present,
+        :id         => type[:id],
+        :properties => string2array(type[:properties])
+      })
+    end
+  end
+
+  def self.prefetch(resources)
+    types = instances
+    resources.keys.each do |name|
+      if provider = types.find{ |type| type.name == name }
+        resources[name].provider = provider
+      end
+    end
+  end
+
+  def self.string2array(input)
+    return input.delete("'").split(/,\s/)
+  end
+end

--- a/profile/lib/puppet/type/cinder_type_norcams.rb
+++ b/profile/lib/puppet/type/cinder_type_norcams.rb
@@ -1,0 +1,31 @@
+Puppet::Type.newtype(:cinder_type_norcams) do
+
+  desc 'Type for managing cinder types with extra params.'
+
+  ensurable
+
+  newparam(:name, :namevar => true) do
+    newvalues(/\S+/)
+  end
+
+  newparam(:visibility) do
+    desc 'Whether the volume type is public or private. Defaults to public.'
+    newvalues(/(p|P)ublic/, /(p|P)rivate/, public, private )
+  end
+
+  newproperty(:properties, :array_matching => :all) do
+    desc 'The properties of the cinder type. Should be an array, all items should match pattern <key=value1[,value2 ...]>'
+    defaultto []
+    def insync?(is)
+      return false unless is.is_a? Array
+      is.sort == should.sort
+    end
+    validate do |value|
+      raise ArgumentError, "Properties doesn't match" unless value.match(/^\s*[^=\s]+=[^=\s]+$/)
+    end
+  end
+
+  autorequire(:anchor) do
+    ['cinder::service::end']
+  end
+end

--- a/profile/manifests/openstack/volume/api.pp
+++ b/profile/manifests/openstack/volume/api.pp
@@ -23,7 +23,7 @@ class profile::openstack::volume::api(
     include cinder::backends
 
     create_resources(cinder::backend::rbd, lookup('profile::openstack::volume::backend::rbd', Hash, 'first', {}))
-    create_resources(cinder::type, lookup('profile::openstack::volume::type', Hash, 'first', {}))
+    create_resources(cinder_type_norcams, lookup('profile::openstack::volume::type', Hash, 'first', {}))
   } else {
     include ::cinder::setup_test_volume
   }


### PR DESCRIPTION
a) add a new custom cinder volume type which enables us to specify if the type is public or private

b) use the new custom type instead of deprecated type class in cinder puppet module

These changes should not make any changes on existing systems.