### PR TITLE
enable jumbo frames for trp network on remaining phyhosts

### DIFF
--- a/hieradata/osl/roles/cephmon.yaml
+++ b/hieradata/osl/roles/cephmon.yaml
@@ -19,7 +19,7 @@ profile::base::network::network_auto_opts:
   trp:
     'defroute': 'no'
     'ipv6init': 'no'
-    'mtu':      '1500'
+    'mtu': '9000'
     'devicetype': 'Team'
     'team_config': >-
                    { "runner" : {  "name" : "lacp",  "active": true, "fast_rate" : true,
@@ -30,10 +30,10 @@ profile::base::network::network_auto_bonding:
   trp:
     em1:
       'team_port_config': '{ "prio" : 100 }'
-      'mtu': '1500'
+      'mtu': '9000'
     em2:
       'team_port_config': '{ "prio" : 100 }'
-      'mtu': '1500'
+      'mtu': '9000'
 
 profile::base::common::manage_lvm: true
 profile::base::lvm::physical_volume:

--- a/hieradata/osl/roles/compute-atlas.yaml
+++ b/hieradata/osl/roles/compute-atlas.yaml
@@ -16,8 +16,10 @@ profile::base::network::network_auto_bonding:
   trp:
     eth0:
       'team_port_config': '{ "prio" : 100 }'
+      'mtu': '9000'
     eth1:
       'team_port_config': '{ "prio" : 100 }'
+      'mtu': '9000'
 
 # Turn off nested virtualization
 profile::virtualization::nested::manage: false

--- a/hieradata/osl/roles/storage.yaml
+++ b/hieradata/osl/roles/storage.yaml
@@ -11,6 +11,7 @@ profile::base::network::network_auto_opts:
   trp:
     'defroute': 'no'
     'devicetype': 'Team'
+    'mtu': '9000'
     'team_config': >-
                    { "runner" : {  "name" : "lacp",  "active": true, "fast_rate" : true,
                    "tx_hash": ["eth", "ipv4", "ipv6"], "tx_balancer": { "name": "basic" } },


### PR DESCRIPTION
All physical networking infrastructure is MTU 9000 enabled, and jumbo frames can now be enabled on all physical hosts.