### PR TITLE
Reconfigure switches for new uplink

### DIFF
--- a/hieradata/nodes/osl/osl-torack-01.yaml
+++ b/hieradata/nodes/osl/osl-torack-01.yaml
@@ -332,16 +332,17 @@ frrouting::frrouting::zebra_interfaces:
     - 'link-detect'
 
 frrouting::frrouting::zebra_ip6_routes:
-  - '::/0 fd32:18:228::2'
   - '2001:700:2:8200::/64 Null0'
   - '2001:700:2:8201::/64 Null0'
   - '2001:700:2:82ff::12/128 fd32::12'
   - '2001:700:2:82ff::251/128 fd32::16'
   - '2001:700:2:82ff::256/128 fd32::34'
 frrouting::frrouting::zebra_ip_routes:
-  - '0.0.0.0/0 172.18.228.2'
   - '10.0.0.0/8 Null0'
   - '158.37.63.0/24 Null0'
+  - '158.39.48.0/24 Null0'
+  - '158.39.75.0/24 Null0'
+  - '158.39.200.0/24 Null0'
   - '158.37.63.248/32 172.18.32.26'
   - '158.39.75.248/32 172.18.32.27'
   - '158.37.63.249/32 172.18.32.41'
@@ -349,9 +350,6 @@ frrouting::frrouting::zebra_ip_routes:
   - '158.37.63.251/32 172.18.32.16'
   - '158.37.63.253/32 172.18.32.12'
   - '158.37.63.254/32 172.18.32.51'
-  - '158.39.48.0/24 Null0'
-  - '158.39.75.0/24 Null0'
-  - '158.39.200.0/24 Null0'
 
 frrouting::frrouting::zebra_generic_options:
   'ip':
@@ -361,14 +359,16 @@ frrouting::frrouting::zebra_generic_options:
 
 frrouting::frrouting::bgp_neighbors:
   - '158.36.4.98 remote-as 224'
-#  - '158.36.4.98 bfd 5 500 500'
+  - '158.36.4.98 bfd 5 500 500'
   - '158.36.4.98 soft-reconfiguration inbound'
   - '158.36.4.98 prefix-list uninett-routes-in in'
   - '158.36.4.98 prefix-list uninett-routes-out out'
   - '2001:700:0:8105:: remote-as 224'
   - '2001:700:0:8105:: bfd 5 500 500'
   - "172.31.228.2 remote-as %{hiera('bgp_as')}"
-  - '172.31.228.2 soft-reconfiguration inbound'
+  - '172.31.229.2 default-originate'
+  - '172.31.229.2 soft-reconfiguration inbound'
+  - '172.31.229.2 route-map failover-default-route in'
   - "172.18.38.1 remote-as %{hiera('bgp_as')}"
   - '172.18.38.1 soft-reconfiguration inbound'
   - "fd32::6:1 remote-as %{hiera('bgp_as')}"
@@ -393,20 +393,12 @@ frrouting::frrouting::bgp_options:
   - 'bgp bestpath as-path multipath-relax'
 
 frrouting::frrouting::bgp_networks:
-#  - '158.37.63.0/24'
-#  - '158.39.48.0/24'
-#  - '158.39.75.0/24'
+  - '158.37.63.0/24'
+  - '158.39.48.0/24'
+  - '158.39.75.0/24'
   - '158.39.200.0/24'
-#frrouting::frrouting::bgp_networks6:
-#  - '2001:700:2:8200::/56'
-
-frrouting::frrouting::bgp_networks:
-#  -'158.37.63.0/24'
-#  -'158.39.48.0/24'
-#  -'158.39.75.0/24'
-  -'158.39.200.0/24'
-#frrouting::frrouting::bgp_networks6:
-#  - '2001:700:2:8200::/56'
+frrouting::frrouting::bgp_networks6:
+  - '2001:700:2:8200::/56'
 
 frrouting::frrouting::bgp_neighbor_groups:
   'rr-clients':
@@ -416,6 +408,7 @@ frrouting::frrouting::bgp_neighbor_groups:
       - 'route-reflector-client'
       - 'soft-reconfiguration inbound'
       - 'route-map rr-client-allow in'
+      - 'route-map rr-client-allow out'
       - 'bfd'
     'members':
       - '172.18.32.17'
@@ -473,12 +466,16 @@ frrouting::frrouting::bgp_neighbor_groups:
       - '172.18.33.82'
     'options6':
       - 'neighbor rr-clients route-reflector-client'
+      - 'neighbor rr-clients route-map rr-client-allow6 in'
+      - 'neighbor rr-clients route-map rr-client-allow6 out'
       - 'maximum-paths ibgp 3'
       - 'neighbor fd32::6:1 activate'
       - 'neighbor fd32::6:1 soft-reconfiguration inbound'
       - 'neighbor fd32::6:2 activate'
       - 'neighbor fd32::6:2 soft-reconfiguration inbound'
       - 'neighbor fd32:18:228::2 activate'
+      - 'neighbor fd32:18:229::2 route-map failover-default-route6 in'
+      - 'neighbor fd32:18:229::2 default-originate'
       - 'neighbor fd32:18:228::2 soft-reconfiguration inbound'
     'members6':
       - 'fd32::17'
@@ -559,27 +556,24 @@ frrouting::frrouting::bgp_accesslist6:
 frrouting::frrouting::bgp_ip_prefix_list:
   - 'routes-from-leaf1 seq 5 deny any'
   - 'routes-to-leaf1 seq 5 permit 0.0.0.0/0'
-  - 'uninett-routes-in seq 5 deny any' # FIXME
-#  - 'uninett-routes-in seq 5 permit any'
-#  - 'uninett-routes-in seq 10 deny any'
-#  - 'uninett-routes-out seq 5 permit 158.37.63.0/24'
-#  - 'uninett-routes-out seq 6 permit 158.39.48.0/24'
-#  - 'uninett-routes-out seq 7 permit 158.39.75.0/24'
+  - 'uninett-routes-in seq 5 permit any'
+  - 'uninett-routes-in seq 10 deny any'
+  - 'uninett-routes-out seq 5 permit 158.37.63.0/24'
+  - 'uninett-routes-out seq 6 permit 158.39.48.0/24'
+  - 'uninett-routes-out seq 7 permit 158.39.75.0/24'
   - 'uninett-routes-out seq 8 permit 158.39.200.0/24'
   - 'uninett-routes-out seq 10 deny any'
-#  - 'uio-routes-in seq 5 permit 129.177.0.0/16'
+#  - 'uio-routes-in seq 5 permit 129.240.0.0/16'
 #  - 'uio-routes-in seq 10 deny any'
-#  - 'default-route seq 5 permit 0.0.0.0/0'
+  - 'default-route seq 5 permit 0.0.0.0/0'
 frrouting::frrouting::bgp_ipv6_prefix_list:
-  - 'uninett-routes6-in seq 5 deny any' # FIXME
-  - 'uninett-routes6-out seq 10 deny any' # FIXME
-#  - 'uninett-routes6-in seq 5 permit any'
-#  - 'uninett-routes6-in seq 10 deny any'
-#  - 'uninett-routes6-out seq 5 permit 2001:700:2:8200::/56'
-#  - 'uninett-routes6-out seq 10 deny any'
+  - 'uninett-routes6-in seq 5 permit any'
+  - 'uninett-routes6-in seq 10 deny any'
+  - 'uninett-routes6-out seq 5 permit 2001:700:2:8200::/56'
+  - 'uninett-routes6-out seq 10 deny any'
 #  - 'uio-routes-in6 seq 5 permit 2001:700:200::/48'
 #  - 'uio-routes-in6 seq 10 deny any'
-#  - 'default-route6 seq 5 permit ::/0'
+  - 'default-route6 seq 5 permit ::/0'
 
 frrouting::frrouting::bgp_route_maps:
   'rr-client-allow permit 10':

--- a/hieradata/nodes/osl/osl-torack-02.yaml
+++ b/hieradata/nodes/osl/osl-torack-02.yaml
@@ -338,16 +338,17 @@ frrouting::frrouting::zebra_interfaces:
     - 'link-detect'
 
 frrouting::frrouting::zebra_ip6_routes:
-  - '::/0 2001:700:100:aa3::21'
   - '2001:700:2:8200::/64 Null0'
   - '2001:700:2:8201::/64 Null0'
   - '2001:700:2:82ff::12/128 fd32::12'
   - '2001:700:2:82ff::251/128 fd32::16'
   - '2001:700:2:82ff::256/128 fd32::34'
 frrouting::frrouting::zebra_ip_routes:
-  - '0.0.0.0/0 129.240.25.109'
   - '10.0.0.0/8 Null0'
   - '158.37.63.0/24 Null0'
+  - '158.39.48.0/24 Null0'
+  - '158.39.75.0/24 Null0'
+  - '158.39.200.0/24 Null0'
   - '158.37.63.248/32 172.18.32.26'
   - '158.39.75.248/32 172.18.32.27'
   - '158.37.63.249/32 172.18.32.41'
@@ -355,9 +356,6 @@ frrouting::frrouting::zebra_ip_routes:
   - '158.37.63.251/32 172.18.32.16'
   - '158.37.63.253/32 172.18.32.12'
   - '158.37.63.254/32 172.18.32.51'
-  - '158.39.48.0/24 Null0'
-  - '158.39.75.0/24 Null0'
-  - '158.39.200.0/24 Null0'
 
 frrouting::frrouting::zebra_generic_options:
   'ip':
@@ -367,14 +365,16 @@ frrouting::frrouting::zebra_generic_options:
 
 frrouting::frrouting::bgp_neighbors:
   - '158.36.4.90 remote-as 224'
-#  - '158.36.4.90 bfd 5 500 500'
+  - '158.36.4.90 bfd 5 500 500'
   - '158.36.4.90 soft-reconfiguration inbound'
   - '158.36.4.90 prefix-list uninett-routes-in in'
   - '158.36.4.90 prefix-list uninett-routes-out out'
   - '2001:700:0:807a:: remote-as 224'
   - '2001:700:0:807a:: bfd 5 500 500'
   - "172.31.228.1 remote-as %{hiera('bgp_as')}"
-  - '172.31.228.1 soft-reconfiguration inbound'
+  - '172.31.229.1 default-originate'
+  - '172.31.229.1 soft-reconfiguration inbound'
+  - '172.31.229.1 route-map failover-default-route in'
   - "172.18.38.1 remote-as %{hiera('bgp_as')}"
   - '172.18.38.1 soft-reconfiguration inbound'
   - "fd32::6:1 remote-as %{hiera('bgp_as')}"
@@ -399,12 +399,12 @@ frrouting::frrouting::bgp_options:
   - 'bgp bestpath as-path multipath-relax'
 
 frrouting::frrouting::bgp_networks:
-#  - '158.37.63.0/24'
-#  - '158.39.48.0/24'
-#  - '158.39.75.0/24'
+  - '158.37.63.0/24'
+  - '158.39.48.0/24'
+  - '158.39.75.0/24'
   - '158.39.200.0/24'
-#frrouting::frrouting::bgp_networks6:
-#  - '2001:700:2:8200::/56'
+frrouting::frrouting::bgp_networks6:
+  - '2001:700:2:8200::/56'
 
 frrouting::frrouting::bgp_neighbor_groups:
   'rr-clients':
@@ -414,6 +414,7 @@ frrouting::frrouting::bgp_neighbor_groups:
       - 'route-reflector-client'
       - 'soft-reconfiguration inbound'
       - 'route-map rr-client-allow in'
+      - 'route-map rr-client-allow out'
       - 'bfd'
     'members':
       - '172.18.32.17'
@@ -471,12 +472,16 @@ frrouting::frrouting::bgp_neighbor_groups:
       - '172.18.33.82'
     'options6':
       - 'neighbor rr-clients route-reflector-client'
+      - 'neighbor rr-clients route-map rr-client-allow6 in'
+      - 'neighbor rr-clients route-map rr-client-allow6 out'
       - 'maximum-paths ibgp 3'
       - 'neighbor fd32::6:1 activate'
       - 'neighbor fd32::6:1 soft-reconfiguration inbound'
       - 'neighbor fd32::6:2 activate'
       - 'neighbor fd32::6:2 soft-reconfiguration inbound'
       - 'neighbor fd32:18:228::1 activate'
+      - 'neighbor fd32:18:229::1 route-map failover-default-route6 in'
+      - 'neighbor fd32:18:229::1 default-originate'
       - 'neighbor fd32:18:228::1 soft-reconfiguration inbound'
     'members6':
       - 'fd32::17'
@@ -557,26 +562,24 @@ frrouting::frrouting::bgp_accesslist6:
 frrouting::frrouting::bgp_ip_prefix_list:
   - 'routes-from-leaf1 seq 5 deny any'
   - 'routes-to-leaf1 seq 5 permit 0.0.0.0/0'
-  - 'uninett-routes-in seq 5 deny any' # FIXME
-#  - 'uninett-routes-in seq 5 permit any'
-#  - 'uninett-routes-in seq 10 deny any'
-#  - 'uninett-routes-out seq 5 permit 158.37.63.0/24'
-#  - 'uninett-routes-out seq 6 permit 158.39.48.0/24'
-#  - 'uninett-routes-out seq 7 permit 158.39.75.0/24'
+  - 'uninett-routes-in seq 5 permit any'
+  - 'uninett-routes-in seq 10 deny any'
+  - 'uninett-routes-out seq 5 permit 158.37.63.0/24'
+  - 'uninett-routes-out seq 6 permit 158.39.48.0/24'
+  - 'uninett-routes-out seq 7 permit 158.39.75.0/24'
   - 'uninett-routes-out seq 8 permit 158.39.200.0/24'
   - 'uninett-routes-out seq 10 deny any'
-#  - 'uio-routes-in seq 5 permit 129.177.0.0/16'
+#  - 'uio-routes-in seq 5 permit 129.240.0.0/16'
 #  - 'uio-routes-in seq 10 deny any'
-#  - 'default-route seq 5 permit 0.0.0.0/0'
+  - 'default-route seq 5 permit 0.0.0.0/0'
 frrouting::frrouting::bgp_ipv6_prefix_list:
-  - 'uninett-routes6-in seq 5 deny any' # FIXME
-#  - 'uninett-routes6-in seq 5 permit any'
-#  - 'uninett-routes6-in seq 10 deny any'
-#  - 'uninett-routes6-out seq 5 permit 2001:700:2:8200::/56'
-#  - 'uninett-routes6-out seq 10 deny any'
+  - 'uninett-routes6-in seq 5 permit any'
+  - 'uninett-routes6-in seq 10 deny any'
+  - 'uninett-routes6-out seq 5 permit 2001:700:2:8200::/56'
+  - 'uninett-routes6-out seq 10 deny any'
 #  - 'uio-routes-in6 seq 5 permit 2001:700:200::/48'
 #  - 'uio-routes-in6 seq 10 deny any'
-#  - 'default-route6 seq 5 permit ::/0'
+  - 'default-route6 seq 5 permit ::/0'
 
 frrouting::frrouting::bgp_route_maps:
   'rr-client-allow permit 10':


### PR DESCRIPTION
- Remove static default routes
- Add export/import filters for new uplink peers
- Add export filter for route reflector clients (computes) so that they don't inherit external routes from uplink
- Originate default route
