### PR TITLE
feat: upgrade of admin and foreman

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -84,16 +84,17 @@ mod 'gitolite', :ref => '1.1',                      :git => github + 'uib/puppet
 # profile::application::foreman
 #
 mod 'voxpupuli/r10k', :ref => 'v6.2.0',             :git => github + 'voxpupuli/puppet-r10k'
-mod 'theforeman/foreman', :ref => '15.1.1',         :git => github + 'theforeman/puppet-foreman.git'
+mod 'theforeman/foreman', :ref => '23.2.0',         :git => github + 'theforeman/puppet-foreman.git'
 # mod 'theforeman/concat_native', '1.5.0'             # forge replace with puppetlabs-concat (further down)
-mod 'theforeman/tftp', :ref => '6.0.0',             :git => github + 'theforeman/puppet-tftp'
-mod 'theforeman/puppet', :ref => '14.0.0',          :git => github + 'theforeman/puppet-puppet.git'
+mod 'theforeman/tftp', :ref => '8.0.0',             :git => github + 'theforeman/puppet-tftp'
+mod 'theforeman/puppet', :ref => '18.0.0',          :git => github + 'theforeman/puppet-puppet.git'
+mod 'theforeman/puppetserver_foreman', :ref => '2.4.0', :git => github + 'theforeman/puppet-puppetserver_foreman'
 mod 'puppetlabs/hocon', :ref => '1.0.0',            :git => github + 'puppetlabs/puppetlabs-hocon'
 mod 'puppetlabs-puppetserver_gem', '1.1.1'          # need to install puppetserver gems
 mod 'puppetlabs/puppet_authorization', :ref => '0.4.0', :git => github + 'puppetlabs/puppetlabs-puppet_authorization'
-mod 'theforeman/dns', :ref => '8.0.0',              :git => github + 'theforeman/puppet-dns'
-mod 'theforeman/dhcp', :ref => '6.1.0',             :git => github + 'theforeman/puppet-dhcp.git'
-mod 'theforeman/foreman_proxy', :ref => '15.1.0',   :git => github + 'theforeman/puppet-foreman_proxy.git'
+mod 'theforeman/dns', :ref => '10.0.0',             :git => github + 'theforeman/puppet-dns'
+mod 'theforeman/dhcp', :ref => '9.0.0',             :git => github + 'theforeman/puppet-dhcp.git'
+mod 'theforeman/foreman_proxy', :ref => '25.1.0',   :git => github + 'theforeman/puppet-foreman_proxy.git'
 mod 'theforeman/git', :ref => '3.0.0',              :git => github + 'theforeman/puppet-git'
 mod 'voxpupuli/alternatives', :ref => 'v2.0.0',     :git => github + 'voxpupuli/puppet-alternatives'
 mod 'voxpupuli/extlib', :ref => 'v2.0.1-82-g53c6e2b', :git => github + 'voxpupuli/puppet-extlib.git'
@@ -125,7 +126,7 @@ mod 'sensuclassic', :ref => 'v3.5.0',               :git => github + 'sensu/pupp
 mod 'sensu', :ref => 'v5.8.0',                      :git => github + 'sensu/sensu-puppet'
 mod 'uchiwa', :ref => 'v1.0.1',                     :git => github + 'yelp/puppet-uchiwa'
 mod 'graphite', :ref => 'v7.2.0',                   :git => github + 'echocat/puppet-graphite' # fixed upstream
-mod 'redis', :ref => 'v8.0.0',                      :git => github + 'voxpupuli/puppet-redis'
+mod 'redis', :ref => 'v8.5.0',                      :git => github + 'voxpupuli/puppet-redis'
 mod 'grafana', :ref => 'v8.0.0',                    :git => github + 'voxpupuli/puppet-grafana'
 mod 'statsd', :ref => '3.1.0',                      :git => github + 'justindowning/puppet-statsd'
 mod 'netdata', :ref => '1f8bcef',                   :git => github + 'norcams/denver-netdata'
@@ -137,12 +138,12 @@ mod 'influxdb', :ref => 'norcams',                  :git => github + 'norcams/in
 #
 # profile::webserver::apache
 #
-mod 'puppetlabs/apache', :ref => 'v6.4.0',          :git => github + 'puppetlabs/puppetlabs-apache'
+mod 'puppetlabs/apache', :ref => 'v8.3.0',          :git => github + 'puppetlabs/puppetlabs-apache'
 
 #
 # profile::database::postgresql
 #
-mod 'postgresql', :ref => 'v6.8.0',                 :git => github + 'puppetlabs/puppetlabs-postgresql'
+mod 'postgresql', :ref => 'v7.4.0',                 :git => github + 'puppetlabs/puppetlabs-postgresql'
 
 #
 # profile::database::mariadb

--- a/Puppetfile
+++ b/Puppetfile
@@ -94,7 +94,7 @@ mod 'gitolite', :ref => '1.1',                      :git => github + 'uib/puppet
 #
 # bootstrap
 #
-mod 'himlar_bootstrap', :ref => '2.0.2',            :git => github + 'norcams/puppet-himlar_bootstrap'
+mod 'himlar_bootstrap', :ref => '2.2',              :git => github + 'norcams/puppet-himlar_bootstrap'
 
 #
 # profile::logging

--- a/Puppetfile
+++ b/Puppetfile
@@ -8,7 +8,7 @@ github = 'https://github.com/'
 # profile::base::common
 #
 mod 'sudo', :ref => 'v5.0.0',                       :git => github + 'saz/puppet-sudo'
-mod 'ssh', :ref => 'v6.2.0',                        :git => github + 'saz/puppet-ssh'
+mod 'ssh', :ref => 'v10.2.0',                       :git => github + 'saz/puppet-ssh'
 mod 'ntp', :ref => '7.0.0',                         :git => github + 'puppetlabs/puppetlabs-ntp'
 mod 'chrony', :ref => 'v1.0.0',                     :git => github + 'voxpupuli/puppet-chrony'
 mod 'accounts', :ref => '0fa8ec2e37',               :git => github + 'norcams/puppet-accounts'
@@ -97,7 +97,7 @@ mod 'theforeman/dhcp', :ref => '9.0.0',             :git => github + 'theforeman
 mod 'theforeman/foreman_proxy', :ref => '25.1.0',   :git => github + 'theforeman/puppet-foreman_proxy.git'
 mod 'theforeman/git', :ref => '3.0.0',              :git => github + 'theforeman/puppet-git'
 mod 'voxpupuli/alternatives', :ref => 'v2.0.0',     :git => github + 'voxpupuli/puppet-alternatives'
-mod 'voxpupuli/extlib', :ref => 'v2.0.1-82-g53c6e2b', :git => github + 'voxpupuli/puppet-extlib.git'
+mod 'voxpupuli/extlib', :ref => 'v6.2.0',           :git => github + 'voxpupuli/puppet-extlib.git'
 mod 'puppetlabs/ruby', :ref => '1.0.0',             :git => github + 'puppetlabs/puppetlabs-ruby'
 mod 'puppetlabs/xinetd', :ref => '3.0.0',           :git => github + 'puppetlabs/puppetlabs-xinetd'
 #mod 'eyaml', :ref => 'v0.3.0',                      :git => github + 'ghoneycutt/puppet-module-eyaml'
@@ -143,7 +143,7 @@ mod 'puppetlabs/apache', :ref => 'v8.3.0',          :git => github + 'puppetlabs
 #
 # profile::database::postgresql
 #
-mod 'postgresql', :ref => 'v7.4.0',                 :git => github + 'puppetlabs/puppetlabs-postgresql'
+mod 'postgresql', :ref => 'v9.2.0',                 :git => github + 'puppetlabs/puppetlabs-postgresql'
 
 #
 # profile::database::mariadb
@@ -218,7 +218,7 @@ mod 'subscription_manager', :ref => '5.5.0',        :git => github + 'waveclaw/p
 #
 # Common libs
 #
-mod 'stdlib', :ref => 'v7.0.0',                     :git => github + 'puppetlabs/puppetlabs-stdlib'
+mod 'stdlib', :ref => 'v8.6.0',                     :git => github + 'puppetlabs/puppetlabs-stdlib'
 mod 'translate', :ref => 'v2.2.0',                  :git => github + 'puppetlabs/puppetlabs-translate'
 mod 'concat', :ref => '4.1.0',                      :git => github + 'puppetlabs/puppetlabs-concat'
 mod 'hash_file', :ref => '1.0.3',                   :git => github + 'fiddyspence/puppet-hash_file' # ??

--- a/Puppetfile
+++ b/Puppetfile
@@ -28,6 +28,10 @@ mod 'named_interfaces', :ref => 'e5124925ba',       :git => github + 'norcams/pu
 mod 'network', :ref => '1f23e2e964',                :git => github + 'norcams/puppet-network'
 # mod 'apt', :ref => '2.2.2',                         :git => github + 'puppetlabs/puppetlabs-apt'
 mod 'selinux', :ref => 'v3.4.0',                    :git => github + 'voxpupuli/puppet-selinux'
+mod 'puppet', :ref => '18.0.0',                     :git => github + 'theforeman/puppet-puppet.git'
+mod 'systemd', :ref => 'v3.2.0',                    :git => github + 'voxpupuli/puppet-systemd'
+# used to manage yum repos
+mod 'openstack_extras', :ref => '16.4.0',           :git => github + 'openstack/puppet-openstack_extras'
 
 #
 # FreeBSD spesific
@@ -81,28 +85,11 @@ mod 'dpapp', :ref => '1.4',                         :git => github + 'norcams/pu
 #
 mod 'gitolite', :ref => '1.1',                      :git => github + 'uib/puppet-gitolite'
 
-# profile::application::foreman
-#
-mod 'voxpupuli/r10k', :ref => 'v6.2.0',             :git => github + 'voxpupuli/puppet-r10k'
-mod 'theforeman/foreman', :ref => '23.2.0',         :git => github + 'theforeman/puppet-foreman.git'
-# mod 'theforeman/concat_native', '1.5.0'             # forge replace with puppetlabs-concat (further down)
-mod 'theforeman/tftp', :ref => '8.0.0',             :git => github + 'theforeman/puppet-tftp'
-mod 'theforeman/puppet', :ref => '18.0.0',          :git => github + 'theforeman/puppet-puppet.git'
-mod 'theforeman/puppetserver_foreman', :ref => '2.4.0', :git => github + 'theforeman/puppet-puppetserver_foreman'
-mod 'puppetlabs/hocon', :ref => '1.0.0',            :git => github + 'puppetlabs/puppetlabs-hocon'
-mod 'puppetlabs-puppetserver_gem', '1.1.1'          # need to install puppetserver gems
-mod 'puppetlabs/puppet_authorization', :ref => '0.4.0', :git => github + 'puppetlabs/puppetlabs-puppet_authorization'
-mod 'theforeman/dns', :ref => '10.0.0',             :git => github + 'theforeman/puppet-dns'
-mod 'theforeman/dhcp', :ref => '9.0.0',             :git => github + 'theforeman/puppet-dhcp.git'
-mod 'theforeman/foreman_proxy', :ref => '25.1.0',   :git => github + 'theforeman/puppet-foreman_proxy.git'
-mod 'theforeman/git', :ref => '3.0.0',              :git => github + 'theforeman/puppet-git'
-mod 'voxpupuli/alternatives', :ref => 'v2.0.0',     :git => github + 'voxpupuli/puppet-alternatives'
-mod 'voxpupuli/extlib', :ref => 'v6.2.0',           :git => github + 'voxpupuli/puppet-extlib.git'
-mod 'puppetlabs/ruby', :ref => '1.0.0',             :git => github + 'puppetlabs/puppetlabs-ruby'
-mod 'puppetlabs/xinetd', :ref => '3.0.0',           :git => github + 'puppetlabs/puppetlabs-xinetd'
-#mod 'eyaml', :ref => 'v0.3.0',                      :git => github + 'ghoneycutt/puppet-module-eyaml'
-mod 'bind', :ref => '7.4.0',                        :git => github + 'inkblot/puppet-bind'
-mod 'systemd', :ref => 'v3.2.0',                    :git => github + 'voxpupuli/puppet-systemd'
+#mod 'voxpupuli/alternatives', :ref => 'v2.0.0',     :git => github + 'voxpupuli/puppet-alternatives'
+#mod 'voxpupuli/extlib', :ref => 'v6.2.0',           :git => github + 'voxpupuli/puppet-extlib.git'
+#mod 'puppetlabs/ruby', :ref => '1.0.0',             :git => github + 'puppetlabs/puppetlabs-ruby'
+#mod 'puppetlabs/xinetd', :ref => '3.0.0',           :git => github + 'puppetlabs/puppetlabs-xinetd'
+#mod 'systemd', :ref => 'v3.2.0',                    :git => github + 'voxpupuli/puppet-systemd'
 
 #
 # bootstrap
@@ -143,7 +130,7 @@ mod 'puppetlabs/apache', :ref => 'v8.3.0',          :git => github + 'puppetlabs
 #
 # profile::database::postgresql
 #
-mod 'postgresql', :ref => 'v9.2.0',                 :git => github + 'puppetlabs/puppetlabs-postgresql'
+#mod 'postgresql', :ref => 'v9.2.0',                 :git => github + 'puppetlabs/puppetlabs-postgresql'
 
 #
 # profile::database::mariadb
@@ -152,8 +139,8 @@ mod 'postgresql', :ref => 'v9.2.0',                 :git => github + 'puppetlabs
 # mod 'staging', :ref => '1.0.4',                   :git => github + 'nanliu/puppet-staging' why this fork?
 mod 'staging', :ref => 'v3.0.0',                    :git => github + 'voxpupuli/puppet-staging'
 # FIXME use version of mysql module
-mod 'mysql', :ref => 'norcams/v10.3.0',             :git => github + 'norcams/puppetlabs-mysql'
-mod 'galera_arbitrator', :ref => '1.0.4',           :git => github + 'jadestorm/puppet-galera_arbitrator'
+#mod 'mysql', :ref => 'norcams/v10.3.0',             :git => github + 'norcams/puppetlabs-mysql'
+#mod 'galera_arbitrator', :ref => '1.0.4',           :git => github + 'jadestorm/puppet-galera_arbitrator'
 
 #
 # profile::messaging::rabbitmq
@@ -162,28 +149,11 @@ mod 'erlang', :ref => '23fb75b8b1',                 :git => github + 'garethr/ga
 mod 'rabbitmq', :ref => 'v11.1.0',                  :git => github + 'voxpupuli/puppet-rabbitmq'
 mod 'archive', :ref => 'v2.2.0',                    :git => github + 'voxpupuli/puppet-archive'
 
-#
-# profile::openstack::*
-#
-mod 'glance', :ref => '16.5.0',                     :git => github + 'openstack/puppet-glance'
-mod 'cinder', :ref => '16.4.0',                     :git => github + 'openstack/puppet-cinder'
-mod 'neutron', :ref => '16.5.0',                    :git => github + 'openstack/puppet-neutron'
-mod 'nova',    :ref => '16.6.0',                    :git => github + 'openstack/puppet-nova'
-mod 'horizon', :ref => '16.4.0',                    :git => github + 'openstack/puppet-horizon'
-mod 'gnocchi', :ref => '14.4.0',                    :git => github + 'openstack/puppet-gnocchi'
-mod 'keystone', :ref => '16.4.0',                   :git => github + 'openstack/puppet-keystone'
-#mod 'swift', :ref => 'norcams/ocata',               :git => github + 'norcams/puppet-swift'
-mod 'ceilometer', :ref => '14.4.0',                 :git => github + 'openstack/puppet-ceilometer'
-mod 'designate', :ref => '16.4.0',                  :git => github + 'openstack/puppet-designate'
-mod 'cloudkitty', :ref => '3.4.0',                  :git => github + 'openstack/puppet-cloudkitty'
-mod 'placement', :ref => '2.5.0',                   :git => github + 'openstack/puppet-placement'
 
-mod 'oslo', :ref => '16.4.0',                       :git => github + 'openstack/puppet-oslo'
-mod 'openstacklib', :ref => '16.2.0',               :git => github + 'openstack/puppet-openstacklib'
-mod 'openstack_extras', :ref => '16.4.0',           :git => github + 'openstack/puppet-openstack_extras'
+#mod 'openstacklib', :ref => '16.2.0',               :git => github + 'openstack/puppet-openstacklib'
 mod 'sysctl', :ref => 'v0.0.11',                    :git => github + 'duritong/puppet-sysctl'
-mod 'memcached', :ref => 'v3.0.2',                  :git => github + 'saz/puppet-memcached'
-mod 'rsync', :ref => '0.4.0',                       :git => github + 'puppetlabs/puppetlabs-rsync'
+#mod 'memcached', :ref => 'v3.0.2',                  :git => github + 'saz/puppet-memcached'
+#mod 'rsync', :ref => '0.4.0',                       :git => github + 'puppetlabs/puppetlabs-rsync'
 
 #
 # libvirt
@@ -218,7 +188,8 @@ mod 'subscription_manager', :ref => '5.5.0',        :git => github + 'waveclaw/p
 #
 # Common libs
 #
-mod 'stdlib', :ref => 'v8.6.0',                     :git => github + 'puppetlabs/puppetlabs-stdlib'
+mod 'stdlib', :ref => 'v7.1.0',                     :git => github + 'puppetlabs/puppetlabs-stdlib'
+mod 'extlib', :ref => 'v6.2.0',                     :git => github + 'voxpupuli/puppet-extlib.git'
 mod 'translate', :ref => 'v2.2.0',                  :git => github + 'puppetlabs/puppetlabs-translate'
 mod 'concat', :ref => '4.1.0',                      :git => github + 'puppetlabs/puppetlabs-concat'
 mod 'hash_file', :ref => '1.0.3',                   :git => github + 'fiddyspence/puppet-hash_file' # ??

--- a/Puppetfile
+++ b/Puppetfile
@@ -94,7 +94,7 @@ mod 'gitolite', :ref => '1.1',                      :git => github + 'uib/puppet
 #
 # bootstrap
 #
-mod 'himlar_bootstrap', :ref => '2.0.1',            :git => github + 'norcams/puppet-himlar_bootstrap'
+mod 'himlar_bootstrap', :ref => '2.0.2',            :git => github + 'norcams/puppet-himlar_bootstrap'
 
 #
 # profile::logging

--- a/Puppetfile
+++ b/Puppetfile
@@ -94,7 +94,7 @@ mod 'gitolite', :ref => '1.1',                      :git => github + 'uib/puppet
 #
 # bootstrap
 #
-mod 'himlar_bootstrap', :ref => '2.2',              :git => github + 'norcams/puppet-himlar_bootstrap'
+mod 'himlar_bootstrap', :ref => '2.0.1',            :git => github + 'norcams/puppet-himlar_bootstrap'
 
 #
 # profile::logging

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -67,6 +67,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
       # Pass environment variables to the provisioning scripts
       ENV['HIMLAR_CERTNAME'] = "%s-%s-%s.%s" % [ n['location'],n['role'],n['hostid'],n['domain'] ]
+      ENV['HIMLAR_PUPPET_ENV'] = n['puppet_env']
       env_data = ENV.select { |k, _| /^HIMLAR_|^FACTER_/i.match(k) }
       args = env_data.map { |k, v| "#{k}=#{v}" }
       box.vm.provision :shell, :path => 'provision/puppetbootstrap.sh', args: args

--- a/hieradata/common/modules/foreman.yaml
+++ b/hieradata/common/modules/foreman.yaml
@@ -18,6 +18,10 @@ foreman::config::apache::serveraliases:
   - "foreman.%{hiera('domain_mgmt')}"
 
 profile::application::foreman::config:
+  ignore_facts_for_domain:
+    value:  'true'
+  update_hostgroup_from_facts:
+    value:  'false'
   create_new_host_when_facts_are_uploaded:
     value:  'false'
   default_location:
@@ -30,21 +34,9 @@ profile::application::foreman::config:
     value:  100
   root_pass:
     value:  '$1$16W5j9.P$wrGl0KophqmJwfADuUOIM/'
-  # template_sync_branch:
-  #   value:  'master'
-  # template_sync_dirname:
-  #   value:  '/norcams/'
-  # template_sync_prefix:
-  #   value:  'norcams-'
-  # template_sync_repo:
-  #   value:  'https://github.com/norcams/foreman-templates.git'
   trusted_hosts:
     value:  "[\"foreman.%{hiera('domain_mgmt')}\"]"
   update_ip_from_built_request:
     value:  'true'
   use_shortname_for_vms:
     value:  'true'
-
-# profile::application::foreman::plugins:
-#   hammer_cli_foreman_templates:
-#     package: 'rubygem-hammer_cli_foreman_templates'

--- a/hieradata/common/modules/foreman.yaml
+++ b/hieradata/common/modules/foreman.yaml
@@ -1,9 +1,11 @@
 ---
 foreman::foreman_url:                       "https://%{hiera('mgmt__address__foreman')}"
+foreman::unattended_url:                    "http://foreman.%{hiera('domain_mgmt')}"
 # Disable repo management
 foreman::custom_repo:                       true
 foreman::configure_epel_repo:               false
-foreman::configure_scl_repo:                true
+foreman::configure_scl_repo:                false
+
 foreman::initial_admin_username:            'admin'
 foreman::initial_admin_password:            'changeme'
 foreman::initial_admin_email:               'admin@localhost.localdomain'
@@ -11,7 +13,9 @@ foreman::ssl:                               true
 foreman::cli::manage_root_config:           true
 foreman::plugin::discovery::install_images: true
 foreman::db_host:                           '127.0.0.1'
-foreman::config::passenger::serveraliases:  [ "foreman.%{hiera('domain_mgmt')}" ]
+foreman::config::apache::servername:        "%{hiera('mgmt__address__foreman')}"
+foreman::config::apache::serveraliases:
+  - "foreman.%{hiera('domain_mgmt')}"
 
 profile::application::foreman::config:
   create_new_host_when_facts_are_uploaded:
@@ -24,27 +28,23 @@ profile::application::foreman::config:
     value:  'true'
   entries_per_page:
     value:  100
-  foreman_url:
-    value:  "https://foreman.%{hiera('domain_public')}"
   root_pass:
     value:  '$1$16W5j9.P$wrGl0KophqmJwfADuUOIM/'
-  template_sync_branch:
-    value:  'master'
-  template_sync_dirname:
-    value:  '/norcams/'
-  template_sync_prefix:
-    value:  'norcams-'
-  template_sync_repo:
-    value:  'https://github.com/norcams/foreman-templates.git'
+  # template_sync_branch:
+  #   value:  'master'
+  # template_sync_dirname:
+  #   value:  '/norcams/'
+  # template_sync_prefix:
+  #   value:  'norcams-'
+  # template_sync_repo:
+  #   value:  'https://github.com/norcams/foreman-templates.git'
   trusted_hosts:
-    value:  "[\"foreman.%{hiera('domain_public')}\"]"
-  unattended_url:
-    value:  "http://foreman.%{hiera('domain_mgmt')}"
+    value:  "[\"foreman.%{hiera('domain_mgmt')}\"]"
   update_ip_from_built_request:
     value:  'true'
   use_shortname_for_vms:
     value:  'true'
 
-profile::application::foreman::plugins:
-  hammer_cli_foreman_templates:
-    package: 'rubygem-hammer_cli_foreman_templates'
+# profile::application::foreman::plugins:
+#   hammer_cli_foreman_templates:
+#     package: 'rubygem-hammer_cli_foreman_templates'

--- a/hieradata/common/modules/foreman.yaml
+++ b/hieradata/common/modules/foreman.yaml
@@ -22,14 +22,10 @@ profile::application::foreman::config:
     value:  'Default Organization'
   destroy_vm_on_host_delete:
     value:  'true'
-  discovery_fact_column:
-    value:  'ipmi_ipaddress'
   entries_per_page:
     value:  100
   foreman_url:
     value:  "https://foreman.%{hiera('domain_public')}"
-  global_PXEGrub2:
-    value:  "norcams-PXEGrub2 global default"
   root_pass:
     value:  '$1$16W5j9.P$wrGl0KophqmJwfADuUOIM/'
   template_sync_branch:
@@ -51,4 +47,4 @@ profile::application::foreman::config:
 
 profile::application::foreman::plugins:
   hammer_cli_foreman_templates:
-    package: 'tfm-rubygem-hammer_cli_foreman_templates'
+    package: 'rubygem-hammer_cli_foreman_templates'

--- a/hieradata/common/modules/foreman_proxy.yaml
+++ b/hieradata/common/modules/foreman_proxy.yaml
@@ -18,7 +18,7 @@ foreman_proxy::dns_forwarders:       ['8.8.8.8']
 foreman_proxy::dns_managed:          false
 foreman_proxy::dns_provider:         'nsupdate'
 foreman_proxy::keyfile:              "/etc/rndc-%{::location}.key"
-foreman_proxy::puppet:               false
+foreman_proxy::puppet:               true
 foreman_proxy::puppetca:             true
 foreman_proxy::use_autosignfile:     true
 foreman_proxy::bmc:                  true

--- a/hieradata/common/modules/foreman_proxy.yaml
+++ b/hieradata/common/modules/foreman_proxy.yaml
@@ -18,9 +18,10 @@ foreman_proxy::dns_forwarders:       ['8.8.8.8']
 foreman_proxy::dns_managed:          false
 foreman_proxy::dns_provider:         'nsupdate'
 foreman_proxy::keyfile:              "/etc/rndc-%{::location}.key"
-foreman_proxy::puppetrun:            true
+foreman_proxy::puppet:               false
 foreman_proxy::puppetca:             true
 foreman_proxy::use_autosignfile:     true
 foreman_proxy::bmc:                  true
 foreman_proxy::bmc_default_provider: 'ipmitool'
 foreman_proxy::puppetca_modular:     true
+foreman_proxy::httpboot:             true

--- a/hieradata/common/modules/himlar_bootstrap.yaml
+++ b/hieradata/common/modules/himlar_bootstrap.yaml
@@ -1,4 +1,4 @@
 ---
-himlar_bootstrap::mirror:   'https://download.iaas.uio.no/nrec/prod/el8/almalinux-base/'
+himlar_bootstrap::mirror:   'https://download.iaas.uio.no/nrec/prod/el8/almalinux-base'
 # Himlarchangeme
 himlar_bootstrap::rootpw:   '$1$QVz7ss/3$vkvDqUJflvhVHu02K1MQy0'

--- a/hieradata/common/modules/profile.yaml
+++ b/hieradata/common/modules/profile.yaml
@@ -26,6 +26,9 @@ profile::base::httpproxy::http_proxy_profile:  '/root/proxy.sh'
 profile::base::dell::manage_repos:             true
 profile::base::dell::manage_openmanage:        true
 
+# Default puppet environment. Override in common/roles where needed
+puppet_environment: 'production'
+
 profile::base::common::packages:
   'tcpdump': {}
   'tree': {}

--- a/hieradata/common/modules/profile.yaml
+++ b/hieradata/common/modules/profile.yaml
@@ -123,7 +123,7 @@ profile::base::yumrepo::repo_hash:
     baseurl:        "%{hiera('yum_base_mirror')}/%{hiera('repo_dist')}/almalinux-AppStream/"
     gpgkey:         'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux'
     gpgcheck:       1
-    exclude:        'dnsmasq postgres*'
+    exclude:        'dnsmasq'
   AlmaLinux-PowerTools:
     descr:          'AlmaLinux-$releasever - PowerTools'
     baseurl:        "%{hiera('yum_base_mirror')}/%{hiera('repo_dist')}/almalinux-powertools/"
@@ -182,6 +182,12 @@ profile::base::yumrepo::repo_hash:
     baseurl:        "%{hiera('yum_base_mirror')}/%{hiera('repo_dist')}/puppetlabs6/"
     gpgkey:         "%{hiera('yum_base_mirror')}/%{hiera('repo_dist')}/puppetlabs6/RPM-GPG-KEY-puppet-20250406"
     gpgcheck:       1
+  puppetlabs7:
+    descr:          Puppet 7 Yum Repo
+    baseurl:        "%{hiera('yum_base_mirror')}/%{hiera('repo_dist')}/puppetlabs7/"
+    gpgkey:         "%{hiera('yum_base_mirror')}/%{hiera('repo_dist')}/puppetlabs7/RPM-GPG-KEY-puppet-20250406"
+    gpgcheck:       1
+    ensure:         absent
   epel:
     descr:          "Extra Packages for Enterprise Linux %{operatingsystemmajrelease} - $basearch"
     baseurl:        "%{hiera('yum_base_mirror')}/%{hiera('repo_dist')}/epel"

--- a/hieradata/common/modules/profile.yaml
+++ b/hieradata/common/modules/profile.yaml
@@ -26,9 +26,6 @@ profile::base::httpproxy::http_proxy_profile:  '/root/proxy.sh'
 profile::base::dell::manage_repos:             true
 profile::base::dell::manage_openmanage:        true
 
-# Default puppet environment. Override in common/roles where needed
-puppet_environment: 'production'
-
 profile::base::common::packages:
   'tcpdump': {}
   'tree': {}

--- a/hieradata/common/modules/puppet.yaml
+++ b/hieradata/common/modules/puppet.yaml
@@ -1,12 +1,11 @@
 ---
-puppet::runinterval:       1800
-puppet::runmode:           'cron'
-puppet::puppetmaster:      "puppet.%{hiera('domain_mgmt')}"
-puppet::show_diff:         true
-puppet::classfile:         '$statedir/classes.txt'
-puppet::usecacheonfailure: false
-puppet::client_certname:   "%{::verified_certname}"
-
+puppet::runinterval:            1800
+puppet::runmode:                'cron'
+puppet::show_diff:              true
+puppet::usecacheonfailure:      false
+puppet::client_certname:        "%{::verified_certname}"
+puppet::classfile:              '$statedir/classes.txt'
+puppet::agent_server_hostname:  "puppet.%{hiera('domain_mgmt')}"
 puppet::agent_additional_settings:
   'disable_warnings':   'deprecations'
   'stringify_facts':    'false'

--- a/hieradata/common/modules/puppet.yaml
+++ b/hieradata/common/modules/puppet.yaml
@@ -6,7 +6,6 @@ puppet::show_diff:         true
 puppet::classfile:         '$statedir/classes.txt'
 puppet::usecacheonfailure: false
 puppet::client_certname:   "%{::verified_certname}"
-puppet::environment:       "%{hiera('puppet_environment')}"
 
 puppet::agent_additional_settings:
   'disable_warnings':   'deprecations'

--- a/hieradata/common/modules/puppet.yaml
+++ b/hieradata/common/modules/puppet.yaml
@@ -6,6 +6,7 @@ puppet::show_diff:         true
 puppet::classfile:         '$statedir/classes.txt'
 puppet::usecacheonfailure: false
 puppet::client_certname:   "%{::verified_certname}"
+puppet::environment:       "%{hiera('puppet_environment')}"
 
 puppet::agent_additional_settings:
   'disable_warnings':   'deprecations'

--- a/hieradata/common/roles/access.yaml
+++ b/hieradata/common/roles/access.yaml
@@ -39,7 +39,7 @@ profile::webserver::apache::vhosts:
     serveraliases:
      - "%{hiera('public__address__access')}"
      - "access-%{::location}.%{hiera('domain_frontend')}"
-    port:               '80'
+    port:               80
     manage_docroot:     false
     docroot:            '/var/www/html'
     wsgi_application_group:  '%%{}{GLOBAL}'

--- a/hieradata/common/roles/admin.yaml
+++ b/hieradata/common/roles/admin.yaml
@@ -6,7 +6,6 @@ include:
     - profile::webserver::apache
 
 foreman_version: '3.8'
-puppet_environment: 'admin'
 
 sensu__disk__warning:     80
 sensu__disk__crtical:     90

--- a/hieradata/common/roles/admin.yaml
+++ b/hieradata/common/roles/admin.yaml
@@ -15,6 +15,7 @@ profile::base::common::packages:
   'bash-completion': {}
   'bash-completion-extras': {}
   'python3-requests': {}
+  'python3-pyyaml': {} # needed for ansible-foreman
   'ruby':
     ensure: '2.7'
     provider: 'dnfmodule'
@@ -116,4 +117,3 @@ named_interfaces::config:
     - eth0
   oob:
     - eth1
-

--- a/hieradata/common/roles/admin.yaml
+++ b/hieradata/common/roles/admin.yaml
@@ -19,10 +19,10 @@ profile::base::common::packages:
     ensure: '2.7'
     provider: 'dnfmodule'
     enable_only: true
-  'foreman':
-    ensure: "%{::os_platform}%{os_version}"
-    provider: 'dnfmodule'
-    enable_only: true
+  #  'foreman':
+    #  ensure: "%{::os_platform}%{os_version}"
+    #provider: 'dnfmodule'
+    #enable_only: true
   'toml-rb':
     ensure: present
     provider: 'puppetserver_gem'

--- a/hieradata/common/roles/admin.yaml
+++ b/hieradata/common/roles/admin.yaml
@@ -5,7 +5,7 @@ include:
     - profile::network::services
     - profile::webserver::apache
 
-foreman_version: '2.3'
+foreman_version: '3.8'
 
 sensu__disk__warning:     80
 sensu__disk__crtical:     90
@@ -14,7 +14,15 @@ sensu__memory__check:     "check-memory-percent.rb -w 85 -c 95"
 profile::base::common::packages:
   'bash-completion': {}
   'bash-completion-extras': {}
-  'python2-ruamel-yaml': {}
+  'python3-requests': {}
+  'ruby':
+    ensure: '2.7'
+    provider: 'dnfmodule'
+    enable_only: true
+  'foreman':
+    ensure: "%{::os_platform}%{os_version}"
+    provider: 'dnfmodule'
+    enable_only: true
   'toml-rb':
     ensure: present
     provider: 'puppetserver_gem'
@@ -26,6 +34,7 @@ profile::application::foreman::manage_firewall: true
 profile::application::foreman::manage_repo_dir: true
 profile::application::foreman::manage_r10k:     false
 profile::application::foreman::push_facts:      true
+
 # TODO: Move this up the hiera, it doesn't belong here.
 profile::application::foreman::dhcp_classes:
   onie_dell_s3048:
@@ -91,9 +100,9 @@ profile::base::yumrepo::repo_hash:
     ensure: present
   foreman-plugins:
     ensure: present
-  centos-sclo-rh:
-    ensure: present
-  postgres-10:
+  puppetlabs:
+    ensure: absent
+  puppetlabs7:
     ensure: present
 
 # Enable gem installation
@@ -108,4 +117,3 @@ named_interfaces::config:
   oob:
     - eth1
 
-openstack_version: 'train'

--- a/hieradata/common/roles/admin.yaml
+++ b/hieradata/common/roles/admin.yaml
@@ -6,6 +6,7 @@ include:
     - profile::webserver::apache
 
 foreman_version: '3.8'
+puppet_environment: 'admin'
 
 sensu__disk__warning:     80
 sensu__disk__crtical:     90

--- a/hieradata/common/roles/api.yaml
+++ b/hieradata/common/roles/api.yaml
@@ -133,18 +133,18 @@ profile::highavailability::loadbalancing::haproxy::haproxy_mapfile:
 profile::highavailability::loadbalancing::haproxy::haproxy_frontends:
   frontend_public:
     bind:
-      "%{::ipaddress_public1}:5000":  ['ssl', 'crt', "%{hiera('star_api_ssl_pem')}", 'crt', "%{hiera('star_api_ssl_pem2')}", 'crt', "%{hiera('frontend_star_ssl_pem')}", 'crt', "%{hiera('frontend_star_ssl_pem2')}"]
-      "%{::ipaddress_public1}:8041":  ['ssl', 'crt', "%{hiera('star_api_ssl_pem')}", 'crt', "%{hiera('star_api_ssl_pem2')}"]
-      "%{::ipaddress_public1}:8080":  ['ssl', 'crt', "%{hiera('star_api_ssl_pem')}", 'crt', "%{hiera('star_api_ssl_pem2')}"]
-      "%{::ipaddress_public1}:8778":  ['ssl', 'crt', "%{hiera('star_api_ssl_pem')}", 'crt', "%{hiera('star_api_ssl_pem2')}"]
-      "%{::ipaddress_public1}:8774":  ['ssl', 'crt', "%{hiera('star_api_ssl_pem')}", 'crt', "%{hiera('star_api_ssl_pem2')}"]
-      "%{::ipaddress_public1}:8776":  ['ssl', 'crt', "%{hiera('star_api_ssl_pem')}", 'crt', "%{hiera('star_api_ssl_pem2')}"]
-      "%{::ipaddress_public1}:9292":  ['ssl', 'crt', "%{hiera('star_api_ssl_pem')}", 'crt', "%{hiera('star_api_ssl_pem2')}"]
-      "%{::ipaddress_public1}:9696":  ['ssl', 'crt', "%{hiera('star_api_ssl_pem')}", 'crt', "%{hiera('star_api_ssl_pem2')}"]
-      "%{::ipaddress_public1}:9001":  ['ssl', 'crt', "%{hiera('star_api_ssl_pem')}", 'crt', "%{hiera('star_api_ssl_pem2')}"]
-      "%{::ipaddress_public1}:443":   ['ssl', 'crt', "%{hiera('frontend_star_ssl_pem')}", 'crt', "%{hiera('frontend_star_ssl_pem2')}"]
+      "%{::ipaddress_public1}:5000":  ['ssl', "crt %{hiera('star_api_ssl_pem')}", "crt %{hiera('star_api_ssl_pem2')}", "crt %{hiera('frontend_star_ssl_pem')}", "crt %{hiera('frontend_star_ssl_pem2')}"]
+      "%{::ipaddress_public1}:8041":  ['ssl', "crt %{hiera('star_api_ssl_pem')}", "crt %{hiera('star_api_ssl_pem2')}"]
+      "%{::ipaddress_public1}:8080":  ['ssl', "crt %{hiera('star_api_ssl_pem')}", "crt %{hiera('star_api_ssl_pem2')}"]
+      "%{::ipaddress_public1}:8778":  ['ssl', "crt %{hiera('star_api_ssl_pem')}", "crt %{hiera('star_api_ssl_pem2')}"]
+      "%{::ipaddress_public1}:8774":  ['ssl', "crt %{hiera('star_api_ssl_pem')}", "crt %{hiera('star_api_ssl_pem2')}"]
+      "%{::ipaddress_public1}:8776":  ['ssl', "crt %{hiera('star_api_ssl_pem')}", "crt %{hiera('star_api_ssl_pem2')}"]
+      "%{::ipaddress_public1}:9292":  ['ssl', "crt %{hiera('star_api_ssl_pem')}", "crt %{hiera('star_api_ssl_pem2')}"]
+      "%{::ipaddress_public1}:9696":  ['ssl', "crt %{hiera('star_api_ssl_pem')}", "crt %{hiera('star_api_ssl_pem2')}"]
+      "%{::ipaddress_public1}:9001":  ['ssl', "crt %{hiera('star_api_ssl_pem')}", "crt %{hiera('star_api_ssl_pem2')}"]
+      "%{::ipaddress_public1}:443":   ['ssl', "crt %{hiera('frontend_star_ssl_pem')}", "crt %{hiera('frontend_star_ssl_pem2')}"]
       "%{::ipaddress_public1}:80":    []
-      "%{::ipaddress_public1}:6080":  ['ssl', 'crt', "%{hiera('console_ssl_pem')}", 'crt', "%{hiera('console_ssl_pem2')}"]
+      "%{::ipaddress_public1}:6080":  ['ssl', "crt %{hiera('console_ssl_pem')}", "crt %{hiera('console_ssl_pem2')}"]
     options:
       - capture:        'request header Host len 64' #for debug
       - acl:

--- a/hieradata/common/roles/report.yaml
+++ b/hieradata/common/roles/report.yaml
@@ -87,7 +87,7 @@ profile::webserver::apache::vhosts:
      - "%{hiera('public__address__report')}"
      - "report-%{::location}.%{hiera('domain_frontend')}"
      - "report-%{::location}.%{hiera('domain_frontend2')}"
-    port:               '80'
+    port:               80
     manage_docroot:     false
     docroot:            '/var/www/html'
     wsgi_application_group:  '%%{}{GLOBAL}'

--- a/hieradata/local1/modules/foreman.yaml
+++ b/hieradata/local1/modules/foreman.yaml
@@ -1,2 +1,3 @@
 ---
+foreman::logging_level: 'debug'
 foreman::plugin::discovery::install_images: false

--- a/hieradata/local1/modules/himlar_bootstrap.yaml
+++ b/hieradata/local1/modules/himlar_bootstrap.yaml
@@ -1,4 +1,4 @@
 ---
-#himlar_bootstrap::puppetrepo:  '-b master https://github.com/norcams/himlar'
+himlar_bootstrap::puppetrepo:  '-b foreman_upgrade https://github.com/norcams/himlar'
 himlar_bootstrap::mirror:      'https://download.iaas.uio.no/nrec/test/el8/almalinux-base'
 himlar_bootstrap::yumrepo:     'https://download.iaas.uio.no/nrec/test/el8'

--- a/hieradata/local1/roles/login.yaml
+++ b/hieradata/local1/roles/login.yaml
@@ -10,6 +10,12 @@ profile::network::services::manage_nat:       false
 profile::network::nat::enable_masquerade:     true
 profile::network::nat::source:                "%{::network_mgmt1}/%{::netmask_mgmt1}"
 
+# Fix to avoid running ansible and other virtual with full paths when using sudo
+sudo::configs:
+  python_env:
+    priority: 20
+    content: 'Defaults    env_keep += "VIRTUAL_ENV VIRTUAL_ENV_PROMPT"'
+
 # Himlar bootstrap
 profile::bootstrap::himlar::manage_bootstrap_scripts: true
 himlar_bootstrap::tftp_install:

--- a/hieradata/local1/roles/login.yaml
+++ b/hieradata/local1/roles/login.yaml
@@ -3,6 +3,7 @@ include:
   default:
     - profile::bootstrap::himlar
     - profile::network::nat
+    - profile::application::himlarcli
 
 # Manage NAT with iptables
 profile::base::firewall::manage_firewall:     true

--- a/hieradata/local1/roles/login.yaml
+++ b/hieradata/local1/roles/login.yaml
@@ -10,12 +10,6 @@ profile::network::services::manage_nat:       false
 profile::network::nat::enable_masquerade:     true
 profile::network::nat::source:                "%{::network_mgmt1}/%{::netmask_mgmt1}"
 
-# Fix to avoid running ansible and other virtual with full paths when using sudo
-sudo::configs:
-  python_env:
-    priority: 20
-    content: 'Defaults    env_keep += "VIRTUAL_ENV VIRTUAL_ENV_PROMPT"'
-
 # Himlar bootstrap
 profile::bootstrap::himlar::manage_bootstrap_scripts: true
 himlar_bootstrap::tftp_install:

--- a/hieradata/nodes/local1/local1-login-01.yaml
+++ b/hieradata/nodes/local1/local1-login-01.yaml
@@ -5,8 +5,8 @@ network::interfaces_hash:
     ipaddress: '192.168.3.50'
     netmask:   '255.255.255.0'
     gateway:   '192.168.3.1'
-    dns1:      "%{hiera('netcfg_dns_server1')}"
-    dns2:      "%{hiera('netcfg_dns_server2')}"
+    dns1:      "%{hiera('netcfg_dns_mgmt_server1')}"
+    dns2:      "%{hiera('netcfg_dns_mgmt_server2')}"
     domain:    "%{hiera('netcfg_dns_search')}"
     defroute:  'yes'
     peerdns:   'yes'

--- a/hieradata/nodes/osl/osl-controller-08.yaml
+++ b/hieradata/nodes/osl/osl-controller-08.yaml
@@ -71,3 +71,6 @@ profile::application::windowsimage::manage_firewall: true
 profile::base::yumrepo::repo_hash:
   hashicorp:
     ensure: present
+
+# Himlar bootstrap
+profile::bootstrap::himlar::manage_bootstrap_scripts: true

--- a/hieradata/osl/modules/himlar_bootstrap.yaml
+++ b/hieradata/osl/modules/himlar_bootstrap.yaml
@@ -1,2 +1,3 @@
 ---
+himlar_bootstrap::puppetrepo:  '-b foreman_upgrade https://github.com/norcams/himlar' #FIXME:foreman
 himlar_bootstrap::nameserver:  '129.240.2.3'

--- a/hieradata/osl/roles/controller.yaml
+++ b/hieradata/osl/roles/controller.yaml
@@ -1,7 +1,7 @@
 ---
 himlar_bootstrap::virt_install:
   '%{location}-admin-01':
-    domain:          "%{hiera('mgmt.test01.uhdc.no')}"
+    domain:          "%{hiera('domain_mgmt')}"
     libvirt_pool:    'dirpool'
     libvirt_network: 'directnet'
     install_ip:      "%{hiera('netcfg_mgmt_net_c0')}.11"

--- a/hieradata/osl/roles/controller.yaml
+++ b/hieradata/osl/roles/controller.yaml
@@ -1,14 +1,14 @@
 ---
 himlar_bootstrap::virt_install:
   '%{location}-admin-01':
-    domain:          'mgmt.osl.uhdc.no'
+    domain:          "%{hiera('mgmt.test01.uhdc.no')}"
     libvirt_pool:    'dirpool'
     libvirt_network: 'directnet'
-    install_ip:      '172.16.32.11'
-    install_netmask: '255.255.248.0'
-    install_gateway: '172.16.32.10'
-    vm_vcpus:        2
-    vm_memory:       8096
+    install_ip:      "%{hiera('netcfg_mgmt_net_c0')}.11"
+    install_netmask: "%{hiera('netcfg_mgmt_netmask')}"
+    install_gateway: "%{hiera('netcfg_mgmt_net_c0')}.10" #login
+    vm_vcpus:        4
+    vm_memory:       16192
     vm_console:      false
     use_dhcp:        false
 

--- a/hieradata/test01/modules/himlar_bootstrap.yaml
+++ b/hieradata/test01/modules/himlar_bootstrap.yaml
@@ -1,5 +1,4 @@
 ---
-himlar_bootstrap::puppetrepo:  '-b foreman_upgrade https://github.com/norcams/himlar' #FIXME
+himlar_bootstrap::puppetrepo:  '-b foreman_upgrade https://github.com/norcams/himlar' #FIXME:foreman
 himlar_bootstrap::mirror:      'https://download.iaas.uio.no/nrec/test/el8/almalinux-base'
 himlar_bootstrap::nameserver:  '172.28.0.10' # test01-login-01
-

--- a/hieradata/test01/modules/himlar_bootstrap.yaml
+++ b/hieradata/test01/modules/himlar_bootstrap.yaml
@@ -3,6 +3,3 @@ himlar_bootstrap::puppetrepo:  '-b foreman_upgrade https://github.com/norcams/hi
 himlar_bootstrap::mirror:      'https://download.iaas.uio.no/nrec/test/el8/almalinux-base'
 himlar_bootstrap::nameserver:  '172.28.0.10' # test01-login-01
 
-################ TEMP DATA - SHOULD BE FIXED IN COMMON #########################
-# root pw is changeme
-himlar_bootstrap::rootpw:      '$1$WYxEZtjl$p7FADCWnip0OVmucqO4if/'

--- a/hieradata/test01/roles/report.yaml
+++ b/hieradata/test01/roles/report.yaml
@@ -42,7 +42,7 @@ profile::webserver::apache::vhosts:
      - "%{hiera('public__address__report')}"
      - "report-%{::location}.%{hiera('domain_frontend')}"
      - "report-%{::location}.%{hiera('domain_frontend2')}"
-    port:               '80'
+    port:               80
     manage_docroot:     false
     docroot:            '/var/www/html'
     wsgi_application_group:  '%%{}{GLOBAL}'

--- a/hieradata/vagrant/modules/foreman.yaml
+++ b/hieradata/vagrant/modules/foreman.yaml
@@ -1,0 +1,2 @@
+---
+foreman::logging_level: 'debug'

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -69,7 +69,7 @@ $runmode_classes = lookup("include.${::runmode}", Array, 'deep', [])
 $runmode_classes.include
 
 # Output the node classification data
-info("certname=${verified_certname} location=${location} role=${role} hostid=${hostid} runmode=${::runmode}")
+info("certname=${verified_certname} env=${environment} location=${location} role=${role} hostid=${hostid} runmode=${::runmode}")
 info(join($runmode_classes,' '))
 
 # Empty default node

--- a/nodes.yaml
+++ b/nodes.yaml
@@ -84,7 +84,7 @@ nodesets:
     #  memory:     1024
     #- role:       "nat"
     #  box:        "norcams/freebsd"
-    #- role:       "admin"
+    - role:       "admin"
     #  box:        "norcams/base"
     #  memory:     2048
     #- role:       "ns"

--- a/nodes.yaml
+++ b/nodes.yaml
@@ -9,6 +9,7 @@ defaults:
   autostart:   true
   primary:     false
   location:    "vagrant"
+  puppet_env:  "production"
   domain:      "mgmt.vagrant.iaas.intern"
   cpus:        1
   memory:      1024
@@ -35,19 +36,28 @@ defaults:
 nodesets:
   default:
     - role:       "db-global"
+      puppet_env: "ussuri"
     - role:       "db-regional"
+      puppet_env: "ussuri"
     - role:       "api"
       box:        "norcams/base"
     - role:       "mq"
     - role:       "identity"
+      puppet_env: "ussuri"
     - role:       "novactrl"
+      puppet_env: "ussuri"
     - role:       "image"
+      puppet_env: "ussuri"
     - role:       "network"
+      puppet_env: "ussuri"
     - role:       "volume"
+      puppet_env: "ussuri"
     - role:       "dashboard"
+      puppet_env: "ussuri"
     - role:       "compute"
       memory:     4096
       cpus:       2
+      puppet_env: "ussuri"
   # The following nodes are optional
     #- role:       "access"
     #- role:       "identity"
@@ -85,6 +95,7 @@ nodesets:
     #- role:       "nat"
     #  box:        "norcams/freebsd"
     - role:       "admin"
+      puppet_env: "admin"
     #  box:        "norcams/base"
     #  memory:     2048
     #- role:       "ns"

--- a/profile/manifests/application/foreman.pp
+++ b/profile/manifests/application/foreman.pp
@@ -37,6 +37,7 @@ class profile::application::foreman(
   include ::foreman::plugin::hooks
   include ::foreman::plugin::discovery
   include ::foreman::plugin::templates
+  include ::foreman::plugin::puppet
 
   if $manage_r10k {
     include ::r10k

--- a/profile/manifests/base/package.pp
+++ b/profile/manifests/base/package.pp
@@ -3,14 +3,16 @@
 define profile::base::package (
   $ensure = 'present',
   $provider = undef,
-  $source = undef
+  $source = undef,
+  $enable_only = undef,
 ) {
 
   unless $ensure == 'absent' {
     package { $name:
-      ensure   => $ensure,
-      provider => $provider,
-      source   => $source
+      ensure      => $ensure,
+      provider    => $provider,
+      source      => $source,
+      enable_only => $enable_only
     }
   }
 

--- a/provision/puppetbootstrap.sh
+++ b/provision/puppetbootstrap.sh
@@ -68,6 +68,10 @@ bootstrap_puppet()
     dnf -y upgrade
     dnf install -y puppet-agent git-core vim network-scripts gcc make
 
+    #r10k bug: https://github.com/puppetlabs/r10k/issues/1370
+    /opt/puppetlabs/puppet/bin/gem install -N faraday-net_http -v 3.0.2
+    /opt/puppetlabs/puppet/bin/gem install -N faraday -v 2.8.1
+
     /opt/puppetlabs/puppet/bin/gem install -N r10k
     # this is need one puppetmaster for some modules
     # in vagrant we will need this on all nodes

--- a/provision/puppetbootstrap.sh
+++ b/provision/puppetbootstrap.sh
@@ -46,9 +46,9 @@ EOM
   # Add our puppetlabs mirror
 cat > /etc/yum.repos.d/puppetlabs.repo <<- EOM
 [puppetlabs]
-name=Puppet 6 Yum Repo
-baseurl=$repo/puppetlabs6/
-gpgkey=$repo/puppetlabs6/RPM-GPG-KEY-puppet-20250406
+name=Puppet 7 Yum Repo
+baseurl=$repo/puppetlabs7/
+gpgkey=$repo/puppetlabs7/RPM-GPG-KEY-puppet-20250406
 enabled=1
 gpgcheck=1
 EOM
@@ -68,13 +68,13 @@ bootstrap_puppet()
     dnf -y upgrade
     dnf install -y puppet-agent git-core vim network-scripts gcc make
 
-    /opt/puppetlabs/puppet/bin/gem install -N puppet_forge -v 3.2.0
-    /opt/puppetlabs/puppet/bin/gem install -N r10k -v 3.16.0
+    /opt/puppetlabs/puppet/bin/gem install -N r10k
     # this is need one puppetmaster for some modules
     # in vagrant we will need this on all nodes
     /opt/puppetlabs/puppet/bin/gem install -N toml-rb
-    # /opt/puppetlabs/puppet/bin/gem install -N puppet_forge
-    ln -sf /opt/puppetlabs/puppet/bin/wrapper.sh /opt/puppetlabs/bin/r10k
+
+    # The r10k path must be the same as in puppetmodules.sh
+    ln -sf /opt/puppetlabs/puppet/bin/r10k /opt/puppetlabs/bin/r10k
 
   elif command -v yum >/dev/null 2>&1; then
     echo "bootstrap puppet for el7..."

--- a/provision/puppetrun.sh
+++ b/provision/puppetrun.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+#CODE_PATH=/etc/puppetlabs/code
+#PUPPET_ENV="${HIMLAR_PUPPET_ENV:-production}"
+#ENV_PATH=environments/$PUPPET_ENV
+
 set_certname()
 {
   # Set default certname
@@ -25,12 +29,18 @@ bootstraprun()
 
 puppetrun()
 {
+  CODE_PATH=/etc/puppetlabs/code
+  PUPPET_ENV="${HIMLAR_PUPPET_ENV:-production}"
+  ENV_PATH=environments/$PUPPET_ENV
+
+  echo "puppet run for environment ${PUPPET_ENV}"
   /opt/puppetlabs/puppet/bin/puppet apply --verbose --show_diff \
     --certname $certname \
     --write-catalog-summary \
-    --basemodulepath /opt/himlar/modules:/etc/puppetlabs/code/modules \
+    --hiera_config $CODE_PATH/$ENV_PATH/hiera.yaml \
+    --basemodulepath /opt/himlar/modules:$CODE_PATH/$ENV_PATH/modules:$CODE_PATH/modules \
     ${p_args[*]} \
-    /etc/puppetlabs/code/environments/production/manifests/site.pp
+    $CODE_PATH/$ENV_PATH/manifests/site.pp
 }
 
 # Source command line options as env vars

--- a/provision/puppetrun.sh
+++ b/provision/puppetrun.sh
@@ -37,6 +37,7 @@ puppetrun()
   /opt/puppetlabs/puppet/bin/puppet apply --verbose --show_diff \
     --certname $certname \
     --write-catalog-summary \
+    --environment ${PUPPET_ENV} \
     --hiera_config $CODE_PATH/$ENV_PATH/hiera.yaml \
     --basemodulepath /opt/himlar/modules:$CODE_PATH/$ENV_PATH/modules:$CODE_PATH/modules \
     ${p_args[*]} \

--- a/puppetfiles/admin.Puppetfile
+++ b/puppetfiles/admin.Puppetfile
@@ -1,0 +1,30 @@
+#
+# git repo base URIs
+#
+github = 'https://github.com/'
+#local  = 'iaas@git.norcams.org:'
+
+#
+# Modules used only by profile::application::foreman
+#
+mod 'voxpupuli/r10k', :ref => 'v11.0.1',            :git => github + 'voxpupuli/puppet-r10k'
+mod 'theforeman/foreman', :ref => '23.2.0',         :git => github + 'theforeman/puppet-foreman.git'
+mod 'theforeman/tftp', :ref => '8.0.0',             :git => github + 'theforeman/puppet-tftp'
+mod 'theforeman/puppet', :ref => '18.0.0',          :git => github + 'theforeman/puppet-puppet.git'
+mod 'theforeman/puppetserver_foreman', :ref => '2.4.0', :git => github + 'theforeman/puppet-puppetserver_foreman'
+mod 'puppetlabs/hocon', :ref => '1.0.0',            :git => github + 'puppetlabs/puppetlabs-hocon'
+mod 'puppetlabs-puppetserver_gem', '1.1.1'          # need to install puppetserver gems
+mod 'puppetlabs/puppet_authorization', :ref => '0.4.0', :git => github + 'puppetlabs/puppetlabs-puppet_authorization'
+mod 'theforeman/dns', :ref => '10.0.0',             :git => github + 'theforeman/puppet-dns'
+mod 'theforeman/dhcp', :ref => '9.0.0',             :git => github + 'theforeman/puppet-dhcp.git'
+mod 'theforeman/foreman_proxy', :ref => '25.1.0',   :git => github + 'theforeman/puppet-foreman_proxy.git'
+mod 'theforeman/git', :ref => '3.0.0',              :git => github + 'theforeman/puppet-git'
+mod 'voxpupuli/alternatives', :ref => 'v2.0.0',     :git => github + 'voxpupuli/puppet-alternatives'
+mod 'puppetlabs/ruby', :ref => '1.0.0',             :git => github + 'puppetlabs/puppetlabs-ruby'
+mod 'puppetlabs/xinetd', :ref => '3.0.0',           :git => github + 'puppetlabs/puppetlabs-xinetd'
+mod 'bind', :ref => '7.4.0',                        :git => github + 'inkblot/puppet-bind'
+mod 'postgresql', :ref => 'v7.4.0',                 :git => github + 'puppetlabs/puppetlabs-postgresql'
+
+#
+# Override module version of common modules
+#

--- a/puppetfiles/ussuri.Puppetfile
+++ b/puppetfiles/ussuri.Puppetfile
@@ -25,3 +25,8 @@ mod 'memcached', :ref => 'v3.0.2',                  :git => github + 'saz/puppet
 mod 'rsync', :ref => '0.4.0',                       :git => github + 'puppetlabs/puppetlabs-rsync'
 mod 'mysql', :ref => 'norcams/v10.3.0',             :git => github + 'norcams/puppetlabs-mysql'
 mod 'galera_arbitrator', :ref => '1.0.4',           :git => github + 'jadestorm/puppet-galera_arbitrator'
+
+#
+# override common modules
+#
+mod 'puppetlabs/apache', :ref => 'v6.4.0',          :git => github + 'puppetlabs/puppetlabs-apache'

--- a/puppetfiles/ussuri.Puppetfile
+++ b/puppetfiles/ussuri.Puppetfile
@@ -1,0 +1,27 @@
+#
+# git repo base URIs
+#
+github = 'https://github.com/'
+#local  = 'iaas@git.norcams.org:'
+
+#
+# profile::openstack::*
+#
+mod 'glance', :ref => '16.5.0',                     :git => github + 'openstack/puppet-glance'
+mod 'cinder', :ref => '16.4.0',                     :git => github + 'openstack/puppet-cinder'
+mod 'neutron', :ref => '16.5.0',                    :git => github + 'openstack/puppet-neutron'
+mod 'nova',    :ref => '16.6.0',                    :git => github + 'openstack/puppet-nova'
+mod 'horizon', :ref => '16.4.0',                    :git => github + 'openstack/puppet-horizon'
+mod 'gnocchi', :ref => '14.4.0',                    :git => github + 'openstack/puppet-gnocchi'
+mod 'keystone', :ref => '16.4.0',                   :git => github + 'openstack/puppet-keystone'
+mod 'ceilometer', :ref => '14.4.0',                 :git => github + 'openstack/puppet-ceilometer'
+mod 'designate', :ref => '16.4.0',                  :git => github + 'openstack/puppet-designate'
+mod 'cloudkitty', :ref => '3.4.0',                  :git => github + 'openstack/puppet-cloudkitty'
+mod 'placement', :ref => '2.5.0',                   :git => github + 'openstack/puppet-placement'
+
+mod 'oslo', :ref => '16.4.0',                       :git => github + 'openstack/puppet-oslo'
+mod 'openstacklib', :ref => '16.2.0',               :git => github + 'openstack/puppet-openstacklib'
+mod 'memcached', :ref => 'v3.0.2',                  :git => github + 'saz/puppet-memcached'
+mod 'rsync', :ref => '0.4.0',                       :git => github + 'puppetlabs/puppetlabs-rsync'
+mod 'mysql', :ref => 'norcams/v10.3.0',             :git => github + 'norcams/puppetlabs-mysql'
+mod 'galera_arbitrator', :ref => '1.0.4',           :git => github + 'jadestorm/puppet-galera_arbitrator'


### PR DESCRIPTION
This will contain a multitude of upgrades:

- Two new puppet environment with its own Puppetfile: `admin` and `ussuri`
- Updated provision script for multiple puppet environements
- Upgrade puppet from 6 to 7 (on admin)
- Upgrade the admin role from el7 to el8
- Use Appstream postgresql 12 for foreman
- Upgrade foreman to 3.8
- Upgrade all foreman puppet modules to new version
- Upgrade ssh, apache and redis puppet module

In addition we will use ansible to configure foreman and drop use for `provision/foreman_setttings.sh`.

### Dependencies:
* https://github.com/norcams/himlarcli/pull/123
* https://github.com/norcams/ansible/pull/27

### Ansible repo for setup:
https://github.com/norcams/foreman-setup
https://github.com/norcams/ansible-foreman