### PR TITLE
make libvirt use /dev/hwgen instead of /dev/random in bgo and osl

### DIFF
--- a/hieradata/bgo/roles/compute.yaml
+++ b/hieradata/bgo/roles/compute.yaml
@@ -18,3 +18,8 @@ profile::base::network::rules:
   'team1':
     iprule: [ "from %{hiera('netcfg_priv_network')} lookup private", ]
 profile::base::network::manage_neutron_blackhole: true
+
+# Make libvirt use HW RNG instead of /dev/random
+nova::config::nova_config:
+  libvirt/rng_dev_path:
+    value: '/dev/hwrng'

--- a/hieradata/osl/roles/compute.yaml
+++ b/hieradata/osl/roles/compute.yaml
@@ -36,3 +36,8 @@ profile::base::lvm::logical_volume:
     volume_group: 'vg_ext'
     fs_type:      "xfs"
     mountpath:    "/var/lib/nova/instances"
+
+# Make libvirt use HW RNG instead of /dev/random
+nova::config::nova_config:
+  libvirt/rng_dev_path:
+    value: '/dev/hwrng'


### PR DESCRIPTION
Dette kan testes manuelt ved å legge inn 

`rng_dev_path=/dev/hwrng`

i nova.conf og restarte tjenesten på en aktuell compute-node.