### PR TITLE
Self-reporting imagebuilder scripts

### DIFF
--- a/profile/manifests/application/builder.pp
+++ b/profile/manifests/application/builder.pp
@@ -65,6 +65,12 @@ class profile::application::builder (
     ensure => directory,
     owner  => $user,
     group  => $group
+  } ->
+  file { '/var/log/imagebuilder':
+    ensure => directory,
+    user   => $user,
+    group  => $group,
+    mode   => '0755'
   }
 
   create_resources('profile::application::builder::jobs', lookup('profile::application::builder::images', Hash, 'deep', {}))

--- a/profile/manifests/application/builder.pp
+++ b/profile/manifests/application/builder.pp
@@ -68,7 +68,7 @@ class profile::application::builder (
   } ->
   file { '/var/log/imagebuilder':
     ensure => directory,
-    user   => $user,
+    owner  => $user,
     group  => $group,
     mode   => '0755'
   }

--- a/profile/manifests/application/builder/jobs.pp
+++ b/profile/manifests/application/builder/jobs.pp
@@ -20,13 +20,6 @@ define profile::application::builder::jobs(
 
   $hour = fqdn_rand(23, $name)
 
-  file { '/var/log/imagebuilder':
-    ensure => directory,
-    user   => $user,
-    group  => $group,
-    mode   => '0755'
-  }
-
   file { "/home/${user}/build_scripts/${name}":
     ensure  => $ensure,
     content => template("${module_name}/application/builder/build_script.erb"),

--- a/profile/manifests/application/builder/jobs.pp
+++ b/profile/manifests/application/builder/jobs.pp
@@ -29,13 +29,14 @@ define profile::application::builder::jobs(
     require => File["/home/${user}/build_scripts"]
   } ->
   cron { $name:
-    ensure  => $ensure,
+    ensure      => $ensure,
     # Write to imagebuilder report
-    command => "/home/${user}/build_scripts/${name} || jq -n '{\"result\": \"failed\"}' >> /var/log/imagebuilder/${name}-report.jsonl",
-    user    => $user,
-    weekday => 'Wednesday',
-    hour    => $hour,
-    minute  => 0
+    command     => "/home/${user}/build_scripts/${name} || jq -n '{\"result\": \"failed\"}' >> /var/log/imagebuilder/${name}-report.jsonl",
+    user        => $user,
+    weekday     => 'Wednesday',
+    hour        => $hour,
+    minute      => 0,
+    environment => 'IMAGEBUILDER_REPORT=true'
   }
 
 }

--- a/profile/templates/application/builder/build_script.erb
+++ b/profile/templates/application/builder/build_script.erb
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -x
+set -ux
 
 . <%= @rc_file %>
 
@@ -7,6 +7,7 @@ set -x
 # write a machine-readable report of the last build in JSONL format. There will
 # also be a dated log file in plain text containing the raw output of
 # imagebuilder.
+gen_report="${IMAGEBUILDER_REPORT:-false}"
 plain_log=/var/log/imagebuilder/<%= @name -%>-build-$(date +"%Y%m%d").log
 json_report=/var/log/imagebuilder/<%= @name %>-report.jsonl
 
@@ -39,9 +40,9 @@ imagebuilder_ec=$?
 
 # We set the shell's error handling options here to avoid exiting before a
 # report has been written
-set -euo pipefail
+set -eo pipefail
 
-if [ $IMAGEBUILDER_REPORT = "true" ]; then
+if [ $gen_report == "true" ]; then
   # Write imagebuilder's exit code to imagebuilder report
   jq -Rn '{"result_imagebuilder": input}' <<< $imagebuilder_ec > $json_report
 
@@ -74,7 +75,7 @@ fi
 # Remove old images, always keeping the two most recent
 find /opt/images/public_builds/ -type f -iname <%= @name %>\* | sort -r | tail -n +3 | xargs rm -f
 
-if [ $IMAGEBUILDER_REPORT = "true" ]; then
+if [ $gen_report == "true" ]; then
   # If we make it to here we assume the build has been successful
   jq -n '{"result": "success"}' >> $json_report
 fi

--- a/profile/templates/application/builder/build_script.erb
+++ b/profile/templates/application/builder/build_script.erb
@@ -3,9 +3,10 @@ set -x
 
 . <%= @rc_file %>
 
-# Each build script will write a machine-readable report of the last build
-# in JSONL format. There will also be a dated log file in plain text containing
-# the raw output of imagebuilder.
+# If the environment variable IMAGEBUILDER_REPORT is true each build script will
+# write a machine-readable report of the last build in JSONL format. There will
+# also be a dated log file in plain text containing the raw output of
+# imagebuilder.
 plain_log=/var/log/imagebuilder/<%= @name -%>-build-$(date +"%Y%m%d").log
 json_report=/var/log/imagebuilder/<%= @name %>-report.jsonl
 
@@ -40,13 +41,15 @@ imagebuilder_ec=$?
 # report has been written
 set -euo pipefail
 
-# Write imagebuilder's exit code to imagebuilder report
-jq -Rn '{"result_imagebuilder": input}' <<< $imagebuilder_ec > $json_report
+if [ $IMAGEBUILDER_REPORT = "true" ]; then
+  # Write imagebuilder's exit code to imagebuilder report
+  jq -Rn '{"result_imagebuilder": input}' <<< $imagebuilder_ec > $json_report
 
-# Convert newlines in imagebuilder's output into to literal \n for a
-# single-line value in the report
-awk '{printf "%s\\n", $0}' $plain_log \
-| jq -R '{"output_imagebuilder": .}' >> $json_report
+  # Convert newlines in imagebuilder's output into to literal \n for a
+  # single-line value in the report
+  awk '{printf "%s\\n", $0}' $plain_log \
+  | jq -R '{"output_imagebuilder": .}' >> $json_report
+fi
 
 # Non-zero exit codes from imagebuilder must be handled manually
 if [ $imagebuilder_ec -ne 0 ]; then
@@ -71,5 +74,7 @@ fi
 # Remove old images, always keeping the two most recent
 find /opt/images/public_builds/ -type f -iname <%= @name %>\* | sort -r | tail -n +3 | xargs rm -f
 
-# If we make it to here we assume the build has been successful
-jq -n '{"result": "success"}' >> $json_report
+if [ $IMAGEBUILDER_REPORT = "true" ]; then
+  # If we make it to here we assume the build has been successful
+  jq -n '{"result": "success"}' >> $json_report
+fi

--- a/profile/templates/application/builder/build_script.erb
+++ b/profile/templates/application/builder/build_script.erb
@@ -1,10 +1,13 @@
 #!/bin/bash
-set -euxo pipefail
+set -x
 
 . <%= @rc_file %>
 
-# FIXME: Debug user
-touch /tmp/$(date +"%Y-%m-%d_%H%M")
+# Each build script will write a machine-readable report of the last build
+# in JSONL format. There will also be a dated log file in plain text containing
+# the raw output of imagebuilder.
+plain_log=/var/log/imagebuilder/<%= @name -%>-build-$(date +"%Y%m%d").log
+json_report=/var/log/imagebuilder/<%= @name %>-report.jsonl
 
 # Hack to find packer in /usr/bin/ when run as root
 export PATH=/usr/bin:/usr/local/bin:/bin:/usr/local/sbin:/usr/sbin
@@ -29,7 +32,26 @@ export PATH=/usr/bin:/usr/local/bin:/bin:/usr/local/sbin:/usr/sbin
 -d \
 -x \
 -v \
---debug
+--debug &> $plain_log
+
+imagebuilder_ec=$?
+
+# We set the shell's error handling options here to avoid exiting before a
+# report has been written
+set -euo pipefail
+
+# Write imagebuilder's exit code to imagebuilder report
+jq -Rn '{"result_imagebuilder": input}' <<< $imagebuilder_ec > $json_report
+
+# Convert newlines in imagebuilder's output into to literal \n for a
+# single-line value in the report
+awk '{printf "%s\\n", $0}' $plain_log \
+| jq -R '{"output_imagebuilder": .}' >> $json_report
+
+# Non-zero exit codes from imagebuilder must be handled manually
+if [ $imagebuilder_ec -ne 0 ]; then
+  exit 1
+fi
 
 # Compress image
 filename=/opt/images/public_builds/<%= @name %>-$(date +"%Y%m%d").qcow2
@@ -48,3 +70,6 @@ fi
 
 # Remove old images, always keeping the two most recent
 find /opt/images/public_builds/ -type f -iname <%= @name %>\* | sort -r | tail -n +3 | xargs rm -f
+
+# If we make it to here we assume the build has been successful
+jq -n '{"result": "success"}' >> $json_report


### PR DESCRIPTION
I stedet for å logge til cronlogg vil alle scriptene skrive en individuell rapport i JSONL (JSON Lines) som lagres til /var/log/imagebuilder/<navn>-report.jsonl. Denne inneholder exitcode fra imagebuilder-pipeline'en (inkl xargs sin), output fra imagebuilder og et sluttresultat som baseres på om hele scriptet har kjørt uten feil eller ikke. En rapport overskrives for hver bygging så den kan overvåkes som en tilstand av Sensu. I tillegg omdirigeres output fra imagebuilder-kommandoen til en datert fil i ren tekst.

Rapporten skrives kun dersom miljøvariabelen IMAGEBUILDER_REPORT har verdien "true", som settes i crontab. Dette er for å ikke ende opp med en brukket rapport om en kjører scriptene manuelt. imagebuilder output i ren tekst skrives alltid (periodisk opprydding av disse filene implementeres sammen med de andre oppryddingsjobbene vi skal lage).

Siden alt gjøres vha Bash og jq er det noen hacks som kanskje ikke er veldig intuitive, men jeg har forsøkt å kommentere disse i scriptene. Spør hvis det er noe.