### PR TITLE
Added lockout after failed login for api users in keystone

### DIFF
--- a/hieradata/common/roles/identity.yaml
+++ b/hieradata/common/roles/identity.yaml
@@ -37,6 +37,10 @@ profile::openstack::identity::keystone_config:
     value:  "http://%{hiera('mgmt__address__monitor')}:8080"
   'DEFAULT/notification_opt_out':
     value:  'identity.authenticate.success'
+  'security_compliance/lockout_duration':
+    value:  '3600'
+  'security_compliance/lockout_failure_attempts':
+    value:  '10'
 
 # Key rotation and syncronization
 profile::openstack::identity::cron_master:

--- a/hieradata/vagrant/roles/identity.yaml
+++ b/hieradata/vagrant/roles/identity.yaml
@@ -15,7 +15,12 @@ profile::openstack::identity::keystone_config:
     value:  "http://%{hiera('mgmt__address__monitor')}:8080"
   'DEFAULT/notification_opt_out':
     value:  'identity.authenticate.success'
-#  'DEFAULT/insecure_debug':
-#    value:  'true'
+  # Use this to test lockout in vagrant
+  # 'security_compliance/lockout_duration':
+  #   value:  '60'
+  # 'security_compliance/lockout_failure_attempts':
+  #   value:  '3'
+  # 'DEFAULT/insecure_debug':
+  #   value:  'true'
 
 profile::base::selinux::manage_selinux:       true


### PR DESCRIPTION
Will lock account for 1 hour after 10 failed auth attempts for local api user. Tested in vagrant.