### PR TITLE
feat:Elastic IP for instances with BGP Anycast

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -43,7 +43,7 @@ mod 'googleauthenticator', :ref => 'norcams-4.0.0-2', :git => github + 'norcams/
 # profile::network::leaf/torack
 #
 mod 'quagga', :ref => '42f883092d',                 :git => github + 'norcams/puppet-quagga'
-mod 'frrouting', :ref => 'd07940e660',              :git => github + 'norcams/puppet-frrouting'
+mod 'frrouting', :ref => '70450dd6de',              :git => github + 'norcams/puppet-frrouting'
 
 #
 # profile::network::

--- a/hieradata/bgo/common.yaml
+++ b/hieradata/bgo/common.yaml
@@ -110,6 +110,7 @@ netcfg_anycast_dns:       '158.39.77.252'
 netcfg_anycast_dns6:      '2001:700:2:83ff::252'
 netcfg_ib_vlan:           '908'
 netcfg_oob_vlan:          '909'
+netcfg_elastic_cidr:      '10.5.0.0/20'
 netcfg_trp_rr:
   rr1:
     peer_ipv4: '172.18.6.1'

--- a/hieradata/common/roles/spine.yaml
+++ b/hieradata/common/roles/spine.yaml
@@ -81,6 +81,7 @@ profile::network::leaf::acls:
       - "-A $INGRESS_CHAIN -s %{hiera('netcfg_mgmt_netpart')}.0/%{hiera('netcfg_mgmt_netmask')} -p tcp --dport 19999 -j ACCEPT"
       - "-A $INGRESS_CHAIN -p tcp --dport 19999 -j DROP"
       - "-A $INGRESS_CHAIN -s %{hiera('netcfg_trp_netpart')}.0/%{hiera('netcfg_trp_netmask')} -p tcp --dport 179 -j ACCEPT"
+      - "-A $INGRESS_CHAIN -s %{hiera('netcfg_elastic_cidr')} -p tcp --dport 179 -j ACCEPT"
       - "-A $INGRESS_CHAIN -p tcp --dport 179 -j DROP"
       - "-A $INGRESS_CHAIN -s %{hiera('netcfg_mgmt_netpart')}.0/%{hiera('netcfg_mgmt_netmask')} -p tcp --dport 22 -j ACCEPT"
       - "-A $INGRESS_CHAIN -s %{hiera('netcfg_trp_netpart')}.0/%{hiera('netcfg_trp_netmask')} -p tcp --dport 22 -j ACCEPT"

--- a/hieradata/nodes/test01/test01-spine-01.yaml
+++ b/hieradata/nodes/test01/test01-spine-01.yaml
@@ -2,16 +2,20 @@
 # The uplink interface
 profile::base::network::uplink_interface: 'swp48'
 
-network::interfaces_hash:
-  'eth0':
-    'ipaddress': "%{hiera('netcfg_mgmt_net_c6')}.1/21"
-    'gateway':   "%{hiera('netcfg_mgmt_gateway')}"
-    'vrf':       'mgmt'
-  'mgmt':
-    'ipaddress': '127.0.0.1/8'
-    'vrf_table': 'auto'
+bgp_loopback_addr: '10.255.255.1' # IP for elastic IP instances to peer to
+bgp_loopback_addr6: 'fcff::6:1'   # Needed for BGP-MP to work 
 
 profile::base::network::cumulus_interfaces:
+  'eth0':
+    'ipv4': "%{hiera('netcfg_mgmt_net_c6')}.1/21"
+    'gateway': "%{hiera('netcfg_mgmt_gateway')}"
+    'vrf': 'mgmt'
+  'mgmt':
+    'ipv4': '127.0.0.1/8'
+    'vrf_table': 'auto'
+  'lo':
+    'ipv4': [ "%{hiera('bgp_loopback_addr')}/32", ]
+    'ipv6': [ "%{hiera('bgp_loopback_addr6')}/128", ]
   'bridge.100':
     'ipv4': [ "%{hiera('netcfg_trp_net_c6')}.1/21", ]
     'ipv6': [ 'fd00::6:1/64', ]
@@ -23,42 +27,11 @@ profile::base::network::cumulus_interfaces:
     'clagd_enable': true
     'clagd_priority': '4096'
     'clagd_peer_ip': 'linklocal'
+    'clagd_backup_ip': "%{hiera('netcfg_trp_net_c6')}.2/21"
     'clagd_sys_mac': '44:38:39:ff:bb:2c'
   'swp48':
     'ipv4': [ '129.177.1.198/30', ]
     'ipv6': [ '2001:700:200:914::10/64', ]
-
-frrouting::frrouting::bgp_neighbor_groups:
-  'rr-clients':
-    'options':
-      - 'peer-group'
-      - "remote-as %{hiera('bgp_as')}"
-      - 'route-reflector-client'
-      - 'soft-reconfiguration inbound'
-      - 'route-map rr-client-allow in'
-      - 'bfd'
-    'members':
-      - '172.30.0.26'
-      - '172.30.0.44'
-      - '172.30.0.45'
-      - '172.30.0.103'
-      - '172.30.0.104'
-      - '172.30.0.105'
-      - '172.30.0.111'
-    'options6':
-      - 'neighbor rr-clients route-reflector-client'
-      - 'neighbor rr-clients soft-reconfiguration inbound'
-      - 'maximum-paths ibgp 3'
-    'members6':
-      - 'fd00::44'
-      - 'fd00::45'
-      - 'fd00::103'
-      - 'fd00::104'
-      - 'fd00::105'
-      - 'fd00::111'
-#  'other-clients':
-#    'options':
-#    - 'peer-group'
 
 frrouting::frrouting::zebra_ip6_routes:
   - '::/0 2001:700:200:914::1'

--- a/hieradata/nodes/test01/test01-spine-02.yaml
+++ b/hieradata/nodes/test01/test01-spine-02.yaml
@@ -2,16 +2,20 @@
 # dummy variable, spine-02 doesn't really have an uplink interface
 profile::base::network::uplink_interface: 'swp48'
 
-network::interfaces_hash:
-  'eth0':
-    'ipaddress': "%{hiera('netcfg_mgmt_net_c6')}.2/21"
-    'gateway':   "%{hiera('netcfg_mgmt_gateway')}"
-    'vrf':       'mgmt'
-  'mgmt':
-    'ipaddress': '127.0.0.1/8'
-    'vrf_table': 'auto'
+bgp_loopback_addr: '10.255.255.2' # IP for elastic IP instances to peer to
+bgp_loopback_addr6: 'fcff::6:2'   # Needed for BGP-MP to work 
 
 profile::base::network::cumulus_interfaces:
+  'eth0':
+    'ipv4': "%{hiera('netcfg_mgmt_net_c6')}.2/21"
+    'gateway': "%{hiera('netcfg_mgmt_gateway')}"
+    'vrf': 'mgmt'
+  'mgmt':
+    'ipv4': '127.0.0.1/8'
+    'vrf_table': 'auto'
+  'lo':
+    'ipv4': [ "%{hiera('bgp_loopback_addr')}/32", ]
+    'ipv6': [ "%{hiera('bgp_loopback_addr6')}/128", ]
   'bridge.100':
     'ipv4': [ "%{hiera('netcfg_trp_net_c6')}.2/21", ]
     'ipv6': [ 'fd00::6:2/64', ]
@@ -23,39 +27,8 @@ profile::base::network::cumulus_interfaces:
     'clagd_enable': true
     'clagd_priority': '4096'
     'clagd_peer_ip': 'linklocal'
+    'clagd_backup_ip': "%{hiera('netcfg_trp_net_c6')}.1/21"
     'clagd_sys_mac': '44:38:39:ff:bb:2c'
-
-frrouting::frrouting::bgp_neighbor_groups:
-  'rr-clients':
-    'options':
-      - 'peer-group'
-      - "remote-as %{hiera('bgp_as')}"
-      - 'route-reflector-client'
-      - 'soft-reconfiguration inbound'
-      - 'route-map rr-client-allow in'
-      - 'bfd'
-    'members':
-      - '172.30.0.26'
-      - '172.30.0.44'
-      - '172.30.0.45'
-      - '172.30.0.103'
-      - '172.30.0.104'
-      - '172.30.0.105'
-      - '172.30.0.111'
-    'options6':
-      - 'neighbor rr-clients route-reflector-client'
-      - 'neighbor rr-clients soft-reconfiguration inbound'
-      - 'maximum-paths ibgp 3'
-    'members6':
-      - 'fd00::44'
-      - 'fd00::45'
-      - 'fd00::103'
-      - 'fd00::104'
-      - 'fd00::105'
-      - 'fd00::111'
-#  'other-clients':
-#    'options':
-#    - 'peer-group'
 
 frrouting::frrouting::zebra_ip6_routes:
   - '::/0 fd00:18:233::1'

--- a/hieradata/osl/common.yaml
+++ b/hieradata/osl/common.yaml
@@ -88,6 +88,7 @@ netcfg_anycast_dns:       '158.37.63.252'
 netcfg_anycast_dns6:      '2001:700:2:82ff::252'
 netcfg_ib_vlan:           '3379'
 netcfg_oob_vlan:          '3378'
+netcfg_elastic_cidr:      '10.6.0.0/20'
 netcfg_trp_rr:
   rr1:
     peer_ipv4: '172.18.38.1'

--- a/hieradata/test01/common.yaml
+++ b/hieradata/test01/common.yaml
@@ -78,6 +78,7 @@ netcfg_priv_network:    '10.0.250.0/24'
 netcfg_pub_natgw:       '129.177.31.121'
 netcfg_anycast_dns:     '129.177.31.118'
 netcfg_anycast_dns6:    '2001:700:200:917::3f18'
+netcfg_elastic_cidr:    '10.0.240.0/24'
 netcfg_trp_rr:
   rr1:
     peer_ipv4: '172.30.6.1'
@@ -197,6 +198,12 @@ profile::openstack::resource::networks:
     shared: false
     tenant_name: 'imagebuilder'
     provider_network_type: 'local'
+  Elastic_IP_test:
+    name: 'Elastic_IP_test'
+    admin_state_up: true
+    shared: false
+    tenant_name: 'openstack'
+    provider_network_type: 'local'
 
 profile::openstack::resource::subnets:
   public1_IPv4:
@@ -223,6 +230,18 @@ profile::openstack::resource::subnets:
       - '129.177.6.54'
     network_name: 'IPv6'
     tenant_name: 'openstack'
+  elastic1_IPv4:
+    name: 'elastic1_IPv4'
+    cidr: '10.0.240.0/24'
+    ip_version: '4'
+    allocation_pools:
+      - 'start=10.0.240.10,end=10.0.240.250'
+    gateway_ip: '10.0.240.1'
+    dns_nameservers:
+      - '129.177.31.118'
+      - '129.177.6.54'
+    network_name: 'Elastic_IP_test'
+    tenant_name: 'openstack'
   public1_ipv6:
     name: 'public1_IPv6'
     cidr: '2001:700:200:916::/64'
@@ -246,6 +265,18 @@ profile::openstack::resource::subnets:
       - '2001:700:200:917::3f18'
       - '2001:700:200:6::a1f:a1fa'
     network_name: 'dualStack'
+    tenant_name: 'openstack'
+  public3_ipv6:
+    name: 'public3_IPv6'
+    cidr: '2001:700:200:916::/64'
+    ip_version: '6'
+    allocation_pools:
+      - 'start=2001:700:200:916::4000,end=2001:700:200:916::7eff'
+    gateway_ip: '2001:700:200:916::1'
+    dns_nameservers:
+      - '2001:700:200:917::3f18'
+      - '2001:700:200:6::a1f:a1fa'
+    network_name: 'Elastic_IP_test'
     tenant_name: 'openstack'
   public2_IPv4:
     name: 'public2_IPv4'

--- a/hieradata/test01/roles/compute.yaml
+++ b/hieradata/test01/roles/compute.yaml
@@ -59,7 +59,7 @@ profile::base::network::routing_tables:
     'table_id':  '240'
 profile::base::network::rules:
   'team1':
-    iprule: [ "from %{hiera('netcfg_priv_network')} lookup private", ]
+    iprule: [ "from %{hiera('netcfg_priv_network')} lookup private", "from %{hiera('netcfg_elastic_cidr')} lookup private"  ]
 profile::base::network::manage_neutron_blackhole:      true # FIXME - remove when el7 is gone
 profile::network::interface::manage_neutron_blackhole: true
 

--- a/hieradata/test01/roles/spine.yaml
+++ b/hieradata/test01/roles/spine.yaml
@@ -11,7 +11,19 @@ named_interfaces::config:
 # FIXME:sensu-go
 profile::monitoring::sensu::agent::enable_go_agent:     false
 
+profile::monitoring::sensu::agent::enable_agent: false
+sensuclassic::install_repo: false
+sensuclassic::manage_repo: false
+
+openstack_extras::repo::debian::debian::source_hash:
+  'buster':
+    'location': 'http://ftp.no.debian.org/debian'
+    'repos':    'main'
+
 profile::monitoring::collectd::enable: true
+profile::base::common::manage_ntp:     false
+profile::base::common::manage_chrony:  true
+chrony::service_name: 'chrony@mgmt'
 
 profile::network::leaf::acls:
   '02control_plane_custom.rules':
@@ -274,42 +286,6 @@ profile::base::network::cumulus_bonds:
     'vids': [ '100', '110', '120', ]
     'mtu': '9216'
 
-frrouting::frrouting::zebra_interfaces:
-  'bridge':
-    - 'link-detect'
-    - 'description linux-bridge'
-  'bridge.100':
-    - 'link-detect'
-    - 'description linux-bridge-100'
-  'host1':
-    - 'link-detect'
-  'host2':
-    - 'link-detect'
-  'host3':
-    - 'link-detect'
-  'host4':
-    - 'link-detect'
-  'host5':
-    - 'link-detect'
-  'host6':
-    - 'link-detect'
-  'host7':
-    - 'link-detect'
-  'host8':
-    - 'link-detect'
-  'host9':
-    - 'link-detect'
-  'host10':
-    - 'link-detect'
-  'host11':
-    - 'link-detect'
-  'host12':
-    - 'link-detect'
-  'host13':
-    - 'link-detect'
-  'swp48':
-    - 'link-detect'
-
 profile::base::network::cumulus_bridges:
   'bridge':
     'ports':
@@ -335,39 +311,9 @@ profile::base::network::cumulus_bridges:
 
 frrouting::frrouting::zebra_interfaces:
   'bridge':
-    - 'link-detect'
     - 'description linux-bridge'
   'bridge.100':
-    - 'link-detect'
     - 'description linux-bridge-100'
-  'host1':
-    - 'link-detect'
-  'host2':
-    - 'link-detect'
-  'host3':
-    - 'link-detect'
-  'host4':
-    - 'link-detect'
-  'host5':
-    - 'link-detect'
-  'host6':
-    - 'link-detect'
-  'host7':
-    - 'link-detect'
-  'host8':
-    - 'link-detect'
-  'host9':
-    - 'link-detect'
-  'host10':
-    - 'link-detect'
-  'host11':
-    - 'link-detect'
-  'host12':
-    - 'link-detect'
-  'host13':
-    - 'link-detect'
-  'swp48':
-    - 'link-detect'
 
 frrouting::frrouting::zebra_generic_options:
   'ip':
@@ -383,33 +329,90 @@ frrouting::frrouting::bgp_options:
   - 'bgp default local-preference 200'
   - 'maximum-paths ibgp 5'
   - 'bgp bestpath as-path multipath-relax'
+  - 'aggregate-address 10.0.240.0/24 summary-only'
   - 'aggregate-address 10.0.250.0/24 summary-only'
   - 'aggregate-address 129.177.31.64/27 summary-only'
-  - 'aggregate-address 129.177.31.96/27 summary-only'
+#  - 'aggregate-address 129.177.31.96/27 summary-only' # Cannot aggregate network if anycasting addresses from that network
 frrouting::frrouting::bgp_options6:
   - 'aggregate-address 2001:700:200:915::/64 summary-only'
-  - 'aggregate-address 2001:700:200:916::/64 summary-only'
+#  - 'aggregate-address 2001:700:200:916::/64 summary-only'
 
 frrouting::frrouting::bgp_networks:
   - '0.0.0.0/0'
+  - "%{hiera('bgp_loopback_addr')}/32"
   - '172.30.0.0/21'
-  - 'aggregate-address 10.0.250.0/24 summary-only'
-  - 'aggregate-address 129.177.31.64/27 summary-only'
-  - 'aggregate-address 129.177.31.96/27 summary-only'
+  - '129.177.31.96/27'
 frrouting::frrouting::bgp_networks6:
   - '::/0'
   - 'fd00::/64'
+  - '2001:700:200:916::/64'
+
+frrouting::frrouting::bgp_neighbor_groups:
+  'rr-clients':
+    'options':
+      - 'peer-group'
+      - "remote-as %{hiera('bgp_as')}"
+      - 'addpath-tx-all-paths'
+      - 'route-reflector-client'
+      - 'soft-reconfiguration inbound'
+      - 'route-map rr-client-allow in'
+      - 'bfd'
+    'members':
+      - '172.30.0.26'
+      - '172.30.0.44'
+      - '172.30.0.45'
+      - '172.30.0.103'
+      - '172.30.0.104'
+      - '172.30.0.105'
+      - '172.30.0.111'
+    'options6':
+      - 'neighbor rr-clients route-reflector-client'
+      - 'neighbor rr-clients soft-reconfiguration inbound'
+      - 'neighbor rr-clients addpath-tx-all-paths'
+      - 'maximum-paths ibgp 5'
+    'members6':
+      - 'fd00::44'
+      - 'fd00::45'
+      - 'fd00::103'
+      - 'fd00::104'
+      - 'fd00::105'
+      - 'fd00::111'
+  'elastic_test':
+    'options':
+      - 'peer-group'
+      - "remote-as 4200000000" # 8 bytes private AS, set in secrets
+      - "password b1ecd7f662e6ff6ce03ab33626f92cfe" # MD5 bgp password, set in secrets
+      - 'soft-reconfiguration inbound'
+      - 'ebgp-multihop'
+      - 'bfd'
+    'options6':
+      - 'neighbor elastic_test activate'
+      - 'neighbor elastic_test soft-reconfiguration inbound'
+    'bgp_listen_range':
+      - "%{hiera('netcfg_elastic_cidr')}"
+    'ip_access_list':
+      - "192.168.100.100/32"
+      - "129.177.31.100/31 le 32" # minimum 31 and maximum 32 prefix length
+    'ip_access_list6':
+      - "2001:700:200:916::4000/127 le 128"
+      - "fc00::/64 le 128"
+#  'other-clients':
+#    'options':
+#    - 'peer-group'
 
 frrouting::frrouting::bgp_accesslist:
   '10':
-    - 'permit 129.177.31.0 0.0.0.255'
-    - 'permit 10.0.250.0 0.0.0.255'
-    - 'permit 172.30.0.0 0.0.7.255'
+    - 'seq 5 permit 129.177.31.0/24'
+    - "seq 10 permit %{hiera('netcfg_elastic_cidr')}"
+    - 'seq 15 permit 10.0.250.0/24'
+    - 'seq 20 permit 172.30.0.0/21'
+    - 'seq 250 deny 0.0.0.0/0'
   '20':
-    - 'deny 129.177.31.0 0.0.0.255'
-    - 'deny 10.0.250.0 0.0.0.255'
-    - 'deny 172.30.0.0 0.0.7.255'
-    - 'permit any'
+    - 'seq 5 deny 129.177.31.0/24'
+    - "seq 10 deny %{hiera('netcfg_elastic_cidr')}"
+    - 'seq 15 deny 10.0.250.0/24'
+    - 'seq 20 deny 172.30.0.0/21'
+    - 'seq 250 permit 0.0.0.0/0'
 
 frrouting::frrouting::bgp_ip_prefix_list:
   - 'routes-from-leaf1 seq 5 deny any'

--- a/hieradata/test02/common.yaml
+++ b/hieradata/test02/common.yaml
@@ -83,6 +83,7 @@ netcfg_priv_network:    '10.0.244.0/24'
 netcfg_pub_natgw:       '10.100.200.248'
 netcfg_anycast_dns:     '10.100.200.252'
 netcfg_anycast_dns6:    'fd34::252'
+netcfg_elastic_cidr:    '10.0.244.0/24'
 netcfg_trp_rr:
   rr1:
     peer_ipv4: '172.30.32.1'

--- a/profile/templates/bird/bird-nat.conf.8.erb
+++ b/profile/templates/bird/bird-nat.conf.8.erb
@@ -11,6 +11,13 @@ filter export_bgp {
   reject;
 }
 
+filter import_peer {
+  if dest = RTD_UNREACHABLE then {
+    reject;
+  }
+  accept;
+}
+
 # Configure synchronization between BIRD's routing tables and the
 # kernel.
 protocol kernel {
@@ -44,7 +51,7 @@ protocol direct {
   local as <%= scope().call_function('hiera',['bgp_as']) %>;
   neighbor <%= values["peer_ipv4"] %> as <%= scope().call_function('hiera',['bgp_as']) %>;
   ipv4 {
-    import all;
+    import filter import_peer;
     export filter export_bgp;
   };
   multihop;

--- a/profile/templates/bird/bird-resolver.conf.8.erb
+++ b/profile/templates/bird/bird-resolver.conf.8.erb
@@ -25,18 +25,28 @@ filter export_anycast6 {
 }
 
 filter import_bgp {
-  if  net != 0.0.0.0/0 then {
-    if net !=<%= scope().call_function('hiera',['netcfg_anycast_dns']) %>/32 then {
-      accept;
-    }
+  if dest = RTD_UNREACHABLE then {
+    reject;
   }
-  reject;
+  else {
+    if  net != 0.0.0.0/0 then {
+      if net !=<%= scope().call_function('hiera',['netcfg_anycast_dns']) %>/32 then {
+        accept;
+      }
+    }
+    reject;
+  }
 }
 
 filter import_bgp6 {
-  if  net != ::/0 then {
-    if net !=<%= scope().call_function('hiera',['netcfg_anycast_dns6']) %>/128 then {
-      accept;
+  if dest = RTD_UNREACHABLE then {
+    reject;
+  }
+  else {
+    if  net != ::/0 then {
+      if net !=<%= scope().call_function('hiera',['netcfg_anycast_dns6']) %>/128 then {
+        accept;
+      }
     }
   }
   reject;

--- a/profile/templates/bird/bird-rr-ipv4.erb
+++ b/profile/templates/bird/bird-rr-ipv4.erb
@@ -11,12 +11,13 @@ protocol bgp '<%= @name %>' {
   neighbor <%= @peer_ip %> as <%= @peer_as %>;
   multihop;
   ipv4 {
-  <% if @local_pref %>  import filter setpref;<% else %>  import all;<% end %>
+  <% if @local_pref %>  import filter setpref;<% else %>  import filter import_peer;<% end %>
   <% if @local_pref -%>
     default bgp_local_pref <%= @local_pref %>;
   <% end -%>
   export filter export_bgp;
     next hop self;    # Disable next hop processing and always advertise our local address as nexthop
+    add paths rx;     # Import ECMP routes
   };
   graceful restart;
   source address <%= @local_ip %>;  # The local address we use for the TCP connection

--- a/profile/templates/bird/bird-rr-ipv6.erb
+++ b/profile/templates/bird/bird-rr-ipv6.erb
@@ -11,12 +11,13 @@ protocol bgp '<%= @name %>' {
   neighbor <%= @peer_ip %> as <%= @peer_as %>;
   multihop;
   ipv6 {
-  <% if @local_pref %>  import filter setpref;<% else %>  import all;<% end %>
+  <% if @local_pref %>  import filter setpref;<% else %>  import filter import_peer;<% end %>
   <% if @local_pref -%>
     default bgp_local_pref <%= @local_pref %>;
   <% end -%>
   export filter export_bgp;
     next hop self;    # Disable next hop processing and always advertise our local address as nexthop
+    add paths rx;     # Import ECMP routes
   };
   graceful restart;
   source address <%= @local_ip %>;  # The local address we use for the TCP connection

--- a/profile/templates/bird/bird.conf.8.erb
+++ b/profile/templates/bird/bird.conf.8.erb
@@ -38,6 +38,13 @@ filter import_bgp {
   reject;
 }
 
+filter import_peer {
+  if dest = RTD_UNREACHABLE then {
+    reject;
+  }
+  accept;
+}
+
 filter export_bgp6 {
   if ( (ifname ~ "tap*") || (ifname ~ "atap*") || (ifname ~ "cali*") || (ifname ~ "dummy1") ) then {
     if  net != ::/0 then accept;

--- a/profile/templates/bird/bird.conf.bgo.8.erb
+++ b/profile/templates/bird/bird.conf.bgo.8.erb
@@ -38,6 +38,13 @@ filter import_bgp {
   reject;
 }
 
+filter import_peer {
+  if dest = RTD_UNREACHABLE then {
+    reject;
+  }
+  accept;
+}
+
 filter export_bgp6 {
   if ( (ifname ~ "tap*") || (ifname ~ "atap*") || (ifname ~ "cali*") || (ifname ~ "dummy1") ) then {
     if  net != ::/0 then accept;


### PR DESCRIPTION
**Overview**
These changes add the ability for selected instances in selected projects to announce IPv4/IPv6 prefixes with a BGP speaker of the user's choice to the NREC infrastructure. Usecases include MetalLB for container clusters and failover-handling haproxy servers.

**How it works**
The NREC Team defines a hash in <location>/roles/spine.yaml that includes a 4 byte AS number, an MD5 password, and one or more IPv4/IPv6 CIDRs that the user's project is allowed to announce. The user instances will do the BGP peering with loopback addresses on spine with the said AS number and MD5 password.

**Effect in the NREC infrastructure**
The BGP connections will be multihop eBGP with hops known already from BGP ("hops" being the compute hosts). This creates what is called recursive routing, and the bird routing daemon dislikes it. To that effect, all BGP peers that already exist need to be reconfigured with a filter that removes routes to unreachable destinations (ie, all prefixes announced from an instance). All compute hosts, resolvers, and nat nodes need new bird config, and all required templates are changed in this PR.

Only the compute hosts with workloads announcing will install routes (to the tap interface), so local workloads connecting to the prefix will always connect to the workload internally on that compute host. Compute hosts not hosting workloads announcing the prefix will send the traffic via default gateway. In order for this to work optimally, spines will now send all known paths to a prefix, and the bird routing daemon running on compute hosts (only) will import all of them before filtering out redundant paths via the kernel filter.

**Implementing the changes in production sites**
These changes are already running in the test01 region. Before deploying the changes into production, it will be prudent to disable puppet on all nodes, and then running puppet manually in this order:
spine/torack (a single one at first)
compute  (an empty single one at first)
nat (the one not being used at first)
resolver (a single one at first)
 
There should be minimal changes save for the bird part, but the frr template in puppet-frrouting has been extensively reworked. When these changes are implemented a reconfig will be done on the networking infrastructure combined with updating Cumulus Linux from 3.7.x to 4.3.x.
 