### PR TITLE
Updated ceph storage secrets vars

### DIFF
--- a/hieradata/common/modules/ceph.yaml
+++ b/hieradata/common/modules/ceph.yaml
@@ -20,7 +20,7 @@ ceph::profile::params::public_addr:                 "%{ipaddress_trp1}" # Needed
 ##ceph::profile::params::mon_keyring: '/etc/ceph/ceph.mon.keyring'
 ceph::profile::params::client_keys:
   'client.admin':
-    secret: "%{hiera('client_admin::secret')}"
+    secret: "%{hiera('ceph_storage_client_admin_key')}"
     mode: '0600'
     user: 'ceph'
     group: 'ceph'
@@ -29,29 +29,29 @@ ceph::profile::params::client_keys:
     cap_mds: 'allow *'
     cap_mgr: 'allow *'
   'client.bootstrap-osd':
-    secret: "%{hiera('client_bootstrap-osd::secret')}"
+    secret: "%{hiera('ceph_storage_client_bootstrap_osd_key')}"
     keyring_path: '/var/lib/ceph/bootstrap-osd/ceph.keyring'
     cap_mon: 'allow profile bootstrap-osd'
   'client.bootstrap-mds':
-    secret: "%{hiera('client_bootstrap-mds::secret')}"
+    secret: "%{hiera('ceph_storage_client_bootstrap_mds_key')}"
     keyring_path: '/var/lib/ceph/bootstrap-mds/ceph.keyring'
     cap_mon: 'allow profile bootstrap-mds'
   'client.glance':
-    secret: "%{hiera('client_glance::secret')}"
+    secret: "%{hiera('ceph_storage_client_glance_key')}"
     mode: '0600'
     user: 'glance'
     group: 'glance'
     cap_mon: 'profile rbd'
     cap_osd: 'profile rbd pool=images'
   'client.cinder':
-    secret: "%{hiera('client_cinder::secret')}"
+    secret: "%{hiera('ceph_storage_client_cinder_key')}"
     mode: '0600'
     user: 'cinder'
     group: 'cinder'
     cap_mon: 'profile rbd'
     cap_osd: 'profile rbd pool=volumes, profile rbd pool=vms, profile rbd pool=images'
   'client.cinder-hdd-ec':
-    secret: "%{hiera('client_cinder::secret')}"
+    secret: "%{hiera('ceph_storage_client_cinder_key')}"
     mode: '0600'
     user: 'cinder'
     group: 'cinder'

--- a/hieradata/common/roles/cephmds.yaml
+++ b/hieradata/common/roles/cephmds.yaml
@@ -3,6 +3,10 @@ include:
   default:
     - profile::storage::cephmds
 
+# ceph config keys and ids
+ceph::profile::params::fsid:        "%{hiera('ceph_storage_client_fsid')}"
+ceph::profile::params::mds_key:     "%{hiera('ceph_storage_client_mds_key')}"
+
 profile::storage::cephmds::manage_firewall:  true
 
 profile::base::common::packages:
@@ -24,12 +28,12 @@ profile::base::yumrepo::repo_hash:
 
 ceph::profile::params::client_keys:
   'client.admin':
-    secret: "%{hiera('client_admin::secret')}"
+    secret: "%{hiera('ceph_storage_client_admin_key')}"
     mode: '0600'
     user: 'ceph'
     group: 'ceph'
     cap_mds: 'allow *'
   'client.bootstrap-mds':
-    secret: "%{hiera('client_bootstrap-mds::secret')}"
+    secret: "%{hiera('ceph_storage_client_bootstrap_mds_key')}"
     keyring_path: '/var/lib/ceph/bootstrap-mds/ceph.keyring'
     cap_mon: 'allow profile bootstrap-mds'

--- a/hieradata/common/roles/cephmon.yaml
+++ b/hieradata/common/roles/cephmon.yaml
@@ -6,7 +6,11 @@ include:
   bootstrap:
     - profile::storage::cephmon_firewall
 
-profile::storage::cephmon::manage_dashboard:                    false
+# ceph config keys
+ceph::profile::params::mon_key:     "%{hiera('ceph_storage_client_mon_key')}"
+ceph::profile::params::mgr_key:     "%{hiera('ceph_storage_client_mgr_key')}"
+
+profile::storage::cephmon::manage_dashboard:                    true
 profile::storage::cephmon_firewall::manage_firewall:            true
 profile::storage::cephmon_firewall::manage_dashboard_firewall:  "%{hiera('profile::storage::cephmon::manage_dashboard')}"
 profile::storage::cephmon::dashboard_password:                  "pass123"
@@ -45,6 +49,3 @@ profile::monitoring::sensu::agent::plugins:
 profile::base::yumrepo::repo_hash:
   ceph-%{hiera('ceph_version')}:
     ensure: present
-
-# enable Ceph dashboard
-profile::storage::cephmon::manage_dashboard:                    true

--- a/hieradata/common/roles/compute.yaml
+++ b/hieradata/common/roles/compute.yaml
@@ -193,7 +193,7 @@ profile::base::yumrepo::repo_hash:
 # Compute nodes need only admin and cinder keys
 ceph::profile::params::client_keys:
   'client.admin':
-    secret: "%{hiera('client_admin::secret')}"
+    secret: "%{hiera('ceph_storage_client_admin_key')}"
     mode: '0600'
     user: 'ceph'
     group: 'ceph'
@@ -201,14 +201,14 @@ ceph::profile::params::client_keys:
     cap_osd: 'allow *'
     cap_mds: 'allow *'
   'client.cinder':
-    secret: "%{hiera('client_cinder::secret')}"
+    secret: "%{hiera('ceph_storage_client_cinder_key')}"
     mode: '0600'
     user: 'nova'
     group: 'nova'
     cap_mon: 'profile rbd'
     cap_osd: 'profile rbd pool=volumes, profile rbd pool=vms, profile rbd pool=images'
   'client.cinder-hdd-ec':
-    secret: "%{hiera('client_cinder::secret')}"
+    secret: "%{hiera('ceph_storage_client_cinder_key')}"
     mode: '0600'
     user: 'cinder'
     group: 'cinder'

--- a/hieradata/common/roles/image.yaml
+++ b/hieradata/common/roles/image.yaml
@@ -36,7 +36,7 @@ profile::base::yumrepo::repo_hash:
 # Image nodes need only glance key
 ceph::profile::params::client_keys:
   'client.glance':
-    secret: "%{hiera('client_glance::secret')}"
+    secret: "%{hiera('ceph_storage_client_glance_key')}"
     mode: '0600'
     user: 'glance'
     group: 'glance'

--- a/hieradata/common/roles/volume.yaml
+++ b/hieradata/common/roles/volume.yaml
@@ -85,21 +85,21 @@ profile::base::yumrepo::repo_hash:
 # Volume nodes need only cinder and glance keys
 ceph::profile::params::client_keys:
   'client.cinder':
-    secret: "%{hiera('client_cinder::secret')}"
+    secret: "%{hiera('ceph_storage_client_cinder_key')}"
     mode: '0600'
     user: 'cinder'
     group: 'cinder'
     cap_mon: 'profile rbd'
     cap_osd: 'profile rbd pool=volumes, profile rbd pool=vms, profile rbd pool=images'
   'client.glance':
-    secret: "%{hiera('client_glance::secret')}"
+    secret: "%{hiera('ceph_storage_client_glance_key')}"
     mode: '0600'
     user: 'cinder'
     group: 'cinder'
     cap_mon: 'profile rbd'
     cap_osd: 'profile rbd pool=images'
   'client.cinder-hdd-ec':
-    secret: "%{hiera('client_cinder::secret')}"
+    secret: "%{hiera('ceph_storage_client_cinder_key')}"
     mode: '0600'
     user: 'cinder'
     group: 'cinder'

--- a/hieradata/local2/common.yaml
+++ b/hieradata/local2/common.yaml
@@ -135,23 +135,6 @@ profile::network::services::dns_records:
 ## Secret data which for other environments are stored ooutside of this data tree
 #
 
-# ceph.yaml
-ceph::profile::params::mon_key:                     'AQATGHJTUCBqIBAA7M2yafV1xctn1pgr3GcKPg=='
-client_admin::secret:                               'AQBMGHJTkC8HKhAAJ7NH255wYypgm1oVuV41MA=='
-client_bootstrap-osd::secret:                       'AQARG3JTsDDEHhAAVinHPiqvJkUi5Mww/URupw=='
-client_bootstrap-mds::secret:                       'AQCztJdSyNb0NBAASA2yPZPuwXeIQnDJ9O8gVw=='
-client_glance::secret:                              'AQBGJ8dWKhgcNhAA+VU0GlKHcRLJSsJ8WouuSQ=='
-client_volumes::secret:                             'AQA4MPZTOGU0ARAAXH9a0fXxVq0X25n2yPREDw=='
-client_cinder::secret:                              'AQBypF1V2JYiChAA2qYbjM6jbXJBMmpXPkvwBg=='
-
-# FIXME: puppet 3 legacy params
-client.admin::secret:                               'AQBMGHJTkC8HKhAAJ7NH255wYypgm1oVuV41MA=='
-client.bootstrap-osd::secret:                       'AQARG3JTsDDEHhAAVinHPiqvJkUi5Mww/URupw=='
-client.bootstrap-mds::secret:                       'AQCztJdSyNb0NBAASA2yPZPuwXeIQnDJ9O8gVw=='
-client.glance::secret:                              'AQBGJ8dWKhgcNhAA+VU0GlKHcRLJSsJ8WouuSQ=='
-client.volumes::secret:                             'AQA4MPZTOGU0ARAAXH9a0fXxVq0X25n2yPREDw=='
-client.cinder::secret:                              'AQBypF1V2JYiChAA2qYbjM6jbXJBMmpXPkvwBg=='
-
 # service user api password
 keystone_admin_password:                            'admin_pass'
 cinder_api_password:                                'cinder_pass'

--- a/hieradata/local3/common.yaml
+++ b/hieradata/local3/common.yaml
@@ -146,15 +146,15 @@ profile::openstack::image::api::backend: 'rbd'
 #
 
 # ceph.yaml
-ceph::profile::params::fsid:                        'cc91fb3d-6b18-4640-9743-1b9bb6b97d86'
-ceph::profile::params::mgr_key:                     'AQAOCudaiWQmKxAAjj6i10gfW887T2dYOCNLvw=='
-ceph::profile::params::mon_key:                     'AQBiBuda74XZIhAANsxa31M5wDiLenqEMqjH6g=='
-ceph::profile::params::mds_key:                     'AQAei5dbrrNpDhAA7251s/ZxmXNZvvV0pSOIxA=='
-client_admin::secret:                               'AQCKBudajsWkDxAAbPpCrtTiZrwhjX0VsG7i6Q=='
-client_bootstrap-osd::secret:                       'AQCpBudas7f5CRAAoWjwsLyPafAoLAOVA0IvDQ=='
-client_bootstrap-mds::secret:                       'AQC9B+daWlaNCRAA1thFoG/FasdX4hy8QyYMLw=='
-client_glance::secret:                              'AQDHCOdar7nQMRAAZ2l4hxy7PHWKiT2bXAGXEg=='
-client_cinder::secret:                              'AQDvCOdaJ35QHRAAm1wr52RrldB4TareRfKdww=='
+ceph_storage_client_fsid:                           'cc91fb3d-6b18-4640-9743-1b9bb6b97d86'
+ceph_storage_client_mgr_key:                        'AQAOCudaiWQmKxAAjj6i10gfW887T2dYOCNLvw=='
+ceph_storage_client_mon_key:                        'AQBiBuda74XZIhAANsxa31M5wDiLenqEMqjH6g=='
+ceph_storage_client_mds_key:                        'AQAei5dbrrNpDhAA7251s/ZxmXNZvvV0pSOIxA=='
+ceph_storage_client_admin_key:                      'AQCKBudajsWkDxAAbPpCrtTiZrwhjX0VsG7i6Q=='
+ceph_storage_client_bootstrap_osd_key:              'AQCpBudas7f5CRAAoWjwsLyPafAoLAOVA0IvDQ=='
+ceph_storage_client_bootstrap_mds_key:              'AQC9B+daWlaNCRAA1thFoG/FasdX4hy8QyYMLw=='
+ceph_storage_client_glance_key:                     'AQDHCOdar7nQMRAAZ2l4hxy7PHWKiT2bXAGXEg=='
+ceph_storage_client_cinder_key:                     'AQDvCOdaJ35QHRAAm1wr52RrldB4TareRfKdww=='
 libvirt_rbd_secret_uuid:                            '38d88163-3058-436e-a214-085214c6fa78'
 
 # service user api password


### PR DESCRIPTION
Testet på følgende måte:
* kjørt puppet på cephmon og storage og ingenting endrer seg som forventet
* slettet alle nøkler i /etc/ceph (pluss bootstrap-osd i /var/lib/ceph) på cephmon og storage. Deretter kjørt puppet og nøkler kom tilbake
* slettet nøkler på volume-01 og image-01 og kjørt puppet og får nøkler tilbake
* ceph status har ikke rapportert nye feil etter deployment

Prøvde så å teste med terraform og ansible, men etter 10 min så kommer instansen opp uten nett. Tipper det ikke er relatert til ceph.
