### PR TITLE
added support for el8 in vagrant

### DIFF
--- a/nodes.yaml
+++ b/nodes.yaml
@@ -4,7 +4,7 @@
 #  nodeset configurations
 #
 defaults:
-  box:       "norcams/base"
+  box:       "norcams/el8"
   autostart: true
   primary:   false
   location:  "vagrant"
@@ -34,9 +34,12 @@ defaults:
 nodesets:
   default:
     - role:       "db-global"
+      box:        "norcams/base"
     - role:       "db-regional"
-    - role:       "mq"
+      box:        "norcams/base"
     - role:       "api"
+      box:        "norcams/base"
+    - role:       "mq"
     - role:       "identity"
     - role:       "novactrl"
     - role:       "image"
@@ -77,6 +80,7 @@ nodesets:
     #- role:       "nat"
     #  box:        "norcams/freebsd"
     - role:       "admin"
+      box:        "norcams/base"
       memory:     2048
     #- role:       "ns"
     #  memory:     3096
@@ -96,31 +100,42 @@ nodesets:
   ha:
     - role:       'ha'
       hostid:     '01'
+      box:        "norcams/base"
     - role:       'ha'
       hostid:     '02'
+      box:        "norcams/base"
   grid:
     - role:       'ha-grid'
       hostid:     '01'
+      box:        "norcams/base"
     - role:       'ha-grid'
       hostid:     '02'
+      box:        "norcams/base"
   db:
     - role:       'db-global'
       hostid:     '01'
+      box:        "norcams/base"
     - role:       'db-global'
       hostid:     '02'
+      box:        "norcams/base"
     # galera arbitrator
     - role:       'ha'
       hostid:     '01'
+      box:        "norcams/base"
     - role:       'ha'
       hostid:     '02'
+      box:        "norcams/base"
   ceph:
     - role:       "cephmon"
     - role:       "storage"
   dns:
     - role:       "db-global"
+      box:        "norcams/base"
     - role:       "db-regional"
+      box:        "norcams/base"
     - role:       "mq"
     - role:       "api"
+      box:        "norcams/base"
     - role:       "ns"
     - role:       "resolver"
       hostid:     "01"
@@ -146,20 +161,6 @@ nodesets:
       hostid:     '02'
     - role:       'object-ceph'
       hostid:     '03'
-  iam:
-    - role:       'iam-consumer'
-    - role:       'iam-monitor'
-      hostid:     '01'
-    - role:       'iam-monitor'
-      hostid:     '02'
-    - role:       'iam-nat'
-      hostid:     '01'
-    - role:       'iam-nat'
-      hostid:     '02'
-    - role:       'iam-ha'
-      hostid:     '01'
-    - role:       'iam-ha'
-      hostid:     '02'
 
 networks:
   mgmt:

--- a/provision/puppetbootstrap.sh
+++ b/provision/puppetbootstrap.sh
@@ -5,17 +5,11 @@
 
 el_repos()
 {
-  if [ "$#" -ne 1 ]; then
-    repo="https://download.iaas.uio.no/nrec/test/${repo_dist}"
-  else
-    repo="https://download.iaas.uio.no/uh-iaas/${1}/${repo_dist}"
-  fi
-
-  wget -O /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-Official https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official
+  repo="https://download.iaas.uio.no/nrec/${repo_env}/${repo_dist}"
 
   cat > /etc/yum.repos.d/epel.repo <<- EOM
 [epel]
-name=Extra Packages for Enterprise Linux ${repo_dist:2} - \$basearch
+name=Extra Packages for Enterprise Linux \$releasever - \$basearch
 failovermethod=priority
 enabled=1
 gpgcheck=1
@@ -35,32 +29,74 @@ EOM
 name=CentOS-\$releasever - Base
 baseurl=$repo/centos-base/
 gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-Official
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
 
 [updates]
 name=CentOS-\$releasever - Updates
 baseurl=$repo/centos-updates/
 gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-Official
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
 
 [extras]
 name=CentOS-\$releasever - Extras
 baseurl=$repo/centos-extras/
 gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-Official
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
 EOM
+}
+
+el8_repos()
+{
+
+  repo="https://download.iaas.uio.no/nrec/${repo_env}/${repo_dist}"
+
+  # we do not use epel modular
+  rm -f /etc/yum.repos.d/epel-modular.repo
+
+  # Add our epel mirror
+  cat > /etc/yum.repos.d/epel.repo <<- EOM
+[epel]
+name=Extra Packages for Enterprise Linux \$releasever - \$basearch
+failovermethod=priority
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-${repo_dist:2}
+baseurl=$repo/epel
+EOM
+
+  # Add our puppetlabs mirror
+cat > /etc/yum.repos.d/puppetlabs.repo <<- EOM
+[puppetlabs]
+name=Puppet 6 Yum Repo
+baseurl=$repo/puppetlabs6/
+gpgkey=$repo/puppetlabs6/RPM-GPG-KEY-puppet-20250406
+enabled=1
+gpgcheck=1
+EOM
+
 }
 
 bootstrap_puppet()
 {
-  # packages
-  if command -v yum >/dev/null 2>&1; then
-    echo "bootstrap puppet ..."
-    # RHEL, CentOS, Fedora
-    repo_dist=$(uname -r | sed 's/.*\(el[0-9]\).*x86.*/\1/')
-    # FIXME
-    yum install -y http://download.iaas.uio.no/uh-iaas/repo/${repo_dist}/centos-extras/Packages/epel-release-7-11.noarch.rpm
-    # yum install -y epel-release # to get gpgkey for epel
+
+  repo_dist=$(uname -r | sed 's/.*\(el[0-9]\).*x86.*/\1/')
+
+  # setup dnf/yum
+  if command -v dnf >/dev/null 2>&1; then
+    echo "bootstrap puppet for el8..."
+    dnf install -y epel-release # to get gpgkey for epel
+    el8_repos
+    dnf clean all
+    dnf -y upgrade
+    dnf install -y puppet-agent git vim
+
+    /opt/puppetlabs/puppet/bin/gem install -N r10k
+    # /opt/puppetlabs/puppet/bin/gem install -N puppet_forge
+    ln -sf /opt/puppetlabs/puppet/bin/wrapper.sh /opt/puppetlabs/bin/r10k
+
+  elif command -v yum >/dev/null 2>&1; then
+    echo "bootstrap puppet for el7..."
+    yum install -y epel-release # to get gpgkey for epel
     el_repos test
     yum clean all
     yum -y update
@@ -100,5 +136,15 @@ bootstrap_puppet()
 }
 
 REPORT_DIR=/opt/puppetlabs/puppet/cache/state
+
+# test repos are used if we do not provide repo env or is running in vagrant
+# in vagrant this script is called with multiple args
+if [[ $(hostname) == *"vagrant"* ]]; then
+  repo_env='test'
+elif [ $# -e 1 ]; then
+  repo_env=$1
+else
+  repo_env='test'
+fi
 
 test -f $REPORT_DIR/last_run_report.yaml || bootstrap_puppet


### PR DESCRIPTION
Looks like puppet fails on all el8 nodes. Set the box for the node in `nodes.yaml` to `norcams/base` for a working el7 node.

`nodes.yaml` might break other nodeset than default. 