### PR TITLE
Adding HUP on rsyslog on the syslog logrotate job

### DIFF
--- a/hieradata/common/roles/logger.yaml
+++ b/hieradata/common/roles/logger.yaml
@@ -106,7 +106,7 @@ logrotate::rules:
     path:           ['/var/log/cron', '/var/log/maillog', '/var/log/messages', '/var/log/secure', '/var/log/spooler']
     rotate:         10
     rotate_every:   daily
-    postrotate:     '/bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true'
+    postrotate:     ['/bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true', '/bin/kill -HUP `cat /var/run/rsyslogd.pid 2> /dev/null` 2> /dev/null || true']
     dateext:        true
     sharedscripts:  true
     missingok:      true


### PR DESCRIPTION
Shouldn't this work, haproxy logrotate has two postrotate commands.