### PR TITLE
feat:Add ability to set jumbo frames for neutron networks

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -49,7 +49,7 @@ mod 'frrouting', :ref => '70450dd6de',              :git => github + 'norcams/pu
 # profile::network::
 #
 mod 'bird', :ref => 'v4.1.0',                       :git => github + 'voxpupuli/puppet-bird'
-mod 'calico', :ref => '7a59530de6',                 :git => github + 'norcams/puppet-calico'
+mod 'calico', :ref => 'v1.0.13',                    :git => github + 'norcams/puppet-calico'
 mod 'dnsmasq', :ref => 'b04a474295',                :git => github + 'saz/puppet-dnsmasq'
 mod 'ipcalc', :ref => '2.2.0',                      :git => github + 'inkblot/puppet-ipcalc'
 # FIXME: remove tinyproxy when all proxies have el8

--- a/hieradata/bgo/common.yaml
+++ b/hieradata/bgo/common.yaml
@@ -414,6 +414,7 @@ profile::openstack::resource::networks:
     shared: false
     tenant_name: 'openstack'
     provider_network_type: 'local'
+#    mtu: '9000' # FIXME: param available in puppet-neutron for Zed. Meanwhile, set once with CLI after creation
 
 profile::openstack::resource::subnets:
   public1_IPv4:

--- a/hieradata/bgo/roles/compute.yaml
+++ b/hieradata/bgo/roles/compute.yaml
@@ -100,6 +100,7 @@ profile::monitoring::sensu::agent::checks:
 
 calico::compute::bird_template:  'profile/bird/bird.conf.bgo.%{operatingsystemmajrelease}.erb'
 calico::compute::bird6_template: 'profile/bird/bird6.conf.bgo.erb'
+calico::compute::felix_mtuIfacePattern: '^team*'
 
 # Cron tabs for power metric
 profile::base::common::manage_cron: true

--- a/hieradata/common/modules/neutron.yaml
+++ b/hieradata/common/modules/neutron.yaml
@@ -63,6 +63,9 @@ neutron::config::server_config:
 #  keystone_authtoken/service_token_roles_required:
 #    value: 'true'
 
+neutron::global_physnet_mtu:     '9000'
+neutron::plugins::ml2::path_mtu: '9000'
+
 # quota (node: network)
 neutron::quota::quota_port:   '-1'
 

--- a/hieradata/local1/modules/neutron.yaml
+++ b/hieradata/local1/modules/neutron.yaml
@@ -6,3 +6,6 @@ neutron::debug: true
 
 neutron::server::api_workers:           1
 neutron::server::rpc_workers:           1
+
+neutron::global_physnet_mtu:     '1500'
+neutron::plugins::ml2::path_mtu: '1500'

--- a/hieradata/local2/modules/neutron.yaml
+++ b/hieradata/local2/modules/neutron.yaml
@@ -1,2 +1,5 @@
 ---
 neutron::keystone::authtoken::cafile: '/etc/pki/tls/certs/cachain.pem'
+
+neutron::global_physnet_mtu:     '1500'
+neutron::plugins::ml2::path_mtu: '1500'

--- a/hieradata/local3/modules/neutron.yaml
+++ b/hieradata/local3/modules/neutron.yaml
@@ -4,3 +4,6 @@ neutron::db::mysql::allowed_hosts:
 
 # neutron cli do not support ca_cert variable. Run without TSL in vagrant.
 neutron::keystone::auth::public_url: "%{hiera('endpoint__network__internal')}"
+
+neutron::global_physnet_mtu:     '1500'
+neutron::plugins::ml2::path_mtu: '1500'

--- a/hieradata/osl/common.yaml
+++ b/hieradata/osl/common.yaml
@@ -404,6 +404,7 @@ profile::openstack::resource::networks:
     shared: false
     tenant_name: 'openstack'
     provider_network_type: 'local'
+#    mtu: '9000' # FIXME: param available in puppet-neutron for Zed. Meanwhile, set once with CLI after creation
 
 profile::openstack::resource::subnets:
   public1_IPv4:

--- a/hieradata/osl/roles/compute.yaml
+++ b/hieradata/osl/roles/compute.yaml
@@ -72,3 +72,5 @@ profile::monitoring::sensu::agent::checks:
     command:      '/usr/local/bin/calico_dhcp_agent_check.sh'
     interval:     600
     subscribers:  ['checks']
+
+calico::compute::felix_mtuIfacePattern: '^team*'

--- a/hieradata/test01/common.yaml
+++ b/hieradata/test01/common.yaml
@@ -204,6 +204,7 @@ profile::openstack::resource::networks:
     shared: false
     tenant_name: 'openstack'
     provider_network_type: 'local'
+#    mtu: '9000' # FIXME: param available in puppet-neutron for Zed. Meanwhile, set once with CLI after creation
 
 profile::openstack::resource::subnets:
   public1_IPv4:

--- a/hieradata/test01/roles/compute.yaml
+++ b/hieradata/test01/roles/compute.yaml
@@ -127,6 +127,8 @@ sensu::agent::service_env_vars:
   PATH: '/usr/local/bin:/bin:/usr/bin:/opt/puppetlabs/bin:/opt/sensu-plugins-ruby/embedded/bin'
   HTTPS_PROXY: "%{hiera('mgmt__address__proxy')}:8888"
 
+calico::compute::felix_mtuIfacePattern: '^team*'
+
 nova::config::nova_config:
   DEFAULT/metadata_workers:
     value: '4'

--- a/hieradata/vagrant/modules/neutron.yaml
+++ b/hieradata/vagrant/modules/neutron.yaml
@@ -4,3 +4,6 @@ neutron::keystone::auth::public_url:    "%{hiera('endpoint__network__internal')}
 
 neutron::server::api_workers:           1
 neutron::server::rpc_workers:           1
+
+neutron::global_physnet_mtu:     '1500'
+neutron::plugins::ml2::path_mtu: '1500'


### PR DESCRIPTION
These changes add the ability to set higher MTU size for a neutron network in the BGO, OSL and test01 regions, where the underlaying infrastructure actually facilitates jumbo frames. The MTU change is not intended for the public "dualStack" and "IPv6" networks, and those networks will not be affected in any way, neither existing workloads, nor future workloads.

Implementing the changes will result in a neutron server restart on network nodes, and a calico-felix restart on the compute nodes.

After implementing the changes it's possible to set jumbo frames for a neutron network with OpenStack CLI. Dnsmasq for that network will restart and change it's parameters from "...host_mtu=1500,..." to host_mtu=9000. Configuration of workloads are transparent to the user, as instances attached to that network will automatically configure it's interface to MTU 9000.