### PR TITLE
fix(bgo): don't export uib-route from uib-table

### DIFF
--- a/profile/templates/bird/bird.conf.bgo.8.erb
+++ b/profile/templates/bird/bird.conf.bgo.8.erb
@@ -137,8 +137,8 @@ protocol kernel {
 protocol kernel {
   ipv4 {
     table uib4;
-    export all;
-    import filter import_kernel;
+    export none;
+    import none;
   };
   kernel table ipt_uib;
   graceful restart;


### PR DESCRIPTION
Har testa dette litt for mykje.  Ser ingen problem.
Fjerner 129.177.0.0/16 via 172.18.7.4 frå lhc-private, lhc og private(duh).