### PR TITLE
Api restriction

### DIFF
--- a/hieradata/bgo/common.yaml
+++ b/hieradata/bgo/common.yaml
@@ -52,6 +52,8 @@ public6__address__ns:          '2001:700:2:83ff::251'
 public__address__resolver_01:  '158.39.77.252'
 public6__address__resolver_01: '2001:700:2:83ff::252'
 
+public__ip__proxy:              '158.39.77.253'
+
 #
 # DNS (merge of common and this)
 #

--- a/hieradata/common/common.yaml
+++ b/hieradata/common/common.yaml
@@ -56,6 +56,7 @@ allow_from_testing_network: # this do not merge!
   - '129.240.6.14/32'    # mikael
   - '129.177.10.189/32'  # tor
   - '129.177.10.212/32'  # raymond
+  - '158.39.74.6/32'     # raymond mgmt-admin-instance
   - '129.177.10.111/32'  # anders
   - '129.240.202.64/32'  # tannaz
   - '129.177.6.133/32'   # bgo-login

--- a/hieradata/common/common.yaml
+++ b/hieradata/common/common.yaml
@@ -51,6 +51,17 @@ valid_location_environments:
 
 profile::base::firewall::purge_firewall: true
 
+allow_from_testing_network: # this do not merge!
+  - '129.240.202.12/32'  # trond
+  - '129.240.6.14/32'    # mikael
+  - '129.177.10.189/32'  # tor
+  - '129.177.10.212/32'  # raymond
+  - '129.177.10.111/32'  # anders
+  - '129.240.202.64/32'  # tannaz
+  - '129.177.6.133/32'   # bgo-login
+  - '129.240.224.100/32' # osl-login
+  - "%{hiera('public__ip__proxy')}/32"
+
 #
 # Use this for firewall rules to allow only from some networks
 #
@@ -127,6 +138,13 @@ public__address__report:          "report.%{hiera('domain_frontend')}"
 
 # DNS servers
 public__name__ns:                 "ns.%{hiera('domain_public')}"
+
+#
+# Public IPs
+#
+
+# In vagrant this is the host, otherwise it should be the NAT server used
+public__ip__proxy:                "%{hiera('netcfg_public_netpart')}.253"
 
 #
 # Services (internal non openstack services)

--- a/hieradata/common/roles/api.yaml
+++ b/hieradata/common/roles/api.yaml
@@ -4,6 +4,9 @@ include:
     - profile::highavailability::loadbalancing::haproxy
     - profile::logging::rsyslog::client
 
+# FIXME Temp hack to block access to test01, all others will allow all connections
+block_api_connection:   'connection accept'
+
 profile::base::common::packages:
   'bash-completion': {}
   'bash-completion-extras': {}
@@ -52,6 +55,11 @@ haproxy::defaults_options:
     - 'client 1m'
     - 'server 3m'
     - 'queue 1m'
+
+# Access lists
+profile::highavailability::loadbalancing::haproxy::access_list:
+  testing_network:
+    ips:  "%{alias('allow_from_testing_network')}"
 
 # Domain mapping to backend
 profile::highavailability::loadbalancing::haproxy::haproxy_mapfile:
@@ -109,6 +117,9 @@ profile::highavailability::loadbalancing::haproxy::haproxy_frontends:
         - 'set-header X-Forwarded-Port %[dst_port]'
       - acl:            'is_request hdr_beg(host) -i request'
       - redirect:       'scheme https if !{ ssl_fc } !is_request' # redirect all to https (only port 80)
+      - tcp-request:    "%{hiera('block_api_connection')}" # should only block in test01
+      # Uncomment this to restrict access to testing network only
+      #- use_backend:    'bk_maintenance unless { src -f /etc/haproxy/testing_network.list }'
       - use_backend:    '%[req.hdr(host),lower,map(/etc/haproxy/public_domains.map)]'
   frontend_internal:
     bind:
@@ -187,6 +198,10 @@ profile::highavailability::loadbalancing::haproxy::haproxy_backends:
   bk_request:
     options:
       redirect:         'location https://skjema.uio.no/iaas-project'
+  bk_maintenance:
+    options:
+      - option:       'httplog'
+      - errorfile:    '503 /etc/haproxy/error.maintenance.http'
 
 # Servers for backends. This will be merged and can should be overridden i location
 profile::highavailability::loadbalancing::haproxy::haproxy_balancermembers:
@@ -314,12 +329,16 @@ profile::base::selinux::ports:
 
 # Errorpage for api, not used for status!
 profile::highavailability::loadbalancing::haproxy::haproxy_errorpage:
+  'maintenance':
+    code:     503
+    header:   'Scheduled maintenance'
+    content:  'Unavailable due to scheduled maintenance. Be right back.'
+    url:      'https://twitter.com/uhiaas'
   'api':
     code:     503
     header:   'Be Right Back'
     content:  'The API are down at the moment'
     url:      "https://status.%{hiera('domain_frontend')}"
-
   'console':
     code:     503
     header:   'Be Right Back'

--- a/hieradata/osl/common.yaml
+++ b/hieradata/osl/common.yaml
@@ -58,6 +58,8 @@ public6__address__ns:          '2001:700:2:82ff::251'
 public__address__resolver_01:  '158.37.63.252'
 public6__address__resolver_01: '2001:700:2:82ff::252'
 
+public__ip__proxy:             '158.37.63.253'
+
 #
 # DNS (merge of common and this)
 #

--- a/hieradata/test01/common.yaml
+++ b/hieradata/test01/common.yaml
@@ -48,6 +48,8 @@ public6__address__ns:          '2001:700:200:917::3f17'
 public__address__resolver_01:  '129.177.31.118'
 public6__address__resolver_01: '2001:700:200:917::3f18'
 
+public__ip__proxy:              '129.177.31.123'
+
 #
 # DNS (merge of common and this)
 #

--- a/hieradata/test01/roles/api.yaml
+++ b/hieradata/test01/roles/api.yaml
@@ -5,6 +5,9 @@ status_ssl_pem:   "status.%{hiera('domain_public')}.pem"
 console_ssl_pem:  "status.%{hiera('domain_public')}.pem" #FIXME (cert)
 access_ssl_pem:   "status.%{hiera('domain_public')}.pem" #FIXME (cert)
 
+# Filter api access to testing network
+block_api_connection:   'connection reject unless { src -f /etc/haproxy/testing_network.list }'
+
 profile::highavailability::loadbalancing::haproxy::allow_from_network:
   - '129.177.6.133/32'  # bgo-login
   - '129.177.31.96/27'  # test01

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -53,6 +53,9 @@ public6__address__ns:          "%{hiera('netcfg_public_netpart6')}::251"
 public__address__resolver_01:  "%{hiera('netcfg_public_netpart')}.252"
 public6__address__resolver_01: "%{hiera('netcfg_public_netpart6')}::252"
 
+# In vagrant this is the host, otherwise it should be the NAT server used
+public__ip__proxy:             "%{hiera('netcfg_public_netpart')}.1"
+
 #
 # Default interfaces
 #


### PR DESCRIPTION
Will do the following:

* create array for testing network in common
* restrict access to api/haproxy in test01 to only testing network
* add optional access list to use for maintenance based on testing network
 