### PR TITLE
EL8 compat changes for HAproxy puppet module

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -197,7 +197,7 @@ mod 'ceph', :ref => '5.0.0',                        :git => github + 'openstack/
 #
 # ha
 #
-mod 'haproxy', :ref => 'v6.2.0',                    :git => github + 'puppetlabs/puppetlabs-haproxy'
+mod 'haproxy', :ref => 'v6.5.0',                    :git => github + 'puppetlabs/puppetlabs-haproxy'
 mod 'corosync', :ref => 'v6.0.1',                   :git => github + 'voxpupuli/puppet-corosync'
 mod 'zookeeper', :ref => 'v0.8.1',                  :git => github + 'deric/puppet-zookeeper'
 

--- a/hieradata/common/modules/haproxy.yaml
+++ b/hieradata/common/modules/haproxy.yaml
@@ -8,3 +8,4 @@ haproxy::global_options:
   ssl-default-bind-ciphers:   'ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:RSA+AESGCM:RSA+AES:!aNULL:!MD5:!DSS'
   ssl-default-server-options: 'no-sslv3 no-tls-tickets no-tlsv10 no-tlsv11'
   ssl-default-server-ciphers: 'ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:RSA+AESGCM:RSA+AES:!aNULL:!MD5:!DSS'
+  stats:                      'socket /var/run/haproxy.sock'

--- a/hieradata/uib/roles/ha-grid.yaml
+++ b/hieradata/uib/roles/ha-grid.yaml
@@ -90,7 +90,7 @@ profile::highavailability::loadbalancing::haproxy::haproxy_mapfile:
 profile::highavailability::loadbalancing::haproxy::haproxy_balancermembers:
   'uib-https-grid':
     listening_service:  'uib-https-grid'
-    ports:              18082
+    ports:              '18082'
     server_names:
       - 'uib-grid-01.grid.uib.no'
       - 'uib-grid-02.grid.uib.no'

--- a/hieradata/uib/roles/ha-test.yaml
+++ b/hieradata/uib/roles/ha-test.yaml
@@ -127,7 +127,7 @@ profile::highavailability::loadbalancing::haproxy::haproxy_balancermembers:
 # Apps
   'ssl-https-apps':
     listening_service:  'ssl-https-apps'
-    ports:              443
+    ports:              '443'
     server_names:
       - 'apps-test03.uib.no'
       - 'apps-test04.uib.no'
@@ -141,7 +141,7 @@ profile::highavailability::loadbalancing::haproxy::haproxy_balancermembers:
     options:            'verify none inter 120s check check-ssl ssl'
   'ssl-https-apps-admin':
     listening_service:  'ssl-https-apps-admin'
-    ports:              443
+    ports:              '443'
     server_names:       ['apps-test02.uib.no']
     ipaddresses:        ['129.177.30.16']
     options:            'verify none inter 120s check check-ssl ssl'

--- a/hieradata/uib/roles/ha.yaml
+++ b/hieradata/uib/roles/ha.yaml
@@ -215,32 +215,32 @@ profile::highavailability::loadbalancing::haproxy::haproxy_balancermembers:
 # NREC
   'public-https-uh-status':
     listening_service:  'public-https-uh-status'
-    ports:              443
+    ports:              '443'
     server_names:       ['status-osl', 'status-bgo']
     ipaddresses:        ['158.37.63.250', '158.39.77.250']
     options:            'verify none inter 1000 check check-ssl'
   'public-https-uh-report':
     listening_service:  'public-https-uh-report'
-    ports:              443
+    ports:              '443'
     server_names:       ['report-osl', 'report-bgo']
     ipaddresses:        ['158.37.63.250', '158.39.77.250']
     options:            'verify none inter 1000 check check-ssl'
   'ssl-https-nrec-www':
     listening_service:  'ssl-https-nrec-www'
-    ports:              443
+    ports:              '443'
     server_names:       ['www01']
     ipaddresses:        ['norcams.github.io']
     options:            'verify none inter 1000 check check-ssl ssl'
   'ssl-https-nrec-docs':
     listening_service:  'ssl-https-nrec-docs'
-    ports:              443
+    ports:             '443'
     server_names:       ['docs01']
     ipaddresses:        ['uh-iaas.readthedocs.io']
     options:            'verify none inter 1000 check check-ssl ssl'
 # Apps
   'ssl-https-apps':
     listening_service:  'ssl-https-apps'
-    ports:              443
+    ports:              '443'
     # server_names:       ['appsanywhere01.uib.no', 'appsanywhere02.uib.no', 'appsanywhere03.uib.no']
     # ipaddresses:        ['129.177.150.207', '129.177.150.208', '129.177.150.201']
     # server_names:       ['appsanywhere04.uib.no', 'appsanywhere05.uib.no', 'appsanywhere06.uib.no']
@@ -250,34 +250,34 @@ profile::highavailability::loadbalancing::haproxy::haproxy_balancermembers:
     options:            'verify none inter 30s check check-ssl ssl'
   # 'public-https-apps':
   #   listening_service:  'public-https-apps'
-  #   ports:              443
+  #   ports:              '443'
   #   server_names:       ['appsanywhere04.uib.no', 'appsanywhere05.uib.no', 'appsanywhere06.uib.no']
   #   ipaddresses:        ['129.177.150.202', '129.177.150.205', '129.177.150.206']
   #   options:            'check'
   'ssl-https-apps-admin':
     listening_service:  'ssl-https-apps-admin'
-    ports:              443
+    ports:              '443'
     server_names:       ['apps-admin01.uib.no', 'apps-admin02.uib.no']
     ipaddresses:        ['129.177.14.170', '129.177.14.171']
     options:            'verify none inter 120s check check-ssl ssl'
 # Exchange
   'uib-https-exch':
     listening_service:  'uib-https-exch'
-    ports:              443
+    ports:              '443'
     server_names:       ['exchange01.uib.no', 'exchange02.uib.no']
     ipaddresses:        ['129.177.14.178','129.177.14.179']
     options:            'check'
 # Portal
   'uib-https-adm':
     listening_service:  'uib-https-adm'
-    ports:              443
+    ports:              '443'
     server_names:       ['rd-web01.uib.no', 'rd-web02.uib.no']
     ipaddresses:        ['129.177.14.13', '129.177.14.182']
     options:
       - 'check'
   'uib-http-adm':
     listening_service:  'uib-http-adm'
-    ports:              80
+    ports:              '80'
     server_names:       ['rd-web01.uib.no', 'rd-web02.uib.no']
     ipaddresses:        ['129.177.14.13', '129.177.14.182']
     options:
@@ -314,14 +314,14 @@ profile::highavailability::loadbalancing::haproxy::haproxy_balancermembers:
   # myprint
   'ssl-https-myprint':
     listening_service:  'ssl-https-myprint'
-    ports:              443
+    ports:              '443'
     server_names:       ['p1-myprint01.uib.no', 'p2-myprint01.uib.no']
     ipaddresses:        ['129.177.30.26', '129.177.30.27']
     options:            'verify none inter 30s check check-ssl ssl'
   # SMB
   'uib-smb':
     listening_service:  'uib-smb'
-    ports:              [135, 445]
+    ports:              ['135', '445']
 #    server_names:       ['p1-print01.uib.no','p2-print01.uib.no']
     server_names:       ['p1-print01.uib.no']
 #    ipaddresses:        ['129.177.14.126', '129.177.14.128']


### PR DESCRIPTION
These changes allow the configuration of haproxy on el8 nodes. The v6.5.0 version of the haproxy module is the last version supporting puppet 6, while still supporting AlmaLinux.

- works for EL7 and EL8
- works with newer puppet clients
- tested for the NREC api role (EL7/EL8)
- tested for the uib/test-ha role (EL7)
- the status page is still working
