### PR TITLE
allow vlan 130 and avoid future problems

### DIFF
--- a/hieradata/bgo/roles/leaf-v2.yaml
+++ b/hieradata/bgo/roles/leaf-v2.yaml
@@ -142,7 +142,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host49':
     'slaves': [ 'swp13s0', ]
@@ -150,7 +150,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host50':
     'slaves': [ 'swp13s1', ]
@@ -158,7 +158,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host51':
     'slaves': [ 'swp13s2', ]
@@ -166,7 +166,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host52':
     'slaves': [ 'swp13s3', ]
@@ -174,7 +174,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host53':
     'slaves': [ 'swp14s0', ]
@@ -182,7 +182,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host54':
     'slaves': [ 'swp14s1', ]
@@ -190,7 +190,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host55':
     'slaves': [ 'swp14s2', ]
@@ -198,7 +198,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host56':
     'slaves': [ 'swp14s3', ]
@@ -206,7 +206,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host57':
     'slaves': [ 'swp15s0', ]
@@ -214,7 +214,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host58':
     'slaves': [ 'swp15s1', ]
@@ -222,7 +222,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host59':
     'slaves': [ 'swp15s2', ]
@@ -230,7 +230,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host73':
     'slaves': [ 'swp19s0', ]
@@ -238,7 +238,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host74':
     'slaves': [ 'swp19s1', ]
@@ -246,7 +246,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host75':
     'slaves': [ 'swp19s2', ]
@@ -254,7 +254,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host76':
     'slaves': [ 'swp19s3', ]
@@ -262,7 +262,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host77':
     'slaves': [ 'swp20s0', ]
@@ -270,7 +270,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host78':
     'slaves': [ 'swp20s1', ]
@@ -278,7 +278,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host79':
     'slaves': [ 'swp20s2', ]
@@ -286,7 +286,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host80':
     'slaves': [ 'swp20s3', ]
@@ -294,7 +294,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host81':
     'slaves': [ 'swp21s0', ]
@@ -302,7 +302,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host82':
     'slaves': [ 'swp21s1', ]
@@ -310,7 +310,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host83':
     'slaves': [ 'swp21s2', ]
@@ -318,7 +318,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host84':
     'slaves': [ 'swp21s3', ]
@@ -326,7 +326,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host85':
     'slaves': [ 'swp22s0', ]
@@ -334,7 +334,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host86':
     'slaves': [ 'swp22s1', ]
@@ -342,7 +342,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host87':
     'slaves': [ 'swp22s2', ]
@@ -350,7 +350,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host88':
     'slaves': [ 'swp22s3', ]
@@ -358,7 +358,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host89':
     'slaves': [ 'swp23s0', ]
@@ -366,7 +366,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host90':
     'slaves': [ 'swp23s1', ]
@@ -374,7 +374,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host91':
     'slaves': [ 'swp23s2', ]
@@ -382,7 +382,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host92':
     'slaves': [ 'swp23s3', ]
@@ -390,13 +390,13 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'uplink':
     'slaves': [ 'swp29', 'swp30', ]
     'clag_id': '1004'
     'pvid': '100'
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
 
 # Edgecore as7726 needs explicit config

--- a/hieradata/bgo/roles/spine.yaml
+++ b/hieradata/bgo/roles/spine.yaml
@@ -250,19 +250,19 @@ profile::base::network::cumulus_bonds:
 #    'slaves': [ 'swp29-30', ]
 #    'clag_id': '1000'
 #    'pvid': '100'
-#    'vids': [ '100', '110', '120', ]
+#    'vids': [ '100', '110', '120', '130', ]
 #    'mtu': '9216'
   'downlinkl0102':
     'slaves': [ 'swp24-25', ]
     'clag_id': '1001'
     'pvid': '100'
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'downlinkl0304':
     'slaves': [ 'swp26-27', ]
     'clag_id': '1002'
     'pvid': '100'
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'uib_dc':
     'slaves': [ 'swp28s1', ]
@@ -275,7 +275,7 @@ profile::base::network::cumulus_bonds:
     'slaves': [ 'swp29-30', ]
     'clag_id': '1004'
     'pvid': '100'
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host1':
     'slaves': [ 'swp1s0', ]
@@ -283,7 +283,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host2':
     'slaves': [ 'swp1s1', ]
@@ -291,7 +291,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host3':
     'slaves': [ 'swp1s2', ]
@@ -299,7 +299,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host4':
     'slaves': [ 'swp1s3', ]
@@ -307,7 +307,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host5':
     'slaves': [ 'swp2s0', ]
@@ -315,7 +315,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host6':
     'slaves': [ 'swp2s1', ]
@@ -323,7 +323,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host7':
     'slaves': [ 'swp2s2', ]
@@ -331,7 +331,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host8':
     'slaves': [ 'swp2s3', ]
@@ -339,7 +339,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host9':
     'slaves': [ 'swp3s0', ]
@@ -347,7 +347,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host10':
     'slaves': [ 'swp3s1', ]
@@ -355,7 +355,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host11':
     'slaves': [ 'swp3s2', ]
@@ -363,7 +363,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host12':
     'slaves': [ 'swp3s3', ]
@@ -371,7 +371,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host13':
     'slaves': [ 'swp4s0', ]
@@ -379,7 +379,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host14':
     'slaves': [ 'swp4s1', ]
@@ -387,7 +387,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host15':
     'slaves': [ 'swp4s2', ]
@@ -395,7 +395,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host16':
     'slaves': [ 'swp4s3', ]
@@ -403,7 +403,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host17':
     'slaves': [ 'swp5s0', ]
@@ -411,7 +411,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host18':
     'slaves': [ 'swp5s1', ]
@@ -419,7 +419,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host19':
     'slaves': [ 'swp5s2', ]
@@ -427,7 +427,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host20':
     'slaves': [ 'swp5s3', ]
@@ -435,7 +435,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host21':
     'slaves': [ 'swp6s0', ]
@@ -443,7 +443,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host22':
     'slaves': [ 'swp6s1', ]
@@ -451,7 +451,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host23':
     'slaves': [ 'swp6s2', ]
@@ -459,7 +459,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host25':
     'slaves': [ 'swp7s0', ]
@@ -467,7 +467,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host26':
     'slaves': [ 'swp7s1', ]
@@ -475,7 +475,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host27':
     'slaves': [ 'swp7s2', ]
@@ -483,7 +483,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host28':
     'slaves': [ 'swp7s3', ]
@@ -491,7 +491,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host29':
     'slaves': [ 'swp8s0', ]
@@ -499,7 +499,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host30':
     'slaves': [ 'swp8s1', ]
@@ -507,7 +507,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host31':
     'slaves': [ 'swp8s2', ]
@@ -515,7 +515,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host32':
     'slaves': [ 'swp8s3', ]
@@ -523,7 +523,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host33':
     'slaves': [ 'swp9s0', ]
@@ -531,7 +531,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host34':
     'slaves': [ 'swp9s1', ]
@@ -539,7 +539,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host35':
     'slaves': [ 'swp9s2', ]
@@ -547,7 +547,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host36':
     'slaves': [ 'swp9s3', ]
@@ -555,7 +555,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host37':
     'slaves': [ 'swp10s0', ]
@@ -563,7 +563,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host38':
     'slaves': [ 'swp10s1', ]
@@ -571,7 +571,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host39':
     'slaves': [ 'swp10s2', ]
@@ -579,7 +579,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host40':
     'slaves': [ 'swp10s3', ]
@@ -587,7 +587,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host41':
     'slaves': [ 'swp11s0', ]
@@ -595,7 +595,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host42':
     'slaves': [ 'swp11s1', ]
@@ -603,7 +603,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host43':
     'slaves': [ 'swp11s2', ]
@@ -611,7 +611,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host44':
     'slaves': [ 'swp11s3', ]
@@ -619,7 +619,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host45':
     'slaves': [ 'swp12s0', ]
@@ -627,7 +627,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host46':
     'slaves': [ 'swp12s1', ]
@@ -635,7 +635,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host49':
     'slaves': [ 'swp13s0', ]
@@ -643,7 +643,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host50':
     'slaves': [ 'swp13s1', ]
@@ -651,7 +651,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host51':
     'slaves': [ 'swp13s2', ]
@@ -659,7 +659,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host52':
     'slaves': [ 'swp13s3', ]
@@ -667,7 +667,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host53':
     'slaves': [ 'swp14s0', ]
@@ -675,7 +675,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host54':
     'slaves': [ 'swp14s1', ]
@@ -683,7 +683,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host55':
     'slaves': [ 'swp14s2', ]
@@ -691,7 +691,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host56':
     'slaves': [ 'swp14s3', ]
@@ -699,7 +699,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host57':
     'slaves': [ 'swp15s0', ]
@@ -707,7 +707,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host58':
     'slaves': [ 'swp15s1', ]
@@ -715,7 +715,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host59':
     'slaves': [ 'swp15s2', ]
@@ -723,7 +723,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host60':
     'slaves': [ 'swp15s3', ]
@@ -731,7 +731,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host61':
     'slaves': [ 'swp16s0', ]
@@ -739,7 +739,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host62':
     'slaves': [ 'swp16s1', ]
@@ -747,7 +747,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host63':
     'slaves': [ 'swp16s2', ]
@@ -755,7 +755,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host64':
     'slaves': [ 'swp16s3', ]
@@ -763,7 +763,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host65':
     'slaves': [ 'swp17s0', ]
@@ -771,7 +771,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host66':
     'slaves': [ 'swp17s1', ]
@@ -779,7 +779,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host67':
     'slaves': [ 'swp17s2', ]
@@ -787,7 +787,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host68':
     'slaves': [ 'swp17s3', ]
@@ -795,7 +795,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host69':
     'slaves': [ 'swp18s0', ]
@@ -803,7 +803,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host70':
     'slaves': [ 'swp18s1', ]
@@ -811,7 +811,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host71':
     'slaves': [ 'swp18s2', ]
@@ -819,7 +819,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host72':
     'slaves': [ 'swp18s3', ]
@@ -827,7 +827,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host73':
     'slaves': [ 'swp19s0', ]
@@ -835,7 +835,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host74':
     'slaves': [ 'swp19s1', ]
@@ -843,7 +843,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host75':
     'slaves': [ 'swp19s2', ]
@@ -851,7 +851,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host76':
     'slaves': [ 'swp19s3', ]
@@ -859,7 +859,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host77':
     'slaves': [ 'swp20s0', ]
@@ -867,7 +867,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host78':
     'slaves': [ 'swp20s1', ]
@@ -875,7 +875,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host79':
     'slaves': [ 'swp20s2', ]
@@ -883,7 +883,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host80':
     'slaves': [ 'swp20s3', ]
@@ -891,7 +891,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host81':
     'slaves': [ 'swp21s0', ]
@@ -899,7 +899,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host82':
     'slaves': [ 'swp21s1', ]
@@ -907,7 +907,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host83':
     'slaves': [ 'swp21s2', ]
@@ -915,7 +915,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host84':
     'slaves': [ 'swp21s3', ]
@@ -923,7 +923,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host85':
     'slaves': [ 'swp22s0', ]
@@ -931,7 +931,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host86':
     'slaves': [ 'swp22s1', ]
@@ -939,7 +939,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host87':
     'slaves': [ 'swp22s2', ]
@@ -947,7 +947,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host88':
     'slaves': [ 'swp22s3', ]
@@ -955,7 +955,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host89':
     'slaves': [ 'swp23s0', ]
@@ -963,7 +963,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host90':
     'slaves': [ 'swp23s1', ]
@@ -971,7 +971,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
 
 profile::base::network::cumulus_bridges:

--- a/hieradata/test01/roles/spine.yaml
+++ b/hieradata/test01/roles/spine.yaml
@@ -180,7 +180,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host2':
     'slaves': [ 'swp2', ]
@@ -188,7 +188,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host3':
     'slaves': [ 'swp3', ]
@@ -196,7 +196,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host4':
     'slaves': [ 'swp4', ]
@@ -204,7 +204,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host5':
     'slaves': [ 'swp5', ]
@@ -212,7 +212,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host6':
     'slaves': [ 'swp6', ]
@@ -220,7 +220,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host7':
     'slaves': [ 'swp7', ]
@@ -228,7 +228,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host8':
     'slaves': [ 'swp8', ]
@@ -236,7 +236,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host9':
     'slaves': [ 'swp9', ]
@@ -244,7 +244,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host10':
     'slaves': [ 'swp10', ]
@@ -252,7 +252,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host11':
     'slaves': [ 'swp11', ]
@@ -260,7 +260,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host12':
     'slaves': [ 'swp12', ]
@@ -268,7 +268,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
   'host13':
     'slaves': [ 'swp13', ]
@@ -276,7 +276,7 @@ profile::base::network::cumulus_bonds:
     'pvid': '100'
     'mstpctl_portadminedge': true
     'mstpctl_bpduguard': true
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
 
 profile::base::network::cumulus_bridges:
@@ -299,7 +299,7 @@ profile::base::network::cumulus_bridges:
     'alias_name': 'Transport L2 if'
     'vlan_aware': 'true'
     'stp': 'true'
-    'vids': [ '100', '110', '120', ]
+    'vids': [ '100', '110', '120', '130', ]
     'mtu': '9216'
 
 frrouting::frrouting::zebra_interfaces:


### PR DESCRIPTION
These changes will allow connection from object-ceph nodes (with cluster networking over VLAN 130). While not currently connected to any  of these switches, it will typically be forgotten the day that happens, and these changes add consistancy across the network. The changes will not incur any immediate changes in the infrastructure, a reboot or manual ifup -a is necessary to actually implement the config change.