### PR TITLE
feat: custom report script in imagebuilder

### DIFF
--- a/profile/manifests/application/builder.pp
+++ b/profile/manifests/application/builder.pp
@@ -11,7 +11,7 @@ class profile::application::builder (
   $insecure = false,
   $ipv6 = false,
   $custom_scriptdir = "/home/${user}/custom_scripts",
-  $resolver_address = hiera('netcfg_anycast_dns', '1.1.1.1')
+  $resolver_address = hiera('netcfg_anycast_dns', '1.1.1.1'),
 ) {
 
 
@@ -86,4 +86,15 @@ class profile::application::builder (
 
   create_resources('profile::application::builder::jobs', lookup('profile::application::builder::images', Hash, 'deep', {}))
   create_resources('profile::application::builder::template', lookup('profile::application::builder::templates', Hash, 'deep', {}))
+
+  # report custom script
+  $report = lookup('public__address__report', String, 'first')
+  file { "${custom_scriptdir}/report.sh":
+    ensure  => present,
+    owner   => $user,
+    group   => $group,
+    mode    => '0755',
+    content => template("${module_name}/application/builder/report.sh.erb")
+  }
+
 }

--- a/profile/manifests/application/builder/template.pp
+++ b/profile/manifests/application/builder/template.pp
@@ -1,9 +1,10 @@
 define profile::application::builder::template(
-    $ensure         = present,
-    $template_dir   = $profile::application::builder::template_dir,
-    $insecure       = $profile::application::builder::insecure,
-    $ipv6           = $profile::application::builder::ipv6,
-    $custom_scripts = [],
+    $ensure           = present,
+    $template_dir     = $profile::application::builder::template_dir,
+    $insecure         = $profile::application::builder::insecure,
+    $ipv6             = $profile::application::builder::ipv6,
+    $custom_scriptdir = $profile::application::builder::custom_scriptdir,
+    $custom_scripts   = [],
 ) {
 
   file { "${template_dir}/${name}":

--- a/profile/templates/application/builder/report.sh.erb
+++ b/profile/templates/application/builder/report.sh.erb
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+install_wrapper() {
+cat <<-EOF | sudo tee /usr/local/sbin/report_wrapper
+#!/bin/bash
+set -e
+
+$download_cmd $url
+chmod +x /usr/local/sbin/report
+
+/usr/local/sbin/report
+
+exit 0
+EOF
+  sudo chmod +x /usr/local/sbin/report_wrapper
+}
+
+install_anacron() {
+cat <<-EOF | sudo tee /etc/cron.daily/report
+#!/bin/sh
+
+/usr/local/sbin/report_wrapper &> /dev/null
+
+exit 0
+EOF
+  sudo chmod 700 /etc/cron.daily/report
+}
+
+install_systemd() {
+cat <<-EOF | sudo tee /lib/systemd/system/report.timer
+[Unit]
+Description=Run report script every 6h and on boot
+
+[Timer]
+OnBootSec=15min
+OnUnitActiveSec=12h
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+EOF
+cat <<-EOF | sudo tee /lib/systemd/system/report.service
+[Unit]
+Description=Report to UH-IaaS report API
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/report_wrapper
+EOF
+  sudo systemctl enable report.timer
+}
+
+# Platform detection (borrowed from Omnitruck install script)
+# Debian-family and RedHat-family are currently supported
+os=`uname -s | tr '[A-Z]' '[a-z]'`
+
+if test -f "/etc/lsb-release" && grep -q DISTRIB_ID /etc/lsb-release && ! grep -q wrlinux /etc/lsb-release; then
+  platform=`grep DISTRIB_ID /etc/lsb-release | cut -d "=" -f 2 | tr '[A-Z]' '[a-z]'`
+  platform_version=`grep DISTRIB_RELEASE /etc/lsb-release | cut -d "=" -f 2`
+
+elif test -f "/etc/debian_version"; then
+  platform="debian"
+  platform_version=`cat /etc/debian_version`
+
+elif test -f "/etc/redhat-release"; then
+  platform=`sed 's/^\(.\+\) release.*/\1/' /etc/redhat-release | tr '[A-Z]' '[a-z]'`
+  platform_version=`sed 's/^.\+ release \([.0-9]\+\).*/\1/' /etc/redhat-release`
+
+  # If /etc/redhat-release exists, we act like RHEL by default
+  if test "$platform" != "fedora"; then
+    platform="el"
+  fi
+
+fi
+
+if test "x$platform" = "x"; then
+  echo "Unable to determine platform version!"
+  exit 0
+fi
+
+major_version=`echo $platform_version | cut -d. -f1`
+
+url="https://<%= @report %>/downloads/${platform}/${major_version}/v1/report"
+
+case $platform in
+  "el")
+    case $major_version in
+      "6")
+        download_cmd='curl -fsS -o /usr/local/sbin/report'
+        install_wrapper
+        install_anacron
+        ;;
+      "7"|"8"|"9")
+        download_cmd='curl -fsS -o /usr/local/sbin/report'
+        install_wrapper
+        install_systemd
+        ;;
+    esac
+    ;;
+  "debian")
+    download_cmd='wget --quiet -O /usr/local/sbin/report'
+    install_wrapper
+    install_systemd
+    ;;
+  *)
+    download_cmd='curl -fsS -o /usr/local/sbin/report'
+    install_wrapper
+    install_systemd
+    ;;
+esac

--- a/profile/templates/application/builder/template.erb
+++ b/profile/templates/application/builder/template.erb
@@ -34,7 +34,7 @@
       "/opt/imagebuilder/scripts/upgrade.sh",
       "/opt/imagebuilder/scripts/qemu_guest_agent.sh",
       "/opt/imagebuilder/scripts/autopatch.sh",
-      "/opt/imagebuilder/scripts/report.sh",
+      "<%= @custom_scriptdir %>/report.sh",
       "/opt/imagebuilder/scripts/sshd_hardening.sh",
       "/opt/imagebuilder/scripts/cleanup.sh",
       "/opt/imagebuilder/scripts/uio-cleanup.sh"


### PR DESCRIPTION
With this we use the local report api to download the report script. This will enable us to run report api in test and have all locations use their own db for reports. Today everybody is sending reports to production (dev, test and prod).