### PR TITLE
Run windows builds after patch tuesday

### DIFF
--- a/hieradata/nodes/bgo/bgo-builder-01.yaml
+++ b/hieradata/nodes/bgo/bgo-builder-01.yaml
@@ -17,13 +17,15 @@ profile::application::builder::windows_images:
   'winsrv_2019':
     'version':          '2019'
     'buildhost':        "bgo-controller-08.mgmt.bgo.uhdc.no"
-    'monthday':         '16'
+    'weekday':          *
+    'monthday':         '8-14'
     'hour':             3
     'minute':           0
   'winsrv_2022':
     'version':          '2022'
     'buildhost':        "bgo-controller-08.mgmt.bgo.uhdc.no"
-    'monthday':         '16'
+    'weekday':          *
+    'monthday':         '8-14'
     'hour':             6
     'minute':           0
 

--- a/hieradata/nodes/osl/osl-builder-01.yaml
+++ b/hieradata/nodes/osl/osl-builder-01.yaml
@@ -17,16 +17,17 @@ profile::application::builder::windows_images:
   'winsrv_2019':
     'version':          '2019'
     'buildhost':        "osl-controller-08.mgmt.osl.uhdc.no"
-    'monthday':         '16'
+    'weekday':          *
+    'monthday':         '8-14'
     'hour':             3
     'minute':           0
   'winsrv_2022':
     'version':          '2022'
     'buildhost':        "osl-controller-08.mgmt.osl.uhdc.no"
-    'monthday':         '16'
+    'weekday':          *
+    'monthday':         '8-14'
     'hour':             6
     'minute':           0
-
 
 profile::base::lvm::physical_volume:
   '/dev/sda':

--- a/hieradata/nodes/test01/test01-builder-01.yaml
+++ b/hieradata/nodes/test01/test01-builder-01.yaml
@@ -17,14 +17,14 @@ profile::application::builder::windows_images:
   'winsrv_2019':
     'version':          '2019'
     'buildhost':        "test01-controller-02.mgmt.test01.uhdc.no"
-    'weekday':          3
+    'weekday':          *
     'monthday':         '8-14'
     'hour':             3
     'minute':           0
   'winsrv_2022':
     'version':          '2022'
     'buildhost':        "test01-controller-02.mgmt.test01.uhdc.no"
-    'weekday':          3
+    'weekday':          *
     'monthday':         '8-14'
     'hour':             6
     'minute':           0

--- a/profile/manifests/application/builder/windows_jobs.pp
+++ b/profile/manifests/application/builder/windows_jobs.pp
@@ -30,8 +30,8 @@ define profile::application::builder::windows_jobs (
   } ->
   cron { $name:
     ensure      => $ensure,
-    # Write to imagebuilder report
-    command     => "/home/${user}/build_scripts/${name}_wrapper || jq -nc '{\"result\": \"failed\"}' > /var/log/imagebuilder/${name}-report.jsonl",
+    # Do not run unless it is Wednesday, and Write to imagebuilder report
+    command     => "test $(date +\%u) -eq 3 && /home/${user}/build_scripts/${name}_wrapper || jq -nc '{\"result\": \"failed\"}' > /var/log/imagebuilder/${name}-report.jsonl",
     user        => $user,
     weekday     => $weekday,
     monthday    => $monthday,


### PR DESCRIPTION
Cron is rather quirky, but these changes should ensure that the windows distributions are build *only* the second Wednesday each month. In effect it wil run every day with date 8 to 14, but will only execute if it's Wednesday.