### PR TITLE
osl-compute-60.yaml: turn offloading back on

### DIFF
--- a/hieradata/nodes/osl/osl-compute-60.yaml
+++ b/hieradata/nodes/osl/osl-compute-60.yaml
@@ -3,11 +3,9 @@ profile::base::network::network_auto_bonding:
   trp:
     em3:
       'team_port_config': '{ "prio" : 100 }'
-      'ethtool_opts':  '-K ${DEVICE} gro off'
       'mtu': '9000'
     em4:
       'team_port_config': '{ "prio" : 100 }'
-      'ethtool_opts':  '-K ${DEVICE} gro off'
       'mtu': '9000'
 
 profile::base::network::network_auto_opts:


### PR DESCRIPTION
The server is in placeholder1 and FW is updated with the NIC fix

```
Installing Network_Firmware_PX3JF_LN64_22.61.10.77
Installed successfully
```