### PR TITLE
Windows image building with packer and qemu

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -22,6 +22,7 @@ mod 'mount_core', :ref => '1.0.4',                  :git => github + 'puppetlabs
 mod 'firewall', :ref => 'v3.4.0',                   :git => github + 'puppetlabs/puppetlabs-firewall'
 mod 'apt', :ref => '6.2.1',                         :git => github + 'puppetlabs/puppetlabs-apt'
 mod 'yumrepo_core', :ref => '1.0.7',                :git => github + 'puppetlabs/puppetlabs-yumrepo_core'
+mod 'vcsrepo', :ref => 'v5.5.0',                    :git => github + 'puppetlabs/puppetlabs-vcsrepo'
 mod 'kmod', :ref => 'v3.0.0',                       :git => github + 'voxpupuli/puppet-kmod'
 mod 'named_interfaces', :ref => 'e5124925ba',       :git => github + 'norcams/puppet-named_interfaces'
 mod 'network', :ref => '1f23e2e964',                :git => github + 'norcams/puppet-network'

--- a/hieradata/common/roles/builder.yaml
+++ b/hieradata/common/roles/builder.yaml
@@ -12,6 +12,7 @@ profile::base::common::packages:
   'packer': {}
   'python3': {}
   'qemu-img': {}
+  'rsync': {}
   'bash-completion': {}
   'bash-completion-extras': {}
   'jq': {}
@@ -285,6 +286,22 @@ profile::application::builder::images:
     'username':         'cloud-user'
     'hour':             13
 
+profile::application::builder::windows_images:
+  'winsrv_2019':
+    'version':          '2019'
+    'buildhost':        "test01-controller-02.mgmt.test01.uhdc.no"
+    'weekday':          3
+    'monthday':         '8-14'
+    'hour':             3
+    'minute':           0
+  'winsrv_2022':
+    'version':          '2022'
+    'buildhost':        "test01-controller-02.mgmt.test01.uhdc.no"
+    'weekday':          3
+    'monthday':         '8-14'
+    'hour':             6
+    'minute':           0
+
 profile::application::builder::templates:
   'default':
     custom_scripts:     ["%{profile::application::builder::custom_scriptdir}/resolver.sh"]
@@ -319,6 +336,8 @@ profile::monitoring::sensu::agent::expanded_checks:
   - 'uio_rhel7'
   - 'uio_rhel8'
   - 'uio_rhel9'
+  - ''
+  - ''
 
 profile::monitoring::sensu::agent::expanded_defaults:
     command: "check-imagebuild.rb -d "

--- a/hieradata/nodes/test01/test01-builder-01.yaml
+++ b/hieradata/nodes/test01/test01-builder-01.yaml
@@ -11,3 +11,14 @@ network::interfaces_hash:
     domain:    "%{hiera('netcfg_dns_search')}"
     defroute:  'yes'
 
+profile::application::builder::fetch_windows_images: true
+
+profile::base::lvm::physical_volume:
+  '/dev/sda':
+    ensure: present
+    force:  true
+profile::base::lvm::volume_group:
+  'vg_images':
+    physical_volumes:
+      - /dev/sda
+

--- a/hieradata/nodes/test01/test01-controller-02.yaml
+++ b/hieradata/nodes/test01/test01-controller-02.yaml
@@ -1,4 +1,8 @@
 ---
+include:
+  default:
+    - profile::application::windowsimage
+
 network::interfaces_hash:
   'em1':
     onboot:        'yes'
@@ -51,3 +55,9 @@ network::interfaces_hash:
     type:         'Bridge'
     defroute:     'no'
     bridge_stp:   'off'
+
+profile::application::windowsimage::enable: true
+profile::application::windowsimage::manage_firewall: true
+profile::base::yumrepo::repo_hash:
+  hashicorp:
+    ensure: present

--- a/hieradata/test01/roles/builder.yaml
+++ b/hieradata/test01/roles/builder.yaml
@@ -37,3 +37,5 @@ profile::monitoring::sensu::agent::checks:
       check-imagebuild/args/uio_rhel7: "-d uio_rhel7"
       check-imagebuild/args/uio_rhel8: "-d uio_rhel8"
       check-imagebuild/args/uio_rhel9: "-d uio_rhel9"
+      check-imagebuild/args/winsrv_2019: "-d winsrv_2019"
+      check-imagebuild/args/winsrv_2022: "-d winsrv_2022"

--- a/profile/manifests/application/builder.pp
+++ b/profile/manifests/application/builder.pp
@@ -12,6 +12,7 @@ class profile::application::builder (
   $ipv6 = false,
   $custom_scriptdir = "/home/${user}/custom_scripts",
   $resolver_address = hiera('netcfg_anycast_dns', '1.1.1.1'),
+  $fetch_windows_images = false,
 ) {
 
 
@@ -77,15 +78,19 @@ class profile::application::builder (
   } ->
   # Temp. until cloud-init can handle systemd-resolved (Fedora 33 and onwards)
   file { "${custom_scriptdir}/resolver.sh":
-    ensure => present,
-    owner  => $user,
-    group  => $group,
-    mode   => '0755',
-    content=> template("${module_name}/application/builder/resolver.sh.erb")
+    ensure  => present,
+    owner   => $user,
+    group   => $group,
+    mode    => '0755',
+    content => template("${module_name}/application/builder/resolver.sh.erb")
   }
 
   create_resources('profile::application::builder::jobs', lookup('profile::application::builder::images', Hash, 'deep', {}))
   create_resources('profile::application::builder::template', lookup('profile::application::builder::templates', Hash, 'deep', {}))
+
+  if $fetch_windows_images {
+    create_resources('profile::application::builder::windows_jobs', lookup('profile::application::builder::windows_images', Hash, 'deep', {}))
+  }
 
   # report custom script
   $report = lookup('public__address__report', String, 'first')

--- a/profile/manifests/application/builder/windows_jobs.pp
+++ b/profile/manifests/application/builder/windows_jobs.pp
@@ -31,7 +31,7 @@ define profile::application::builder::windows_jobs (
   cron { $name:
     ensure      => $ensure,
     # Write to imagebuilder report
-    command     => "/home/${user}/build_scripts/${name}_wrapper || jq -nc '{\"result\": \"failed\"}' >> /var/log/imagebuilder/${name}-report.jsonl",
+    command     => "/home/${user}/build_scripts/${name}_wrapper || jq -nc '{\"result\": \"failed\"}' > /var/log/imagebuilder/${name}-report.jsonl",
     user        => $user,
     weekday     => $weekday,
     monthday    => $monthday,

--- a/profile/manifests/application/builder/windows_jobs.pp
+++ b/profile/manifests/application/builder/windows_jobs.pp
@@ -1,0 +1,42 @@
+#
+define profile::application::builder::windows_jobs (
+    $version,
+    $buildhost,
+    $ensure        = present,
+    $user          = $profile::application::builder::user,
+    $group         = $profile::application::builder::group,
+    $environment   = [ 'PLACEHOLDER=true' ],
+    $weekday       = 3,
+    $monthday      = '8-14',
+    $hour          = fqdn_rand(23, $name),
+    $minute        = 0
+) {
+
+  file { "/home/${user}/build_scripts/${name}_wrapper":
+    ensure  => $ensure,
+    content => template("${module_name}/application/builder/windows_build_script_wrapper.erb"),
+    owner   => $user,
+    group   => $group,
+    mode    => '0755',
+    require => File["/home/${user}/build_scripts"]
+  } ->
+  file { "/home/${user}/build_scripts/${name}":
+    ensure  => $ensure,
+    content => template("${module_name}/application/builder/windows_build_script.erb"),
+    owner   => $user,
+    group   => $group,
+    mode    => '0755',
+    require => File["/home/${user}/build_scripts"]
+  } ->
+  cron { $name:
+    ensure      => $ensure,
+    # Write to imagebuilder report
+    command     => "/home/${user}/build_scripts/${name}_wrapper || jq -nc '{\"result\": \"failed\"}' >> /var/log/imagebuilder/${name}-report.jsonl",
+    user        => $user,
+    weekday     => $weekday,
+    monthday    => $monthday,
+    hour        => $hour,
+    minute      => $minute,
+    environment => $environment
+  }
+}

--- a/profile/manifests/application/windowsimage.pp
+++ b/profile/manifests/application/windowsimage.pp
@@ -1,0 +1,70 @@
+# Infrastructure for building windows images with packer and qemu
+class profile::application::windowsimage(
+  $enable          = false,
+  $user            = 'windowsbuilder',
+  $group           = 'windowsbuilder',
+  $build_root      = '/var/lib/libvirt/images/windows_builder',
+  $virtio_src      = 'https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/stable-virtio/virtio-win.iso',
+  $vmbios_src      = 'https://iaas-repo.uio.no/nrec/nrec-resources/files/win_image/',
+  $manage_firewall = false,
+  $firewall_extras = {},
+  $firewall_ports  = ['5998-5999']
+) {
+
+  if $enable {
+
+    package { 'git':
+      ensure   => installed
+    }
+    group { $group:
+      ensure => present
+    } ->
+    user { $user:
+      ensure     => present,
+      managehome => true,
+      gid        => $group,
+    } 
+    file { "${build_root}":
+      ensure => directory,
+      mode   => '0755',
+      owner  => $user,
+      group  => $group
+    }
+    vcsrepo { "${build_root}/packer-windows":
+      ensure   => present,
+      provider => git,
+      source   => 'https://github.com/norcams/packer-windows.git',
+      owner    => $user,
+      group    => $group
+    }
+    file{ "${build_root}/virtio-win.iso":
+      ensure => file,
+      source => "${virtio_src}",
+      owner  => $user,
+      group  => $group
+    }
+    file{ "${build_root}/OVMF_CODE.fd":
+      ensure => file,
+      source => "${vmbios_src}OVMF_CODE.fd",
+      owner  => $user,
+      group  => $group
+    }
+    file{ "${build_root}/OVMF_VARS.fd":
+      ensure => file,
+      source => "${vmbios_src}OVMF_VARS.fd",
+      owner  => $user,
+      group  => $group
+    }
+  }
+
+# Install packer from repo
+
+# Serve the building process over vnc
+if $manage_firewall and $enable {
+    profile::firewall::rule { '253 accept qemu vnc':
+      dport  => $firewall_ports,
+      extras => $firewall_extras
+    }
+  }
+}
+

--- a/profile/manifests/application/windowsimage.pp
+++ b/profile/manifests/application/windowsimage.pp
@@ -73,8 +73,6 @@ class profile::application::windowsimage(
     }
   }
 
-# Install packer from repo
-
 # Serve the building process over vnc
 if $manage_firewall and $enable {
     profile::firewall::rule { '253 accept qemu vnc':
@@ -83,4 +81,3 @@ if $manage_firewall and $enable {
     }
   }
 }
-

--- a/profile/manifests/application/windowsimage.pp
+++ b/profile/manifests/application/windowsimage.pp
@@ -16,6 +16,9 @@ class profile::application::windowsimage(
     package { 'git':
       ensure   => installed
     }
+    package { 'packer':
+      ensure   => installed
+    }
     group { $group:
       ensure => present
     } ->
@@ -23,12 +26,25 @@ class profile::application::windowsimage(
       ensure     => present,
       managehome => true,
       gid        => $group,
-    } 
-    file { "${build_root}":
+    }
+    file { $build_root:
       ensure => directory,
       mode   => '0755',
       owner  => $user,
       group  => $group
+    }
+    file { "/home/${user}/.ssh":
+      ensure => directory,
+      mode   => '0644',
+      owner  => $user,
+      group  => $group
+    }
+    file { "/home/${user}/.ssh/authorized_keys":
+      ensure  => present,
+      mode    => '0644',
+      owner   => $user,
+      group   => $group,
+      content => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDO+pF/Ef8CE0E+56I3lixPHnNowQatNrJ31+Jds5gbEAA13BZeckPhcOkMWIJX+54gf16tbL1olRS7bwbaub+xd9IoXmiDaYfXxq634mYcDbKvbXRYBmBDx6n9+74dhPBzcsli0cQpNCGJvIH0blqprdEgxRPdAnJYuRxK4hOT7LZsgmM+y6PDZxJ+96jDtJsU7Jks8g7wZ1/x380GTE64K0RaperXCs77x5Zky6934aZu1HyPi2EN+4am5MMnwNA6A60j5V8DGoA56G7l47QY5Eb3G4r6XgCS+hemimjr5US/pcZuE38TpbGZHCxH4dqS68umwE6iw/FDNCyR/WmJLCxt9IM+l/hVNtNYyClt8uFBgLGwFX9JNd3JUKJwwl3uiyO79I1CzCx8sjbhX3TrXqqAfGuyEzwo5BRO2kfDiZQC5sTPFXTiKwiVv5SrCjKMrkPgPHmWA47a8Rr+86mHRe0j6wwTq3G7Pm4mT86goZY4mrjZ6oexa6unDKymQS0vEsk4ujIMIM3JkkDy5/velzo8toCKNf6gv4YrJ9lKMhnlojqtJP6FrNYTx/Imq8uDTgrj1sq593elaDV9vvft0zn37uIBpq+9WDfxd+EOvRgJ8rY5Qd6OOYoYkMzB9DcHH1blYge9tl1g/qTuFTHEU0fNrJDqmsH72nNBejQNUw=='
     }
     vcsrepo { "${build_root}/packer-windows":
       ensure   => present,
@@ -39,7 +55,7 @@ class profile::application::windowsimage(
     }
     file{ "${build_root}/virtio-win.iso":
       ensure => file,
-      source => "${virtio_src}",
+      source => $virtio_src,
       owner  => $user,
       group  => $group
     }

--- a/profile/templates/application/builder/build_script.erb
+++ b/profile/templates/application/builder/build_script.erb
@@ -78,7 +78,7 @@ ln -srf ${md5filename} /opt/images/public_builds/<%= @name %>-latest.md5
 ln -srf ${filename} /opt/images/public_builds/<%= @name %>-latest.qcow2
 
 # Remove old images, always keeping the two most recent
-find /opt/images/public_builds/ -type f -iname <%= @name %>-20\* | sort -r | tail -n +3 | xargs rm -f
+find /opt/images/public_builds/ -type f -iname <%= @name %>-20\*.qcow2 | sort -r | tail -n +3 | xargs rm -f
 
 if [ $gen_report == "true" ]; then
   # If we make it to here we assume the build has been successful

--- a/profile/templates/application/builder/windows_build_script.erb
+++ b/profile/templates/application/builder/windows_build_script.erb
@@ -1,0 +1,32 @@
+#!/bin/bash
+ssh -tt -o "StrictHostKeyChecking no" -i ~/.ssh/windowsbuilder_rsa windowsbuilder@<%= @buildhost %> << 'ENDSSH'
+#!/bin/bash
+cd /var/lib/libvirt/images/windows_builder/packer-windows
+
+# Check for already running process
+if ! ps axu | grep windows-<%= @version %> | grep -v grep; then
+    echo "We are not already building"
+else
+    echo "We are already building"
+    exit 1
+fi
+
+# If exist, remove build files
+if test -d ./builds/packer-windows-<%= @version %>-x86_64-qemu; then
+    echo "Build file exists - removing..."
+    rm -rf ./builds/packer-windows-<%= @version %>-x86_64-qemu
+fi
+
+# Build the Windows image
+PACKER_CACHE_DIR="./packer_cache" PACKER_LOG=1 /usr/bin/packer build --only=qemu.vm -var-file=os_pkrvars/windows/windows-<%= @version %>-x86_64.pkrvars.hcl ./packer_templates/
+result=$?
+if test $result -eq 0
+then
+    	echo "Windows image built successfully."
+else
+    	echo "Windows build failed with status $result"
+        exit $result
+fi
+
+exit
+ENDSSH

--- a/profile/templates/application/builder/windows_build_script_wrapper.erb
+++ b/profile/templates/application/builder/windows_build_script_wrapper.erb
@@ -50,4 +50,5 @@ ln -srf /opt/images/public_builds/winsrv_<%= @version %>-${date}.md5 /opt/images
 find /opt/images/public_builds/ -type f -iname winsrv_<%= @version %>-20\*.raw | sort -r | tail -n +3 | xargs rm -f
 
 echo "Finished."  >> $logfile
-echo '{"result":"success"}' > /var/log/imagebuilder/winsrv-<%= @version %>-report.jsonl
+echo '{"result":"success"}' > /var/log/imagebuilder/winsrv_<%= @version %>-report.jsonl
+exit 0

--- a/profile/templates/application/builder/windows_build_script_wrapper.erb
+++ b/profile/templates/application/builder/windows_build_script_wrapper.erb
@@ -1,0 +1,53 @@
+#!/bin/bash
+logfile="/var/log/imagebuilder/winsrv-<%= @version %>-build-$(date +"%Y%m%d").log"
+/home/imagebuilder/build_scripts/<%= @name %> > $logfile
+result=$?
+
+if test $result -eq 0
+then
+	echo "Windows build executed successfully." >> $logfile
+else
+	echo "Windows build failed with status $result" >> $logfile
+        exit $result
+fi
+
+# Copy the image from the build host
+date=$(date +"%Y%m%d")
+/usr/bin/rsync -Hav --sparse -e 'ssh -o "StrictHostKeyChecking no" -i /home/imagebuilder/.ssh/windowsbuilder_rsa'  windowsbuilder@<%= @buildhost %>:/var/lib/libvirt/images/windows_builder/packer-windows/builds/packer-windows-<%= @version %>-x86_64-qemu/windows-<%= @version %>-amd64 /opt/images/public_builds/winsrv_<%= @version %>-${date}.qcow2
+result=$?
+if test $result -eq 0
+then
+    	echo "Image copied from source host." >> $logfile
+else
+    	echo "Failed to copy the image from source host with status $result" >> $logfile
+        exit $result
+fi
+
+# Convert the image to RAW and then delete the source image
+/usr/bin/qemu-img convert -O raw /opt/images/public_builds/winsrv_<%= @version %>-${date}.qcow2 /opt/images/public_builds/winsrv_<%= @version %>-${date}.raw
+if test $result -eq 0
+then
+    	echo "Windows image successfully converted to RAW." >> $logfile
+        rm -rf /opt/images/public_builds/winsrv_<%= @version %>-${date}.qcow2
+else
+    	echo "Image conversion failed with status $result" >> $logfile
+        exit $result
+fi
+
+/usr/bin/md5sum /opt/images/public_builds/winsrv_<%= @version %>-${date}.raw >> /opt/images/public_builds/winsrv_<%= @version %>-${date}.md5
+if test $result -eq 0
+then
+    	echo "Calculated checksum for image." >> $logfile
+else
+    	echo "Failed to calculate checksum with status $result" >> $logfile
+        exit $result
+fi
+
+ln -srf /opt/images/public_builds/winsrv_<%= @version %>-${date}.raw /opt/images/public_builds/winsrv_<%= @version %>-latest.raw
+ln -srf /opt/images/public_builds/winsrv_<%= @version %>-${date}.md5 /opt/images/public_builds/winsrv_<%= @version %>-latest.md5
+
+# Remove old images, always keeping the two most recent
+find /opt/images/public_builds/ -type f -iname winsrv_<%= @version %>-20\*.raw | sort -r | tail -n +3 | xargs rm -f
+
+echo "Finished."  >> $logfile
+echo '{"result":"success"}' > /var/log/imagebuilder/winsrv-<%= @version %>-report.jsonl


### PR DESCRIPTION
Using the https://github.com/norcams/packer-windows repository, these changes enables building of windows images with packer and qemu. The builder node is responsible for triggering and serving the images, while the images are build on a controller node.