### PR TITLE
Replace spice with vnc 2

### DIFF
--- a/hieradata/common/modules/nova.yaml
+++ b/hieradata/common/modules/nova.yaml
@@ -151,17 +151,17 @@ nova::nova_public_key:
 
 # console (node: compute)
 # VNC
-#nova::compute::vnc_enabled: true
-#nova::compute::vncserver_proxyclient_address: "%{ipaddress_mgmt1}"
-#nova::compute::vncproxy_host: "console.%{hiera('domain_public')}"
-#nova::compute::vncproxy_protocol: 'https'
-#nova::compute::libvirt::vncserver_listen: "%{ipaddress_mgmt1}"
+nova::compute::vnc_enabled: true
+nova::compute::vncserver_proxyclient_address: "%{ipaddress_mgmt1}"
+nova::compute::vncproxy_host: "console.%{hiera('domain_public')}"
+nova::compute::vncproxy_protocol: 'https'
+nova::compute::libvirt::vncserver_listen: "%{ipaddress_mgmt1}"
 # SPICE
-nova::compute::vnc_enabled:                       false
-nova::compute::spice::server_proxyclient_address: "%{::ipaddress_trp1}"
-nova::compute::spice::proxy_host:                 "console.%{hiera('domain_public')}"
-nova::compute::spice::proxy_protocol:             'https'
-nova::compute::spice::server_listen:              "%{::ipaddress_trp1}"
+# nova::compute::vnc_enabled:                       false
+# nova::compute::spice::server_proxyclient_address: "%{::ipaddress_trp1}"
+# nova::compute::spice::proxy_host:                 "console.%{hiera('domain_public')}"
+# nova::compute::spice::proxy_protocol:             'https'
+# nova::compute::spice::server_listen:              "%{::ipaddress_trp1}"
 
 # for telemetry reporting
 nova::compute::instance_usage_audit:              true

--- a/hieradata/common/roles/api.yaml
+++ b/hieradata/common/roles/api.yaml
@@ -31,7 +31,7 @@ profile::base::network::manage_dummy:                               true
 profile::highavailability::loadbalancing::haproxy::manage_haproxy:  true
 profile::highavailability::loadbalancing::haproxy::manage_firewall: true
 profile::highavailability::loadbalancing::haproxy::firewall_ports:
-  public:    ['80', '443', '5000', '8041', '8774', '8776', '9292', '9696', '6082', '8080', '8778', '9001']
+  public:    ['80', '443', '5000', '8041', '8774', '8776', '9292', '9696', '6080', '8080', '8778', '9001']
   internal:  ['5000', '8041', '8774', '8776', '9292', '9696', '35357', '8080', '8778', '9001']
   mgmt:      ['9000']
   limited:   []
@@ -79,7 +79,7 @@ profile::highavailability::loadbalancing::haproxy::haproxy_mapfile:
       - "status.%{hiera('domain_frontend')}":               'bk_status'
       - "status-%{::location}.%{hiera('domain_frontend')}": 'bk_status'
       - "request.%{hiera('domain_frontend')}":              'bk_request'
-      - "console.%{hiera('domain_public')}:6082":           'bk_console'
+      - "console.%{hiera('domain_public')}:6080":           'bk_console'
       - "access.%{hiera('domain_frontend')}":               'bk_access'
       - "access-%{::location}.%{hiera('domain_frontend')}": 'bk_access'
       - "report.%{hiera('domain_frontend')}":               'bk_report'
@@ -113,7 +113,7 @@ profile::highavailability::loadbalancing::haproxy::haproxy_frontends:
       "%{::ipaddress_public1}:9001":  ['ssl', 'crt', "%{hiera('star_api_ssl_pem')}"]
       "%{::ipaddress_public1}:443":   ['ssl', 'crt', "%{hiera('status_ssl_pem')}"]
       "%{::ipaddress_public1}:80":    []
-      "%{::ipaddress_public1}:6082":  ['ssl', 'crt', "%{hiera('console_ssl_pem')}"]
+      "%{::ipaddress_public1}:6080":  ['ssl', 'crt', "%{hiera('console_ssl_pem')}"]
     options:
       - capture:        'request header Host len 64' #for debug
       - http-request:
@@ -309,7 +309,7 @@ profile::highavailability::loadbalancing::haproxy::haproxy_balancermembers:
     listening_service:  'bk_console'
     server_names:       "%{alias('console__backend__names')}"
     ipaddresses:        "%{alias('console__backend__ips')}"
-    ports:              '6082'
+    ports:              '6080'
     options:            'check'
   access:
     listening_service:  'bk_access'
@@ -361,7 +361,7 @@ profile::base::selinux::ports:
   console-http:
     seltype:  'http_port_t'
     protocol: 'tcp'
-    port:     6082
+    port:     6080
   dns-http:
     seltype:  'http_port_t'
     protocol: 'tcp'

--- a/hieradata/common/roles/console.yaml
+++ b/hieradata/common/roles/console.yaml
@@ -13,7 +13,7 @@ profile::base::common::packages:
 
 profile::base::network::manage_dummy:                       true
 profile::openstack::compute::consoleproxy::manage_firewall: true
-profile::openstack::compute::consoleproxy::spice:           true
+profile::openstack::compute::consoleproxy::spice:           false
 profile::openstack::compute::consoleproxy::firewall_extras:
   source: "%{::network_trp1}/%{::netmask_trp1}"
 
@@ -27,4 +27,4 @@ profile::base::yumrepo::repo_hash:
     ensure: present
   epel: # should be absent when using RDO, but whitelist can also work
     ensure:   present
-    includepkgs: 'htop bash-completion-extras spice-html5'
+    includepkgs: 'htop bash-completion-extras'

--- a/hieradata/common/roles/monitor.yaml
+++ b/hieradata/common/roles/monitor.yaml
@@ -185,7 +185,7 @@ profile::monitoring::sensu::agent::checks:
     interval:     60
     subscribers:  ['checks']
   'cert-check-console':
-    command:      "check-https-cert.rb -c 10 -w 20 -u https://%{hiera('public__address__console')}:6082 %{hiera('sensu_ssl_cachain')}"
+    command:      "check-https-cert.rb -c 10 -w 20 -u https://%{hiera('public__address__console')}:6080 %{hiera('sensu_ssl_cachain')}"
     interval:     60
     subscribers:  ['checks']
   'metrics-rabbitmq-overview':

--- a/hieradata/test01/modules/nova.yaml
+++ b/hieradata/test01/modules/nova.yaml
@@ -11,15 +11,3 @@ nova::compute::libvirt::libvirt_disk_cachemodes:
 # set lowest common denominator for live migration compat
 nova::compute::libvirt::libvirt_cpu_mode:  'custom'
 nova::compute::libvirt::libvirt_cpu_model: 'Westmere'
-
-nova::compute::vnc_enabled: true
-nova::compute::vncserver_proxyclient_address: "%{ipaddress_mgmt1}"
-nova::compute::vncproxy_host: "console.%{hiera('domain_public')}"
-nova::compute::vncproxy_protocol: 'https'
-nova::compute::libvirt::vncserver_listen: "%{ipaddress_mgmt1}"
-# SPICE
-# nova::compute::vnc_enabled:                       false
-# nova::compute::spice::server_proxyclient_address: "%{::ipaddress_trp1}"
-# nova::compute::spice::proxy_host:                 "console.%{hiera('domain_public')}"
-# nova::compute::spice::proxy_protocol:             'https'
-# nova::compute::spice::server_listen:              "%{::ipaddress_trp1}"

--- a/hieradata/test01/roles/console.yaml
+++ b/hieradata/test01/roles/console.yaml
@@ -8,5 +8,3 @@ profile::openstack::compute::consoleproxy::allow_from_network:
   - '129.240.202.12/32' # trond
   - '129.240.6.14/32'   # mikael
   - '129.240.202.64/32' # tannaz
-
-profile::openstack::compute::consoleproxy::spice: false


### PR DESCRIPTION
Prøver igjen.

Dette bytter ut VNC med Spice, og vil således bruke 6080 i stedet for 6082 som port. Se gjerne til at jeg har fått med meg alt.