### PR TITLE
Updated puppet module for oslo and openstack lib to pike

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -164,8 +164,8 @@ mod 'swift', :ref => 'norcams/ocata',               :git => github + 'norcams/pu
 mod 'ceilometer', :ref => '10.4.0',                 :git => github + 'openstack/puppet-ceilometer'
 mod 'designate', :ref => 'stable/pike',             :git => github + 'openstack/puppet-designate'
 
-mod 'oslo', :ref => '10.4.0',                       :git => github + 'openstack/puppet-oslo'
-mod 'openstacklib', :ref => '10.5.0',               :git => github + 'openstack/puppet-openstacklib'
+mod 'oslo', :ref => '11.4.0',                       :git => github + 'openstack/puppet-oslo'
+mod 'openstacklib', :ref => '11.5.0',               :git => github + 'openstack/puppet-openstacklib'
 mod 'openstack_extras', :ref => '10.4.0',           :git => github + 'openstack/puppet-openstack_extras'
 mod 'sysctl', :ref => 'v0.0.11',                    :git => github + 'duritong/puppet-sysctl'
 mod 'memcached', :ref => 'v3.0.2',                  :git => github + 'saz/puppet-memcached'


### PR DESCRIPTION
Burde være helt uproblematisk. Disse ble også oppgradert til ocata 4-5 mnd før resten.