### PR TITLE
Identity mariadb

### DIFF
--- a/hieradata/common/modules/profile.yaml
+++ b/hieradata/common/modules/profile.yaml
@@ -145,7 +145,7 @@ profile::base::yumrepo::repo_hash:
     enabled:        1
     gpgcheck:       1
     gpgkey:         'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Cloud'
-    exclude:        'mariadb*'
+    #exclude:        'mariadb*' FIXME: this should be added after adding mariadb repo to all roles connecting to db
   calico:
     ensure:         absent
     descr:          'Calico Repository'

--- a/hieradata/common/modules/profile.yaml
+++ b/hieradata/common/modules/profile.yaml
@@ -145,6 +145,7 @@ profile::base::yumrepo::repo_hash:
     enabled:        1
     gpgcheck:       1
     gpgkey:         'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Cloud'
+    exclude:        'mariadb*'
   calico:
     ensure:         absent
     descr:          'Calico Repository'

--- a/hieradata/common/roles/identity.yaml
+++ b/hieradata/common/roles/identity.yaml
@@ -103,9 +103,10 @@ profile::openstack::resource::users::user_roles:
 # Enable extra yum repo
 profile::base::yumrepo::repo_hash:
   rdo-release:
-    ensure: present
+    ensure:   present
   mariadb:
-    ensure: present
+    ensure:   present
+    exclude:  'mariadb*'
 
 profile::base::selinux::boolean:
   'httpd_can_network_connect':

--- a/hieradata/common/roles/identity.yaml
+++ b/hieradata/common/roles/identity.yaml
@@ -104,9 +104,9 @@ profile::openstack::resource::users::user_roles:
 profile::base::yumrepo::repo_hash:
   rdo-release:
     ensure:   present
+    exclude:  'mariadb*'
   mariadb:
     ensure:   present
-    exclude:  'mariadb*'
 
 profile::base::selinux::boolean:
   'httpd_can_network_connect':

--- a/hieradata/common/roles/identity.yaml
+++ b/hieradata/common/roles/identity.yaml
@@ -14,6 +14,7 @@ profile::base::common::packages:
   'bash-completion-extras': {}
   'jq': {}
   'sharutils': {}
+  'MariaDB-client': {}
 
 profile::base::selinux::manage_selinux:                   false
 profile::openstack::identity::disable_admin_token_auth:   true
@@ -102,6 +103,8 @@ profile::openstack::resource::users::user_roles:
 # Enable extra yum repo
 profile::base::yumrepo::repo_hash:
   rdo-release:
+    ensure: present
+  mariadb:
     ensure: present
 
 profile::base::selinux::boolean:

--- a/profile/manifests/openstack/identity.pp
+++ b/profile/manifests/openstack/identity.pp
@@ -60,9 +60,7 @@ class profile::openstack::identity (
       group   => 'root',
       content => template("${module_name}/openstack/keystone/token_dist.erb")
     }
-    package { 'mariadb':
-      ensure => 'installed',
-    }
+
   }
 
   if $disable_admin_token_auth {


### PR DESCRIPTION
Use mariadb repo to install mariadb client on identity.
Tested on vagrant.