### PR TITLE
Enable ECMP resilient hashing for spines

### DIFF
--- a/hieradata/bgo/roles/spine.yaml
+++ b/hieradata/bgo/roles/spine.yaml
@@ -1,7 +1,6 @@
 ---
 profile::network::leaf::manage_license: true
 profile::network::leaf::manage_portconfig: true
-profile::network::leaf::manage_switchdconf: true
 
 named_interfaces::config:
   mgmt:
@@ -11,6 +10,11 @@ named_interfaces::config:
 
 # FIXME:sensu-go
 profile::monitoring::sensu::agent::enable_go_agent:     false
+
+profile::network::leaf::switchd_conf:
+  'resilient_hash_enable':
+    line: 'resilient_hash_enable = TRUE'
+    path: '/etc/cumulus/datapath/traffic.conf'
 
 profile::network::leaf::acls:
   '02control_plane_custom.rules':

--- a/hieradata/common/roles/spine.yaml
+++ b/hieradata/common/roles/spine.yaml
@@ -22,6 +22,7 @@ profile::base::network::net_ifnames:              false
 profile::network::leaf::manage_quagga:            false
 profile::network::leaf::manage_frrouting:         true
 profile::network::leaf::manage_acls:              true
+profile::network::leaf::manage_switchdconf:       true
 profile::base::network::cumulus_ifs:              true
 network::config_file_per_interface:               true
 profile::logging::logrotate::manage_logrotate:    false

--- a/hieradata/osl/roles/spine.yaml
+++ b/hieradata/osl/roles/spine.yaml
@@ -11,6 +11,11 @@ named_interfaces::config:
 # FIXME:sensu-go
 profile::monitoring::sensu::agent::enable_go_agent:     false
 
+profile::network::leaf::switchd_conf:
+  'resilient_hash_enable':
+    line: 'resilient_hash_enable = TRUE'
+    path: '/etc/cumulus/datapath/traffic.conf'
+
 profile::network::leaf::acls:
   '02control_plane_custom.rules':
     iptables:

--- a/hieradata/test01/roles/spine.yaml
+++ b/hieradata/test01/roles/spine.yaml
@@ -18,6 +18,11 @@ profile::base::common::manage_ntp:     false
 profile::base::common::manage_chrony:  true
 chrony::service_name: 'chrony@mgmt'
 
+profile::network::leaf::switchd_conf:
+  'resilient_hash_enable':
+    line: 'resilient_hash_enable = TRUE'
+    path: '/etc/cumulus/datapath/traffic.conf'
+
 profile::network::leaf::acls:
   '02control_plane_custom.rules':
     iptables:


### PR DESCRIPTION
**ECMP (Equal Cost MulitPath) resilient hashing**
For anycast trafficflows over tcp, resilient hashing offers more determinism when the number of nexthops changes. Read the full details here;
https://docs.nvidia.com/networking-ethernet-software/cumulus-linux-43/Layer-3/Routing/Equal-Cost-Multipath-Load-Sharing-Hardware-ECMP/

These configuration changes will only change the traffic configuration file, and in order for the changes to take effect, **switchd** must be restarted (**not recommended**) or the switch need to be rebooted (**recommended**).