### PR TITLE
bgo-compute-03: fix LVM vg_ext volume member not found

### DIFF
--- a/hieradata/nodes/bgo/bgo-compute-03.yaml
+++ b/hieradata/nodes/bgo/bgo-compute-03.yaml
@@ -43,14 +43,10 @@ profile::base::lvm::physical_volume:
   '/dev/sda3':
     ensure: present
     force:  true
-  '/dev/sdb':
-    ensure: present
-    force:  true
 profile::base::lvm::volume_group:
   'vg_ext':
     physical_volumes:
       - /dev/sda3
-      - /dev/sdb
 profile::base::lvm::logical_volume:
   'lv_instances':
     volume_group: 'vg_ext'


### PR DESCRIPTION
Remove LVM physical volume /dev/sdb from bgo-compute-03, this should solve the absence of vg_ext