### PR TITLE
revert back to thias/puppet-libvirt

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -181,7 +181,7 @@ mod 'rsync', :ref => '0.4.0',                       :git => github + 'puppetlabs
 #
 # libvirt
 #
-mod 'libvirt', :ref => '5f55fb66db',                :git => github + 'norcams/puppet-libvirt'
+mod 'libvirt', :git => github + 'thias/puppet-libvirt', :ref => '1.0.1'
 
 #
 # ceph


### PR DESCRIPTION
cgroup_device_acl and clear_emulator_capabilities are no longer
needed (the reason for forking this module), and we can go back to
the upstream module, which has finally received some attention.