### PR TITLE
add new neutron networks for elastic ip feature

### DIFF
--- a/hieradata/bgo/common.yaml
+++ b/hieradata/bgo/common.yaml
@@ -408,6 +408,12 @@ profile::openstack::resource::networks:
     shared: false
     tenant_name: 'openstack'
     provider_network_type: 'local'
+  elasticIP:
+    name: 'elasticIP'
+    admin_state_up: true
+    shared: false
+    tenant_name: 'openstack'
+    provider_network_type: 'local'
 
 profile::openstack::resource::subnets:
   public1_IPv4:
@@ -585,4 +591,26 @@ profile::openstack::resource::subnets:
     dns_nameservers:
       - "%{hiera('netcfg_anycast_dns6')}"
     network_name: 'educloud1'
+    tenant_name: 'openstack'
+  elastic1_IPv4:
+    name: 'elastic1_IPv4'
+    cidr: "%{hiera('netcfg_elastic_cidr')}"
+    ip_version: '4'
+    allocation_pools:
+      - 'start=10.5.0.10,end=10.5.15.240'
+    gateway_ip: '10.5.0.1'
+    dns_nameservers:
+      - "%{hiera('netcfg_anycast_dns')}"
+    network_name: 'elasticIP'
+    tenant_name: 'openstack'
+  elastic1_IPv6:
+    name: 'elastic1_IPv6'
+    cidr: '2001:700:2:8303::/64'
+    ip_version: '6'
+    allocation_pools:
+      - 'start=2001:700:2:8303::1000,end=2001:700:2:8303::4fff'
+    gateway_ip: '2001:700:2:8303::1'
+    dns_nameservers:
+      - "%{hiera('netcfg_anycast_dns6')}"
+    network_name: 'elasticIP'
     tenant_name: 'openstack'

--- a/hieradata/bgo/roles/compute.yaml
+++ b/hieradata/bgo/roles/compute.yaml
@@ -69,7 +69,7 @@ profile::base::network::routing_tables:
     'table_id':  '243'
 profile::base::network::rules:
   'team1':
-    'iprule':  [ "from %{hiera('netcfg_priv_network')} lookup private", "from %{hiera('netcfg_lhc_network')} lookup lhc", "from %{hiera('netcfg_lhcpriv_network')} lookup lhc-private", "from 158.37.64.0/24 to %{hiera('netcfg_uib_network')} lookup uib", "from %{hiera('netcfg_educloud1_network')} lookup private", ]
+    'iprule':  [ "from %{hiera('netcfg_priv_network')} lookup private", "from %{hiera('netcfg_lhc_network')} lookup lhc", "from %{hiera('netcfg_lhcpriv_network')} lookup lhc-private", "from 158.37.64.0/24 to %{hiera('netcfg_uib_network')} lookup uib", "from %{hiera('netcfg_educloud1_network')} lookup private", "from %{hiera('netcfg_elastic_cidr')} lookup private", ]
     'iprule6': [ "from %{hiera('netcfg_lhc_network6')} lookup lhc", "from %{hiera('netcfg_lhc2_network6')} lookup lhc", "from 2001:700:2:8302::/64 to %{hiera('netcfg_uib_network6')} lookup uib", ]
 profile::base::network::manage_neutron_blackhole:      true # FIXME - remove when el7 is gone
 profile::network::interface::manage_neutron_blackhole: true

--- a/hieradata/bgo/roles/spine.yaml
+++ b/hieradata/bgo/roles/spine.yaml
@@ -1315,9 +1315,10 @@ frrouting::frrouting::bgp_accesslist:
     - 'seq 25 permit 109.105.125.0 0.0.0.63'
     - 'seq 30 permit 10.1.0.0 0.0.15.255'
     - 'seq 35 permit 10.3.0.0 0.0.15.255'
-    - 'seq 40 permit 10.109.0.0 0.0.15.255'
-    - 'seq 45 permit 109.105.127.128 0.0.0.63'
-    - 'seq 50 permit 172.18.0.0 0.0.7.255'
+    - 'seq 40 permit 10.5.0.0/20'
+    - 'seq 45 permit 10.109.0.0 0.0.15.255'
+    - 'seq 50 permit 109.105.127.128 0.0.0.63'
+    - 'seq 55 permit 172.18.0.0 0.0.7.255'
     - 'seq 250 deny 0.0.0.0/0'
   '20':
     - 'seq 5 deny 158.37.64.0 0.0.1.255'
@@ -1327,9 +1328,10 @@ frrouting::frrouting::bgp_accesslist:
     - 'seq 25 deny 109.105.125.0 0.0.0.63'
     - 'seq 30 deny 10.1.0.0 0.0.15.255'
     - 'seq 35 deny 10.3.0.0 0.0.15.255'
-    - 'seq 40 deny 10.109.0.0 0.0.15.255'
-    - 'seq 45 deny 109.105.127.128 0.0.0.63'
-    - 'seq 50 deny 172.18.0.0 0.0.7.255'
+    - 'seq 40 deny 10.5.0.0/20'
+    - 'seq 45 deny 10.109.0.0 0.0.15.255'
+    - 'seq 50 deny 109.105.127.128 0.0.0.63'
+    - 'seq 55 deny 172.18.0.0 0.0.7.255'
     - 'seq 250 permit 0.0.0.0/0'
 
 frrouting::frrouting::bgp_accesslist6:

--- a/hieradata/osl/common.yaml
+++ b/hieradata/osl/common.yaml
@@ -398,6 +398,12 @@ profile::openstack::resource::networks:
     shared: false
     tenant_name: 'openstack'
     provider_network_type: 'local'
+  elasticIP:
+    name: 'elasticIP'
+    admin_state_up: true
+    shared: false
+    tenant_name: 'openstack'
+    provider_network_type: 'local'
 
 profile::openstack::resource::subnets:
   public1_IPv4:
@@ -509,4 +515,26 @@ profile::openstack::resource::subnets:
     dns_nameservers:
       - "%{hiera('netcfg_anycast_dns6')}"
     network_name: 'educloud1'
+    tenant_name: 'openstack'
+  elastic1_IPv4:
+    name: 'elastic1_IPv4'
+    cidr: "%{hiera('netcfg_elastic_cidr')}"
+    ip_version: '4'
+    allocation_pools:
+      - 'start=10.6.0.10,end=10.6.15.240'
+    gateway_ip: '10.6.0.1'
+    dns_nameservers:
+      - "%{hiera('netcfg_anycast_dns')}"
+    network_name: 'elasticIP'
+    tenant_name: 'openstack'
+  elastic1_IPv6:
+    name: 'elastic1_IPv6'
+    cidr: '2001:700:2:8203::/64'
+    ip_version: '6'
+    allocation_pools:
+      - 'start=2001:700:2:8203::1000,end=2001:700:2:8203::4fff'
+    gateway_ip: '2001:700:2:8203::1'
+    dns_nameservers:
+      - "%{hiera('netcfg_anycast_dns6')}"
+    network_name: 'elasticIP'
     tenant_name: 'openstack'

--- a/hieradata/osl/roles/compute.yaml
+++ b/hieradata/osl/roles/compute.yaml
@@ -37,7 +37,7 @@ profile::base::network::routing_tables:
     'table_id':  '240'
 profile::base::network::rules:
   'team1':
-    iprule: [ "from %{hiera('netcfg_priv_network')} lookup private", "from %{hiera('netcfg_educloud1_network')} lookup private", ]
+    iprule: [ "from %{hiera('netcfg_priv_network')} lookup private", "from %{hiera('netcfg_educloud1_network')} lookup private", "from %{hiera('netcfg_elastic_cidr')} lookup private", ]
 profile::base::network::manage_neutron_blackhole:      true # FIXME - remove when el7 is gone
 profile::network::interface::manage_neutron_blackhole: true
 

--- a/hieradata/osl/roles/spine.yaml
+++ b/hieradata/osl/roles/spine.yaml
@@ -793,7 +793,8 @@ frrouting::frrouting::bgp_accesslist:
     - 'seq 20 permit 158.39.200.0 0.0.0.255'
     - 'seq 25 permit 10.2.0.0 0.0.15.255'
     - 'seq 30 permit 10.4.0.0 0.0.15.255'
-    - 'seq 35 permit 172.18.32.0 0.0.0.255'
+    - 'seq 35 permit 10.6.0.0/20'
+    - 'seq 40 permit 172.18.32.0 0.0.0.255'
     - 'seq 250 deny 0.0.0.0/0'
   '20':
     - 'seq 5 deny 158.37.63.0 0.0.0.255'
@@ -802,7 +803,8 @@ frrouting::frrouting::bgp_accesslist:
     - 'seq 20 deny 158.39.200.0 0.0.0.255'
     - 'seq 25 deny 10.2.0.0 0.0.15.255'
     - 'seq 30 deny 10.4.0.0 0.0.15.255'
-    - 'seq 35 deny 172.18.32.0 0.0.0.255'
+    - 'seq 35 deny 10.6.0.0/20'
+    - 'seq 40 deny 172.18.32.0 0.0.0.255'
     - 'seq 250 permit 0.0.0.0/0'
 
 frrouting::frrouting::bgp_accesslist6:


### PR DESCRIPTION
Adds a private IPv4 neutron network, as well as a new public IPv6 network in the BGO and OSL regions. The IPv4 network will be used by instances BGP-peering with the NREC infrastructure in order to use the Elastic IP feature.