### PR TITLE
Adding logrotate for rsyslog

### DIFF
--- a/hieradata/common/platform/el8.yaml
+++ b/hieradata/common/platform/el8.yaml
@@ -64,3 +64,17 @@ nova::migration::libvirt::libvirt_version: '7'                   # puppet-nova f
 
 calico_version:       '322'                                      # FIXME This should move to common when el7 network and computes are gone
 mariadb_version:      '10.3'                                     # FIXME This should be removed when all database nodes are on el8 (use only in common/roles/db)
+
+# logrotate
+logrotate::rules:
+  syslog:
+    ensure:         absent
+  rsyslog:
+    path:           ['/var/log/cron', '/var/log/maillog', '/var/log/messages', '/var/log/secure', '/var/log/spooler']
+    rotate:         10
+    rotate_every:   daily
+    postrotate:     '/bin/kill -HUP `cat /var/run/rsyslogd.pid 2> /dev/null` 2> /dev/null || true'
+    dateext:        true
+    sharedscripts:  true
+    missingok:      true
+    compress:       true


### PR DESCRIPTION
To fix the problem with ghost log files which keeps increasing after syslog logrotate and where the fix was to restart rsyslog.  Also ensure syslog logroatet job is not present.