### PR TITLE
Automatically create network interfaces files on nodes

### DIFF
--- a/hieradata/bgo/roles/compute.yaml
+++ b/hieradata/bgo/roles/compute.yaml
@@ -4,6 +4,17 @@ ntp::servers:
   - 172.16.0.101
   - 172.16.0.102
 
+profile::base::network::network_auto_opts:
+  trp:
+    'defroute': 'no'
+    'devicetype': 'Team'
+    'team_config': >-
+                   { "runner" : {  "name" : "lacp",  "active": true, "fast_rate" : true,
+                   "tx_hash": ["eth", "ipv4", "ipv6"], "tx_balancer": { "name": "basic" } },
+                   "link_watch" : {  "name" : "ethtool" } }
+  live:
+    'defroute': 'no'
+
 # Add custom routing table for private network to NAT
 profile::base::network::routes:
   'team1':

--- a/hieradata/bgo/roles/compute.yaml
+++ b/hieradata/bgo/roles/compute.yaml
@@ -7,6 +7,7 @@ ntp::servers:
 profile::base::network::network_auto_opts:
   trp:
     'defroute': 'no'
+    'ipv6init': 'yes'
     'devicetype': 'Team'
     'team_config': >-
                    { "runner" : {  "name" : "lacp",  "active": true, "fast_rate" : true,

--- a/hieradata/bgo/roles/storage.yaml
+++ b/hieradata/bgo/roles/storage.yaml
@@ -9,6 +9,17 @@ named_interfaces::config:
   ceph:
     - team1.110
 
+profile::base::network::network_auto_opts:
+  trp:
+    'defroute': 'no'
+    'devicetype': 'Team'
+    'team_config': >-
+                   { "runner" : {  "name" : "lacp",  "active": true, "fast_rate" : true,
+                   "tx_hash": ["eth", "ipv4", "ipv6"], "tx_balancer": { "name": "basic" } },
+                   "link_watch" : {  "name" : "ethtool" } }
+  ceph:
+    'defroute': 'no'
+
 profile::base::physical::enable_redfish_sensu_check: true
 profile::monitoring::sensu::agent::checks:
   'redfish-check':

--- a/hieradata/common/common.yaml
+++ b/hieradata/common/common.yaml
@@ -144,9 +144,9 @@ profile::base::network::network_auto_opts:
 
 profile::base::network::network_auto_bonding:
   trp:
-    em1: {}
+    em1:
       'team_port_config': '{ "prio" : 100 }'
-    em2: {}
+    em2:
       'team_port_config': '{ "prio" : 100 }'
 
 #

--- a/hieradata/common/common.yaml
+++ b/hieradata/common/common.yaml
@@ -134,6 +134,21 @@ named_interfaces::config:
   public:
     - dummy0
 
+profile::base::network::network_auto_opts:
+  mgmt:
+    'dns1':     "%{hiera('netcfg_dns_server1')}"
+    'domain':   "%{hiera('netcfg_dns_search')}"
+    'defroute': 'yes'
+  trp:
+    'defroute': 'no'
+
+profile::base::network::network_auto_bonding:
+  trp:
+    em1: {}
+      'team_port_config': '{ "prio" : 100 }'
+    em2: {}
+      'team_port_config': '{ "prio" : 100 }'
+
 #
 # project and domain used for internal use
 #

--- a/hieradata/common/roles/builder.yaml
+++ b/hieradata/common/roles/builder.yaml
@@ -15,6 +15,10 @@ profile::base::common::packages:
   'bash-completion-extras': {}
   'jq': {}
 
+named_interfaces::config:
+  mgmt:
+    - eth0
+
 profile::base::lvm::physical_volume:
   '/dev/vdb':
     ensure: present

--- a/hieradata/common/roles/logger.yaml
+++ b/hieradata/common/roles/logger.yaml
@@ -7,6 +7,10 @@ include:
     - profile::logging::kibana
     - profile::logging::logrotate
 
+named_interfaces::config:
+  mgmt:
+    - eth0
+
 rsyslog::perm_dir:    '0755'
 
 profile::logging::logrotate::manage_logrotate:    true

--- a/hieradata/common/roles/monitor.yaml
+++ b/hieradata/common/roles/monitor.yaml
@@ -8,6 +8,10 @@ include:
     - profile::logging::logrotate
     - profile::openstack::openrc
 
+named_interfaces::config:
+  mgmt:
+    - eth0
+
 # Grafana and statsd
 profile::monitoring::grafana::enable:          true
 profile::monitoring::grafana::manage_firewall: true

--- a/hieradata/common/roles/object.yaml
+++ b/hieradata/common/roles/object.yaml
@@ -7,6 +7,16 @@ include:
     - profile::openstack::object::proxy
     - profile::logging::rsyslog::client
 
+profile::base::network::network_auto_opts:
+  trp:
+    'defroute': 'no'
+    'ipv6init': 'yes'
+    'devicetype': 'Team'
+    'team_config': >-
+                   { "runner" : {  "name" : "lacp",  "active": true, "fast_rate" : true,
+                   "tx_hash": ["eth", "ipv4", "ipv6"], "tx_balancer": { "name": "basic" } },
+                   "link_watch" : {  "name" : "ethtool" } }
+
 profile::openstack::object::proxy::manage_firewall:   true
 profile::openstack::object::proxy::manage_ringserver: true
 profile::openstack::object::proxy::manage_ceilometer: true

--- a/hieradata/osl/roles/compute.yaml
+++ b/hieradata/osl/roles/compute.yaml
@@ -7,6 +7,7 @@ ntp::servers:
 profile::base::network::network_auto_opts:
   trp:
     'defroute': 'no'
+    'ipv6init': 'yes'
     'devicetype': 'Team'
     'team_config': >-
                    { "runner" : {  "name" : "lacp",  "active": true, "fast_rate" : true,

--- a/hieradata/osl/roles/compute.yaml
+++ b/hieradata/osl/roles/compute.yaml
@@ -4,6 +4,17 @@ ntp::servers:
   - 172.16.32.101
   - 172.16.32.102
 
+profile::base::network::network_auto_opts:
+  trp:
+    'defroute': 'no'
+    'devicetype': 'Team'
+    'team_config': >-
+                   { "runner" : {  "name" : "lacp",  "active": true, "fast_rate" : true,
+                   "tx_hash": ["eth", "ipv4", "ipv6"], "tx_balancer": { "name": "basic" } },
+                   "link_watch" : {  "name" : "ethtool" } }
+  live:
+    'defroute': 'no'
+
 # Add custom routing table for private network to NAT
 profile::base::network::routes:
   'team1':

--- a/hieradata/osl/roles/storage.yaml
+++ b/hieradata/osl/roles/storage.yaml
@@ -9,6 +9,17 @@ named_interfaces::config:
   ceph:
     - team1.110
 
+profile::base::network::network_auto_opts:
+  trp:
+    'defroute': 'no'
+    'devicetype': 'Team'
+    'team_config': >-
+                   { "runner" : {  "name" : "lacp",  "active": true, "fast_rate" : true,
+                   "tx_hash": ["eth", "ipv4", "ipv6"], "tx_balancer": { "name": "basic" } },
+                   "link_watch" : {  "name" : "ethtool" } }
+  ceph:
+    'defroute': 'no'
+
 profile::base::physical::enable_redfish_sensu_check: true
 profile::monitoring::sensu::agent::checks:
   'redfish-check':

--- a/hieradata/test01/roles/compute.yaml
+++ b/hieradata/test01/roles/compute.yaml
@@ -9,6 +9,7 @@ named_interfaces::config:
 
 profile::base::network::network_auto_opts:
   trp:
+    'ipv6init': 'yes'
     'bonding_opts': 'mode=balance-alb miimon=100'
 
 profile::base::network::network_auto_bonding:

--- a/hieradata/test01/roles/compute.yaml
+++ b/hieradata/test01/roles/compute.yaml
@@ -7,6 +7,15 @@ named_interfaces::config:
   live:
     - bond0.912
 
+profile::base::network::network_auto_opts:
+  trp:
+    'bonding_opts': 'mode=balance-alb miimon=100'
+
+profile::base::network::network_auto_bonding:
+  trp:
+    em1: {}
+    em2: {}
+
 ntp::servers:
   - 172.28.0.100
   - 172.28.0.101

--- a/hieradata/test02/roles/compute.yaml
+++ b/hieradata/test02/roles/compute.yaml
@@ -11,6 +11,10 @@ named_interfaces::config:
   live:
     - em1
 
+profile::base::network::network_auto_opts:
+  trp:
+    'ipv6init': 'yes'
+
 ntp::servers:
   - 172.28.32.100
   - 172.28.32.101

--- a/profile/manifests/base/network.pp
+++ b/profile/manifests/base/network.pp
@@ -127,6 +127,83 @@ class profile::base::network(
     }
   }
 
+  #
+  # If the interfaces_hash is empty, create interface files based on certname on RedHat based platforms
+  #
+  if String(lookup('network::interfaces_hash', Hash, 'deep', {})) == "{}" and $::osfamily == 'RedHat' {
+    $addresslist = lookup('profile::network::services::dns_records', Hash, 'deep', '')
+    $mgmtaddress = $addresslist['A'][$::clientcert]
+
+    # Create interface files only if an A record is defined in hiera
+    # to avoid destroying existing network interfaces config
+    if ! empty($mgmtaddress) {
+      $mgmtnetwork = lookup("netcfg_mgmt_netpart", String, 'first', '')
+      $addrbase = regsubst($mgmtnetwork, '^(\d+)\.(\d+)\.(\d+)$','\3',)
+      $ouraddr = regsubst($mgmtaddress, '^(\d+)\.(\d+)\.(\d+)\.(\d+)$','\3',)
+      $ipbyte = regsubst($mgmtaddress, '^(\d+)\.(\d+)\.(\d+)\.(\d+)$','\4',)
+      # our third octet might be higher than base, we need to know the difference
+      $addrdiff = $ouraddr-$addrbase
+      # Find which interfaces to configure and their options
+      $named_interface_hash = lookup('named_interfaces::config', Hash, 'first', {})
+      $ifopts = lookup('profile::base::network::network_auto_opts', Hash, 'deep', {})
+      # Configure each interface
+      $named_interface_hash.each |$ifrole, $ifnamed| {
+      $ifname = String($ifnamed[0])
+
+      # We must avoid duplicate interface files for logical constructs in named_interfaces, i.e trp vs transport, live etc
+      # Make interface files only for interfaces defined with network_auto_opts
+      if $ifopts[$ifrole] {
+        # Calculate ip address pr interface based on mgmt address, get gw and mask
+        $ipnetpart = lookup("netcfg_${ifrole}_netpart", String, 'first', '')
+        $netrole = regsubst($ipnetpart, '^(\d+)\.(\d+)\.(\d+)$','\3',) + $addrdiff
+        $newipaddr = regsubst($mgmtaddress, '^(\d+)\.(\d+)\.(\d+)\.(\d+)$',"\\1.\\2.${netrole}.\\4",)
+        $ifmask = lookup("netcfg_${ifrole}_netmask", String, 'first', '')
+        $ifgw = lookup("netcfg_${ifrole}_gateway", String, 'first', '')
+
+        # check for IPv6 configuration in options for this interface
+        if $ifopts[$ifrole]['ipv6init'] == 'yes' {
+          # Find network and diff from base
+          $ipnetpart6 = lookup("netcfg_${ifrole}_netpart6", String, 'first', '')
+          if String($addrdiff) != '0' {
+            $newipaddr6 = "${ipnetpart6}::${addrdiff}:${ipbyte}"
+          }
+          else {
+            $newipaddr6 = "${ipnetpart6}::${ipbyte}"
+          }
+          $ifmask6 = lookup("netcfg_${ifrole}_netmask6", String, 'first', '')
+          $ifgw6 = lookup("netcfg_${ifrole}_gateway6", String, 'first', '')
+        }
+
+        # Check for teaming or bonding
+        if (($ifname[0,4] == 'team') or ($ifname[0,4] == 'bond')) and !('.' in $ifname) {
+          # Determine type and create slave interfaces
+          $iftype = $ifname[0,4]
+          $ifslaves = lookup('profile::base::network::network_auto_bonding', Hash, 'first', {})
+          $ifslaves[$ifrole].each |$slave, $slaveopts| {
+            file { "jalla-${slave})":
+              ensure  => file,
+              content => template("${module_name}/network/auto-if-${iftype}slave.erb"),
+              path    => "/etc/sysconfig/network-scripts/ifcfg-${slave}",
+            }
+          }
+        }
+
+        # check for VLAN interface
+        if '.' in $ifname {
+          $ifvlan = "yes"
+        }
+
+        # Write interface file
+        file { "jalla-${ifname})":
+          ensure  => file,
+          content => template("${module_name}/network/auto-if.erb"),
+          path    => "/etc/sysconfig/network-scripts/ifcfg-${ifname}",
+        }
+      }
+    }
+  }
+}
+
   # Create extra routes, tables, rules on ifup
   create_resources(network::mroute, lookup('profile::base::network::mroute', Hash, 'deep', {}))
   create_resources(network::routing_table, lookup('profile::base::network::routing_tables', Hash, 'deep', {}))

--- a/profile/manifests/base/network.pp
+++ b/profile/manifests/base/network.pp
@@ -136,7 +136,7 @@ class profile::base::network(
 
     # Create interface files only if an A record is defined in hiera
     # to avoid destroying existing network interfaces config
-    if ! empty($mgmtaddress) {
+    unless empty($mgmtaddress) {
       $mgmtnetwork = lookup("netcfg_mgmt_netpart", String, 'first', '')
       $addrbase = regsubst($mgmtnetwork, '^(\d+)\.(\d+)\.(\d+)$','\3',)
       $ouraddr = regsubst($mgmtaddress, '^(\d+)\.(\d+)\.(\d+)\.(\d+)$','\3',)
@@ -148,61 +148,61 @@ class profile::base::network(
       $ifopts = lookup('profile::base::network::network_auto_opts', Hash, 'deep', {})
       # Configure each interface
       $named_interface_hash.each |$ifrole, $ifnamed| {
-      $ifname = String($ifnamed[0])
+        $ifname = String($ifnamed[0])
 
-      # We must avoid duplicate interface files for logical constructs in named_interfaces, i.e trp vs transport, live etc
-      # Make interface files only for interfaces defined with network_auto_opts
-      if $ifopts[$ifrole] {
-        # Calculate ip address pr interface based on mgmt address, get gw and mask
-        $ipnetpart = lookup("netcfg_${ifrole}_netpart", String, 'first', '')
-        $netrole = regsubst($ipnetpart, '^(\d+)\.(\d+)\.(\d+)$','\3',) + $addrdiff
-        $newipaddr = regsubst($mgmtaddress, '^(\d+)\.(\d+)\.(\d+)\.(\d+)$',"\\1.\\2.${netrole}.\\4",)
-        $ifmask = lookup("netcfg_${ifrole}_netmask", String, 'first', '')
-        $ifgw = lookup("netcfg_${ifrole}_gateway", String, 'first', '')
+        # We must avoid duplicate interface files for logical constructs in named_interfaces, i.e trp vs transport, live etc
+        # Make interface files only for interfaces defined with network_auto_opts
+        if $ifopts[$ifrole] {
+          # Calculate ip address pr interface based on mgmt address, get gw and mask
+          $ipnetpart = lookup("netcfg_${ifrole}_netpart", String, 'first', '')
+          $netrole = regsubst($ipnetpart, '^(\d+)\.(\d+)\.(\d+)$','\3',) + $addrdiff
+          $newipaddr = regsubst($mgmtaddress, '^(\d+)\.(\d+)\.(\d+)\.(\d+)$',"\\1.\\2.${netrole}.\\4",)
+          $ifmask = lookup("netcfg_${ifrole}_netmask", String, 'first', '')
+          $ifgw = lookup("netcfg_${ifrole}_gateway", String, 'first', '')
 
-        # check for IPv6 configuration in options for this interface
-        if $ifopts[$ifrole]['ipv6init'] == 'yes' {
-          # Find network and diff from base
-          $ipnetpart6 = lookup("netcfg_${ifrole}_netpart6", String, 'first', '')
-          if String($addrdiff) != '0' {
-            $newipaddr6 = "${ipnetpart6}::${addrdiff}:${ipbyte}"
+          # check for IPv6 configuration in options for this interface
+          if $ifopts[$ifrole]['ipv6init'] == 'yes' {
+            # Find network and diff from base
+            $ipnetpart6 = lookup("netcfg_${ifrole}_netpart6", String, 'first', '')
+            if String($addrdiff) != '0' {
+              $newipaddr6 = "${ipnetpart6}::${addrdiff}:${ipbyte}"
+            }
+            else {
+              $newipaddr6 = "${ipnetpart6}::${ipbyte}"
+            }
+            $ifmask6 = lookup("netcfg_${ifrole}_netmask6", String, 'first', '')
+            $ifgw6 = lookup("netcfg_${ifrole}_gateway6", String, 'first', '')
           }
-          else {
-            $newipaddr6 = "${ipnetpart6}::${ipbyte}"
-          }
-          $ifmask6 = lookup("netcfg_${ifrole}_netmask6", String, 'first', '')
-          $ifgw6 = lookup("netcfg_${ifrole}_gateway6", String, 'first', '')
-        }
 
-        # Check for teaming or bonding
-        if (($ifname[0,4] == 'team') or ($ifname[0,4] == 'bond')) and !('.' in $ifname) {
-          # Determine type and create slave interfaces
-          $iftype = $ifname[0,4]
-          $ifslaves = lookup('profile::base::network::network_auto_bonding', Hash, 'first', {})
-          $ifslaves[$ifrole].each |$slave, $slaveopts| {
-            file { "ifcfg-${slave})":
-              ensure  => file,
-              content => template("${module_name}/network/auto-if-${iftype}slave.erb"),
-              path    => "/etc/sysconfig/network-scripts/ifcfg-${slave}",
+          # Check for teaming or bonding
+          if (($ifname[0,4] == 'team') or ($ifname[0,4] == 'bond')) and !('.' in $ifname) {
+            # Determine type and create slave interfaces
+            $iftype = $ifname[0,4]
+            $ifslaves = lookup('profile::base::network::network_auto_bonding', Hash, 'first', {})
+            $ifslaves[$ifrole].each |$slave, $slaveopts| {
+              file { "ifcfg-${slave})":
+                ensure  => file,
+                content => template("${module_name}/network/auto-if-${iftype}slave.erb"),
+                path    => "/etc/sysconfig/network-scripts/ifcfg-${slave}",
+              }
             }
           }
-        }
 
-        # check for VLAN interface
-        if '.' in $ifname {
-          $ifvlan = "yes"
-        }
+          # check for VLAN interface
+          if '.' in $ifname {
+            $ifvlan = "yes"
+          }
 
-        # Write interface file
-        file { "ifcfg-${ifname})":
-          ensure  => file,
-          content => template("${module_name}/network/auto-if.erb"),
-          path    => "/etc/sysconfig/network-scripts/ifcfg-${ifname}",
+          # Write interface file
+          file { "ifcfg-${ifname})":
+            ensure  => file,
+            content => template("${module_name}/network/auto-if.erb"),
+            path    => "/etc/sysconfig/network-scripts/ifcfg-${ifname}",
+          }
         }
       }
     }
   }
-}
 
   # Create extra routes, tables, rules on ifup
   create_resources(network::mroute, lookup('profile::base::network::mroute', Hash, 'deep', {}))

--- a/profile/manifests/base/network.pp
+++ b/profile/manifests/base/network.pp
@@ -180,7 +180,7 @@ class profile::base::network(
           $iftype = $ifname[0,4]
           $ifslaves = lookup('profile::base::network::network_auto_bonding', Hash, 'first', {})
           $ifslaves[$ifrole].each |$slave, $slaveopts| {
-            file { "jalla-${slave})":
+            file { "ifcfg-${slave})":
               ensure  => file,
               content => template("${module_name}/network/auto-if-${iftype}slave.erb"),
               path    => "/etc/sysconfig/network-scripts/ifcfg-${slave}",
@@ -194,7 +194,7 @@ class profile::base::network(
         }
 
         # Write interface file
-        file { "jalla-${ifname})":
+        file { "ifcfg-${ifname})":
           ensure  => file,
           content => template("${module_name}/network/auto-if.erb"),
           path    => "/etc/sysconfig/network-scripts/ifcfg-${ifname}",

--- a/profile/templates/network/auto-if-bondslave.erb
+++ b/profile/templates/network/auto-if-bondslave.erb
@@ -1,0 +1,12 @@
+DEVICE='<%= @slave %>'
+BOOTPROTO='none'
+ONBOOT='yes'
+TYPE='Ethernet'
+USERCTL='no'
+PEERDNS='no'
+PEERNTP='no'
+MASTER='<%= @ifname %>'
+SLAVE='yes'
+<% if @slaveopts.each do |key, value| -%>
+<%= key.upcase %>='<%= value %>'
+<% end -%><% end -%>

--- a/profile/templates/network/auto-if-teamslave.erb
+++ b/profile/templates/network/auto-if-teamslave.erb
@@ -1,0 +1,12 @@
+DEVICE='<%= @slave %>'
+BOOTPROTO='none'
+ONBOOT='yes'
+TYPE='Ethernet'
+USERCTL='no'
+PEERDNS='no'
+PEERNTP='no'
+TEAM_MASTER='<%= @ifname %>'
+DEVICETYPE='TeamPort'
+<% @slaveopts.each do |key, value| -%>
+<%= key.upcase %>='<%= value %>'
+<% end -%>

--- a/profile/templates/network/auto-if.erb
+++ b/profile/templates/network/auto-if.erb
@@ -1,0 +1,21 @@
+DEVICE='<%= @ifname %>'
+BOOTPROTO='none'
+ONBOOT='yes'
+TYPE='Ethernet'
+USERCTL='no'
+IPADDR='<%= @newipaddr %>'
+NETMASK='<%= @ifmask %>'
+GATEWAY='<%= @ifgw -%>'<% @ifopts.each do |key, hash| -%>
+<% if key == @ifrole -%> 
+<% hash.each do |key,value| -%>
+<%= key.upcase %>='<%= value %>'
+<% end -%><% end -%><% end -%>
+<% if @newipaddr6 -%>
+IPV6ADDR='<%= @newipaddr6 %>/<%= @ifmask6 %>'
+<% end -%>
+<% if @ifgw6 -%>
+IPV6_DEFAULTGW='<%= @ifgw6 %>'
+<% end -%>
+<% if @ifvlan -%>
+VLAN='<%= @ifvlan %>'
+<% end -%>


### PR DESCRIPTION
These changes allows automatic creation of network interface files on nodes given

1) Platform is RedHat family
2) an A DNS record is defined in common for the node
3) network::interfaces_hash is not set (in node file)

Supported types:
1) basic interfaces
2) teams and their slaves
3) bonds and their slaves
4) VLAN tagged interfaces (for all of the above types)

Which interfaces to be configured is determined by the named_interfaces::config. Additionally the interface must be defined in profile::base::network::network_auto_opts in order to be configured (mgmt and trp are always defined if in network_auto_opts). This is to avoid creation of duplicate interface files because the named_interfaces::config allows different logical constructs (trp, live, ceph etc) to be the same physical interface.

VLAN tagging is determined by the interfaces name itself, if it contains '.'

IPv6 is identified and configured by defining the 'ipv6init' with the value 'yes' in network_auto_opts.

Teams and bonds are simply identified as such if the interface name begins with 'team' or 'bond' and are not defined as VLAN interfaces. Their children are defined by profile::base::network::network_auto_bonding.

Each interface (including slaves) can be given any number of arbitrary parameters, and the parameters can be overridden, except for IP(6) address, mask, gateway and type.
