### PR TITLE
Ceph mimic

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -180,7 +180,7 @@ mod 'libvirt', :ref => '5f55fb66db',                :git => github + 'norcams/pu
 #
 # ceph
 #
-mod 'ceph', :ref => 'd652d54f6f',                   :git => github + 'norcams/puppet-ceph'
+mod 'ceph', :ref => '43863d13fc',                   :git => github + 'norcams/puppet-ceph'
 
 #
 # ha

--- a/hieradata/common/common.yaml
+++ b/hieradata/common/common.yaml
@@ -33,7 +33,7 @@ domain_mgmt:          "%{::domain}"
 
 openstack_version:    'ocata'
 
-ceph_version:         'luminous'
+ceph_version:         'mimic'
 
 valid_location_tags:
   - bgo

--- a/hieradata/common/common.yaml
+++ b/hieradata/common/common.yaml
@@ -33,7 +33,7 @@ domain_mgmt:          "%{::domain}"
 
 openstack_version:    'ocata'
 
-ceph_version:         'mimic'
+ceph_version:         'luminous'
 
 valid_location_tags:
   - bgo

--- a/hieradata/common/roles/compute.yaml
+++ b/hieradata/common/roles/compute.yaml
@@ -158,7 +158,7 @@ profile::base::yumrepo::repo_hash:
     ensure: present
   epel: # should be absent when using RDO, but whitelist can also work
     ensure:   present
-    includepkgs: 'bird bird6 htop bash-completion-extras lttng-ust userspace-rcu libbabeltrace leveldb'
+    includepkgs: 'bird bird6 htop bash-completion-extras lttng-ust userspace-rcu libbabeltrace leveldb liboath'
 
 # Compute nodes need only admin and cinder keys
 ceph::profile::params::client_keys:

--- a/hieradata/common/roles/compute.yaml
+++ b/hieradata/common/roles/compute.yaml
@@ -158,7 +158,7 @@ profile::base::yumrepo::repo_hash:
     ensure: present
   epel: # should be absent when using RDO, but whitelist can also work
     ensure:   present
-    includepkgs: 'bird bird6 htop bash-completion-extras lttng-ust userspace-rcu libbabeltrace leveldb liboath'
+    includepkgs: 'bird bird6 htop bash-completion-extras lttng-ust userspace-rcu libbabeltrace leveldb liboath py-bcrypt'
 
 # Compute nodes need only admin and cinder keys
 ceph::profile::params::client_keys:

--- a/hieradata/common/roles/image.yaml
+++ b/hieradata/common/roles/image.yaml
@@ -28,7 +28,7 @@ profile::base::yumrepo::repo_hash:
     ensure: present
   epel: # should be absent when using RDO, but whitelist can also work
     ensure:   present
-    includepkgs: 'htop bash-completion-extras lttng-ust userspace-rcu libbabeltrace leveldb'
+    includepkgs: 'htop bash-completion-extras lttng-ust userspace-rcu libbabeltrace leveldb liboath'
 
 # Image nodes need only glance key
 ceph::profile::params::client_keys:

--- a/hieradata/common/roles/image.yaml
+++ b/hieradata/common/roles/image.yaml
@@ -28,7 +28,7 @@ profile::base::yumrepo::repo_hash:
     ensure: present
   epel: # should be absent when using RDO, but whitelist can also work
     ensure:   present
-    includepkgs: 'htop bash-completion-extras lttng-ust userspace-rcu libbabeltrace leveldb liboath'
+    includepkgs: 'htop bash-completion-extras lttng-ust userspace-rcu libbabeltrace leveldb liboath py-bcrypt'
 
 # Image nodes need only glance key
 ceph::profile::params::client_keys:

--- a/hieradata/common/roles/volume.yaml
+++ b/hieradata/common/roles/volume.yaml
@@ -62,7 +62,7 @@ profile::base::yumrepo::repo_hash:
     ensure: present
   epel: # should be absent when using RDO, but whitelist can also work
     ensure:   present
-    includepkgs: 'htop bash-completion-extras lttng-ust userspace-rcu libbabeltrace leveldb'
+    includepkgs: 'htop bash-completion-extras lttng-ust userspace-rcu libbabeltrace leveldb liboath'
 
 # Volume nodes need only cinder and glance keys
 ceph::profile::params::client_keys:

--- a/hieradata/common/roles/volume.yaml
+++ b/hieradata/common/roles/volume.yaml
@@ -62,7 +62,7 @@ profile::base::yumrepo::repo_hash:
     ensure: present
   epel: # should be absent when using RDO, but whitelist can also work
     ensure:   present
-    includepkgs: 'htop bash-completion-extras lttng-ust userspace-rcu libbabeltrace leveldb liboath'
+    includepkgs: 'htop bash-completion-extras lttng-ust userspace-rcu libbabeltrace leveldb liboath py-bcrypt'
 
 # Volume nodes need only cinder and glance keys
 ceph::profile::params::client_keys:

--- a/hieradata/local3/common.yaml
+++ b/hieradata/local3/common.yaml
@@ -36,6 +36,9 @@ netcfg_trp_rr:
   rr1:
     peer_ipv4: '172.31.12.1'
 
+#### FIXME move to common when all ceph clusters are updated to mimic
+ceph_version:         'mimic'
+
 # We need to allow both trafic from mgmt (nat via login) and public net
 
 allow_from_network:

--- a/hieradata/local3/roles/storage.yaml
+++ b/hieradata/local3/roles/storage.yaml
@@ -7,12 +7,15 @@ named_interfaces::config:
   ceph:
     - eth1
 
+#### FIXME move to common when all clusters are upgraded to mimic
+profile::storage::cephosd::create_osds: true
+
 profile::base::common::manage_fake_ssd: true
 
 profile::storage::fake_ssds:
   'vdb': {}
 
-ceph::profile::params::osds:
+profile::storage::cephosd::osds:
   '/dev/vdb':
     ensure: present
   '/dev/vdc':

--- a/hieradata/test01/common.yaml
+++ b/hieradata/test01/common.yaml
@@ -42,6 +42,9 @@ netcfg_trp_rr:
     peer_ipv4: '172.30.0.1'
     peer_ipv6: 'fd00::1'
 
+#### FIXME move to common when all ceph clusters are updated to mimic
+ceph_version:         'mimic'
+
 # DNS servers
 public__address__ns:           '129.177.31.117'
 public6__address__ns:          '2001:700:200:917::3f17'

--- a/hieradata/test01/roles/storage.yaml
+++ b/hieradata/test01/roles/storage.yaml
@@ -7,6 +7,9 @@ named_interfaces::config:
   ceph:
     - bond0
 
+#### FIXME move to common when all clusters are upgraded to mimic
+profile::storage::cephosd::create_osds: true
+
 profile::base::common::manage_fake_ssd: true
 
 #profile::base::lvm::physical_volume:
@@ -27,7 +30,7 @@ profile::base::common::manage_fake_ssd: true
 profile::storage::fake_ssds:
   'sdb': {}
 
-ceph::profile::params::osds:
+profile::storage::cephosd::osds:
   '/dev/sdb':
     ensure: present
   '/dev/sdc':

--- a/profile/manifests/storage/cephosd.pp
+++ b/profile/manifests/storage/cephosd.pp
@@ -1,8 +1,12 @@
 # Class: profile::storage::cephosd
 #
 #
-class profile::storage::cephosd {
+class profile::storage::cephosd(
+  $create_osds = false,
+) {
   include ::ceph::profile::osd
+
+#### FIXME remove after all clusters have been upgraded to mimic
 
   service { 'ceph-osd':
     ensure    => running,
@@ -23,5 +27,13 @@ class profile::storage::cephosd {
     command     => '/bin/systemctl start -l ceph-osd.target',
     require     => File['/var/lib/ceph-configured'],
     refreshonly => true,
+  }
+
+#### FIXME stop removal
+
+  # Create lvm osds
+  if $create_osds {
+    $osd_devices = lookup('profile::storage::cephosd::osds', Hash, 'deep', {})
+    create_resources('profile::storage::create_lvm_osd', $osd_devices)
   }
 }

--- a/profile/manifests/storage/create_lvm_osd.pp
+++ b/profile/manifests/storage/create_lvm_osd.pp
@@ -8,10 +8,10 @@ define profile::storage::create_lvm_osd (
 ) {
 
   if $db_device {
-  	$add_db_device = "--block.db ${db_device}"
+    $add_db_device = "--block.db ${db_device}"
   }
   if $wal_device {
-  	$add_wal_device = "--block.wal ${wal_device}"
+    $add_wal_device = "--block.wal ${wal_device}"
   }
   # Create the osds
   exec { "create_lvm_osd-${name}":

--- a/profile/manifests/storage/create_lvm_osd.pp
+++ b/profile/manifests/storage/create_lvm_osd.pp
@@ -1,0 +1,27 @@
+#
+# Use new lvm mechanism to create ceph osds
+#
+define profile::storage::create_lvm_osd (
+  $ensure      = present,
+  $db_device   = undef,
+  $wal_device  = undef,
+) {
+
+  if $db_device {
+  	$add_db_device = "--block.db ${db_device}"
+  }
+  if $wal_device {
+  	$add_wal_device = "--block.wal ${wal_device}"
+  }
+  # Create the osds
+  exec { "create_lvm_osd-${name}":
+    command => "/sbin/ceph-volume lvm create --bluestore $add_db_device $add_wal_device --data ${name}",
+    unless  => "/sbin/ceph-volume lvm list ${name} | grep ====== >/dev/null 2>&1",
+  }
+  # Ensure that the osd service is running
+  exec { "osd-service-${name}":
+    command => "/bin/systemctl start ceph-osd@$(/sbin/ceph-volume lvm list ${name} | grep 'osd id' | grep -Eo '[0-9]{1,40}').service",
+    onlyif  => "/bin/systemctl status ceph-osd@$(/sbin/ceph-volume lvm list ${name} | grep 'osd id' | grep -Eo '[0-9]{1,40}') | grep inactive",
+  }
+}
+

--- a/profile/manifests/storage/create_lvm_osd.pp
+++ b/profile/manifests/storage/create_lvm_osd.pp
@@ -15,7 +15,7 @@ define profile::storage::create_lvm_osd (
   }
   # Create the osds
   exec { "create_lvm_osd-${name}":
-    command => "/sbin/ceph-volume lvm create --bluestore $add_db_device $add_wal_device --data ${name}",
+    command => "/sbin/ceph-volume lvm create --bluestore ${add_db_device} ${add_wal_device} --data ${name}",
     unless  => "/sbin/ceph-volume lvm list ${name} | grep ====== >/dev/null 2>&1",
   }
   # Ensure that the osd service is running


### PR DESCRIPTION
These changes includes a new mechanism for creating ceph OSDs in profile code instead of using the openstack ceph module. Changes are only applied for local3 and test01 for now.
