### PR TITLE
Enable redfish for agentless monitoring of physical machines via sensu

### DIFF
--- a/hieradata/bgo/roles/compute.yaml
+++ b/hieradata/bgo/roles/compute.yaml
@@ -18,3 +18,11 @@ profile::base::network::rules:
   'team1':
     iprule: [ "from %{hiera('netcfg_priv_network')} lookup private", ]
 profile::base::network::manage_neutron_blackhole: true
+
+profile::base::physical::enable_redfish_sensu_check: true
+profile::base::physical::enable_redfish_http_proxy:  true
+profile::monitoring::sensu::agent::checks:
+  'redfish-check':
+    command:      '/usr/local/bin/redfish_check.sh'
+    interval:     300
+    subscribers:  ['checks']

--- a/hieradata/bgo/roles/controller.yaml
+++ b/hieradata/bgo/roles/controller.yaml
@@ -10,3 +10,10 @@ himlar_bootstrap::virt_install:
     vm_vcpus:        2
     vm_memory:       8096
     vm_console:      false
+
+profile::base::physical::enable_redfish_sensu_check: true
+profile::monitoring::sensu::agent::checks:
+  'redfish-check':
+    command:      '/usr/local/bin/redfish_check.sh'
+    interval:     300
+    subscribers:  ['checks']

--- a/hieradata/bgo/roles/login.yaml
+++ b/hieradata/bgo/roles/login.yaml
@@ -1,6 +1,8 @@
 ---
 profile::network::services::manage_dhcp:  false
 profile::firewall::pre::manage_ipv6_ssh:  true
+profile::base::login::forward_oobnet:     false
+profile::base::login::oob_net:            "172.17.0.0/21"
 
 # Himlar bootstrap
 profile::bootstrap::himlar::manage_bootstrap_scripts: true

--- a/hieradata/bgo/roles/login.yaml
+++ b/hieradata/bgo/roles/login.yaml
@@ -3,6 +3,7 @@ profile::network::services::manage_dhcp:  false
 profile::firewall::pre::manage_ipv6_ssh:  true
 profile::base::login::forward_oobnet:     true
 profile::base::login::oob_net:            "172.17.0.0/21"
+profile::base::login::oob_outiface:       'eth3'
 
 # Himlar bootstrap
 profile::bootstrap::himlar::manage_bootstrap_scripts: true

--- a/hieradata/bgo/roles/login.yaml
+++ b/hieradata/bgo/roles/login.yaml
@@ -1,7 +1,7 @@
 ---
 profile::network::services::manage_dhcp:  false
 profile::firewall::pre::manage_ipv6_ssh:  true
-profile::base::login::forward_oobnet:     false
+profile::base::login::forward_oobnet:     true
 profile::base::login::oob_net:            "172.17.0.0/21"
 
 # Himlar bootstrap

--- a/hieradata/bgo/roles/storage.yaml
+++ b/hieradata/bgo/roles/storage.yaml
@@ -9,6 +9,13 @@ named_interfaces::config:
   ceph:
     - team1.110
 
+profile::base::physical::enable_redfish_sensu_check: true
+profile::monitoring::sensu::agent::checks:
+  'redfish-check':
+    command:      '/usr/local/bin/redfish_check.sh'
+    interval:     300
+    subscribers:  ['checks']
+
 profile::base::lvm::physical_volume:
   '/dev/sdk':
     ensure: present

--- a/hieradata/nodes/bgo/bgo-proxy-01.yaml
+++ b/hieradata/nodes/bgo/bgo-proxy-01.yaml
@@ -27,7 +27,7 @@ profile::base::network::routes:
   'eth0':
     'ipaddress': [ '172.17.0.0', ]
     'netmask':   [ '255.255.248.0', ]
-    'gateway':   [ "%{hiera('netcfg_mgmt_gateway')}", ]
+    'gateway':   [ '172.16.0.10', ]
     'table':     [ 'main', ]
   'eth1':
     'ipaddress': [ '::', ]

--- a/hieradata/nodes/bgo/bgo-proxy-01.yaml
+++ b/hieradata/nodes/bgo/bgo-proxy-01.yaml
@@ -24,6 +24,11 @@ network::interfaces_hash:
     ipv6addr:  '2001:700:2:83ff::12/128'
     defroute:  'no'
 profile::base::network::routes:
+  'eth0':
+    'ipaddress': [ '172.17.0.0', ]
+    'netmask':   [ '255.255.248.0', ]
+    'gateway':   [ "%{hiera('netcfg_mgmt_gateway')}", ]
+    'table':     [ 'main', ]
   'eth1':
     'ipaddress': [ '::', ]
     'netmask':   [ '0', ]

--- a/hieradata/nodes/osl/osl-proxy-01.yaml
+++ b/hieradata/nodes/osl/osl-proxy-01.yaml
@@ -24,6 +24,11 @@ network::interfaces_hash:
     ipv6addr:  '2001:700:2:82ff::12/128'
     defroute:  'no'
 profile::base::network::routes:
+  'eth0':
+    'ipaddress': [ '172.17.32.0', ]
+    'netmask':   [ '255.255.248.0', ]
+    'gateway':   [ '172.16.32.10', ]
+    'table':     [ 'main', ]
   'eth1':
     'ipaddress': [ '::', ]
     'netmask':   [ '0', ]

--- a/hieradata/osl/roles/compute.yaml
+++ b/hieradata/osl/roles/compute.yaml
@@ -36,3 +36,10 @@ profile::base::lvm::logical_volume:
     volume_group: 'vg_ext'
     fs_type:      "xfs"
     mountpath:    "/var/lib/nova/instances"
+
+profile::base::physical::enable_redfish_sensu_check: true
+profile::monitoring::sensu::agent::checks:
+  'redfish-check':
+    command:      '/usr/local/bin/redfish_check.sh'
+    interval:     300
+    subscribers:  ['checks']

--- a/hieradata/osl/roles/compute.yaml
+++ b/hieradata/osl/roles/compute.yaml
@@ -38,6 +38,7 @@ profile::base::lvm::logical_volume:
     mountpath:    "/var/lib/nova/instances"
 
 profile::base::physical::enable_redfish_sensu_check: true
+profile::base::physical::enable_redfish_http_proxy:  true
 profile::monitoring::sensu::agent::checks:
   'redfish-check':
     command:      '/usr/local/bin/redfish_check.sh'

--- a/hieradata/osl/roles/controller.yaml
+++ b/hieradata/osl/roles/controller.yaml
@@ -10,3 +10,10 @@ himlar_bootstrap::virt_install:
     vm_vcpus:        2
     vm_memory:       8096
     vm_console:      false
+
+profile::base::physical::enable_redfish_sensu_check: true
+profile::monitoring::sensu::agent::checks:
+  'redfish-check':
+    command:      '/usr/local/bin/redfish_check.sh'
+    interval:     300
+    subscribers:  ['checks']

--- a/hieradata/osl/roles/login.yaml
+++ b/hieradata/osl/roles/login.yaml
@@ -1,6 +1,9 @@
 ---
 profile::network::services::manage_dhcp:  false
 profile::firewall::pre::manage_ipv6_ssh:  true
+profile::base::login::forward_oobnet:     true
+profile::base::login::oob_net:            "172.17.32.0/21"
+profile::base::login::oob_outiface:       'em3'
 
 openstack_extras::repo::redhat::redhat::purge_unmanaged: false
 

--- a/hieradata/osl/roles/storage.yaml
+++ b/hieradata/osl/roles/storage.yaml
@@ -9,6 +9,13 @@ named_interfaces::config:
   ceph:
     - team1.110
 
+profile::base::physical::enable_redfish_sensu_check: true
+profile::monitoring::sensu::agent::checks:
+  'redfish-check':
+    command:      '/usr/local/bin/redfish_check.sh'
+    interval:     300
+    subscribers:  ['checks']
+
 profile::base::lvm::physical_volume:
   '/dev/sdk':
     ensure: present

--- a/profile/manifests/base/login.pp
+++ b/profile/manifests/base/login.pp
@@ -4,6 +4,8 @@
 class profile::base::login (
   $manage_db_backup         = false,
   $manage_repo_incoming_dir = false,
+  $forward_oobnet           = false,
+  $oob_net                  = '10.0.0.0/24'
   $ensure                   = 'present',
   $agelimit                 = '14',
   $db_servers               = {},
@@ -148,5 +150,17 @@ class profile::base::login (
     }
   }
 
-
+  if $forward_oobnet  {
+    profile::firewall::rule { '098 postrouting to out-of-band network':
+      chain         => 'POSTROUTING',
+      proto         => 'all',
+      destination   => $oob_net,
+      extras => {
+        action      => undef,
+        jump        => 'MASQUERADE',
+        table       => 'nat',
+        state       => undef
+      }
+    }
+  }
 }

--- a/profile/manifests/base/login.pp
+++ b/profile/manifests/base/login.pp
@@ -6,6 +6,7 @@ class profile::base::login (
   $manage_repo_incoming_dir = false,
   $forward_oobnet           = false,
   $oob_net                  = '10.0.0.0/24',
+  $oob_outiface             = undef,
   $ensure                   = 'present',
   $agelimit                 = '14',
   $db_servers               = {},
@@ -159,6 +160,7 @@ class profile::base::login (
         action      => undef,
         jump        => 'MASQUERADE',
         table       => 'nat',
+        outiface    => $oob_outiface,
         state       => undef
       }
     }

--- a/profile/manifests/base/login.pp
+++ b/profile/manifests/base/login.pp
@@ -5,7 +5,7 @@ class profile::base::login (
   $manage_db_backup         = false,
   $manage_repo_incoming_dir = false,
   $forward_oobnet           = false,
-  $oob_net                  = '10.0.0.0/24'
+  $oob_net                  = '10.0.0.0/24',
   $ensure                   = 'present',
   $agelimit                 = '14',
   $db_servers               = {},

--- a/profile/manifests/base/physical.pp
+++ b/profile/manifests/base/physical.pp
@@ -27,7 +27,7 @@ class profile::base::physical (
     $bmc_network  = regsubst("${::ipaddress_trp1}", '^(\d+)\.(\d+)\.(\d+)\.(\d+)$','\2',) - 1
     $bmc_address  = regsubst("${::ipaddress_trp1}", '^(\d+)\.(\d+)\.(\d+)\.(\d+)$',"\\1.${bmc_network}.\\3.\\4",)
     $bmc_username = lookup("bmc_username", String, 'first', '')
-    $bmc_password = lookup("bmc_password_${location}", String, 'first', '')
+    $bmc_password = lookup("bmc_password_${::location}", String, 'first', '')
     if $enable_redfish_http_proxy {
       $http_proxy     = lookup('mgmt__address__proxy', String, 'first', '')
       $http_proxy_url = " --proxy1.0 ${http_proxy}:8888"

--- a/profile/manifests/base/physical.pp
+++ b/profile/manifests/base/physical.pp
@@ -1,7 +1,9 @@
 # This class is included from common.pp if is_virtual is false
 #
-class profile::base::physical
-{
+class profile::base::physical (
+  $enable_redfish_sensu_check = false,
+  $enable_redfish_http_proxy  = undef,
+) {
   include ::lldp
   include ::ipmi
 

--- a/profile/manifests/base/physical.pp
+++ b/profile/manifests/base/physical.pp
@@ -27,7 +27,7 @@ class profile::base::physical (
     $bmc_network  = regsubst("${::ipaddress_trp1}", '^(\d+)\.(\d+)\.(\d+)\.(\d+)$','\2',) - 1
     $bmc_address  = regsubst("${::ipaddress_trp1}", '^(\d+)\.(\d+)\.(\d+)\.(\d+)$',"\\1.${bmc_network}.\\3.\\4",)
     $bmc_username = lookup("bmc_username", String, 'first', '')
-    $bmc_password = lookup("bmc_password_$location", String, 'first', '')
+    $bmc_password = lookup("bmc_password_${location}", String, 'first', '')
     if $enable_redfish_http_proxy {
       $http_proxy     = lookup('mgmt__address__proxy', String, 'first', '')
       $http_proxy_url = " --proxy1.0 ${http_proxy}:8888"

--- a/profile/manifests/base/physical.pp
+++ b/profile/manifests/base/physical.pp
@@ -24,8 +24,8 @@ class profile::base::physical (
   }
 
   if $enable_redfish_sensu_check {
-    $bmc_network  = regsubst("$::ipaddress_trp1", '^(\d+)\.(\d+)\.(\d+)\.(\d+)$','\2',) - 1
-    $bmc_address  = regsubst("$::ipaddress_trp1", '^(\d+)\.(\d+)\.(\d+)\.(\d+)$',"\\1.${bmc_network}.\\3.\\4",)
+    $bmc_network  = regsubst($::ipaddress_trp1, '^(\d+)\.(\d+)\.(\d+)\.(\d+)$','\2',) - 1
+    $bmc_address  = regsubst($::ipaddress_trp1, '^(\d+)\.(\d+)\.(\d+)\.(\d+)$',"\\1.${bmc_network}.\\3.\\4",)
     $bmc_username = lookup("bmc_username", String, 'first', '')
     $bmc_password = lookup("bmc_password_${::location}", String, 'first', '')
     if $enable_redfish_http_proxy {

--- a/profile/manifests/base/physical.pp
+++ b/profile/manifests/base/physical.pp
@@ -25,7 +25,7 @@ class profile::base::physical (
 
   if $enable_redfish_sensu_check {
     $bmc_network  = regsubst("${::ipaddress_trp1}", '^(\d+)\.(\d+)\.(\d+)\.(\d+)$','\2',) - 1
-    $bmc_address  = regsubst("${::ipaddress_trp1}", '^(\d+)\.(\d+)\.(\d+)\.(\d+)$',"\1.$bmc_network.\3.\4",)
+    $bmc_address  = regsubst("${::ipaddress_trp1}", '^(\d+)\.(\d+)\.(\d+)\.(\d+)$',"\\1.${bmc_network}.\\3.\\4",)
     $bmc_username = lookup("bmc_username", String, 'first', '')
     $bmc_password = lookup("bmc_password_$location", String, 'first', '')
     if $enable_redfish_http_proxy {

--- a/profile/manifests/base/physical.pp
+++ b/profile/manifests/base/physical.pp
@@ -21,4 +21,20 @@ class profile::base::physical
     }
   }
 
+  if $enable_redfish_sensu_check {
+    $bmc_network  = regsubst("${::ipaddress_trp1}", '^(\d+)\.(\d+)\.(\d+)\.(\d+)$','\2',) - 1
+    $bmc_address  = regsubst("${::ipaddress_trp1}", '^(\d+)\.(\d+)\.(\d+)\.(\d+)$',"\1.$bmc_network.\3.\4",)
+    $bmc_username = lookup("bmc_username", String, 'first', '')
+    $bmc_password = lookup("bmc_password_$location", String, 'first', '')
+    if $enable_redfish_http_proxy {
+      $http_proxy     = lookup('mgmt__address__proxy', String, 'first', '')
+      $http_proxy_url = " --proxy1.0 ${http_proxy}:8888"
+    }
+    file { 'redfish_status.sh':
+      ensure  => file,
+      path    => '/usr/local/bin/redfish_check.sh',
+      content => template("${module_name}/monitoring/sensu/redfish_check.sh.erb"),
+      mode    => '0755',
+    }
+  }
 }

--- a/profile/manifests/base/physical.pp
+++ b/profile/manifests/base/physical.pp
@@ -24,8 +24,8 @@ class profile::base::physical (
   }
 
   if $enable_redfish_sensu_check {
-    $bmc_network  = regsubst("${::ipaddress_trp1}", '^(\d+)\.(\d+)\.(\d+)\.(\d+)$','\2',) - 1
-    $bmc_address  = regsubst("${::ipaddress_trp1}", '^(\d+)\.(\d+)\.(\d+)\.(\d+)$',"\\1.${bmc_network}.\\3.\\4",)
+    $bmc_network  = regsubst("$::ipaddress_trp1", '^(\d+)\.(\d+)\.(\d+)\.(\d+)$','\2',) - 1
+    $bmc_address  = regsubst("$::ipaddress_trp1", '^(\d+)\.(\d+)\.(\d+)\.(\d+)$',"\\1.${bmc_network}.\\3.\\4",)
     $bmc_username = lookup("bmc_username", String, 'first', '')
     $bmc_password = lookup("bmc_password_${::location}", String, 'first', '')
     if $enable_redfish_http_proxy {

--- a/profile/templates/monitoring/sensu/redfish_check.sh.erb
+++ b/profile/templates/monitoring/sensu/redfish_check.sh.erb
@@ -1,0 +1,8 @@
+#!/bin/bash
+result=$(/bin/curl -s https://<%= @bmc_address %>/redfish/v1/Systems/System.Embedded.1 -k -u <%= @bmc_username %>:<%= @bmc_password %><%= @http_proxy_url %> --connect-timeout 5 |jq .Status.Health)
+if [ ! "$result" ]; then 
+  echo "Error: could not connect to bmc - connection timeout"
+fi
+if [ "$result" ]; then
+  echo "$result"
+fi


### PR DESCRIPTION
These changes enables agentless monitoring via modern baseboard management controllers, which should be vendor neutral.

This is only viable in BGO and OSL locations for now.

- new secrets must be deployed to admin
- routes must be enabled on proxy (ifdown eth0 && ifup eth0)
