### PR TITLE
OSProfiler

### DIFF
--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -393,3 +393,14 @@ profile::monitoring::sensu::agent::namespaces:
 profile::base::yumrepo::repo_hash:
   sensu-community:
     ensure: present
+
+# OSProfiler config
+profile::logging::osprofiler::osprofiler_config:
+  profiler/enabled:
+    value: true
+  profiler/trace_sqlalchemy:
+    value: true
+  profiler/hmac_keys:
+    value: 'tracethis'
+  profiler/connection_string:
+    value: "redis://%{hiera('mgmt__address__proxy')}:6379"

--- a/hieradata/vagrant/roles/compute.yaml
+++ b/hieradata/vagrant/roles/compute.yaml
@@ -83,8 +83,6 @@ profile::monitoring::collectd::plugins:
 profile::base::common::packages:
   'gcc-c++': { ensure: absent }
   'make': { ensure: absent }
-
-profile::base::common::packages:
   'python3-redis': {} # OSProfiler dependency
 
 profile::openstack::compute::manage_osprofiler: true

--- a/hieradata/vagrant/roles/compute.yaml
+++ b/hieradata/vagrant/roles/compute.yaml
@@ -83,3 +83,8 @@ profile::monitoring::collectd::plugins:
 profile::base::common::packages:
   'gcc-c++': { ensure: absent }
   'make': { ensure: absent }
+
+profile::base::common::packages:
+  'python3-redis': {} # OSProfiler dependency
+
+profile::openstack::compute::manage_osprofiler: true

--- a/hieradata/vagrant/roles/identity.yaml
+++ b/hieradata/vagrant/roles/identity.yaml
@@ -37,3 +37,8 @@ profile::openstack::resource::image_sharing::manage: false
 
 # FIXME:sensu-go
 profile::monitoring::sensu::agent::checks:              {}
+
+profile::base::common::packages:
+  'python3-redis': {} # OSProfiler dependency
+
+profile::openstack::identity::manage_osprofiler: true

--- a/hieradata/vagrant/roles/image.yaml
+++ b/hieradata/vagrant/roles/image.yaml
@@ -1,0 +1,4 @@
+profile::base::common::packages:
+  'python3-redis': {} # OSProfiler dependency
+
+profile::openstack::image::manage_osprofiler: true

--- a/hieradata/vagrant/roles/network.yaml
+++ b/hieradata/vagrant/roles/network.yaml
@@ -4,8 +4,6 @@ profile::monitoring::sensu::agent::checks:              {}
 profile::base::common::packages:
   'gcc-c++': { ensure: absent }
   'make': { ensure: absent }
-
-profile::base::common::packages:
   'python3-redis': {} # OSProfiler dependency
 
 profile::openstack::network::manage_osprofiler: true

--- a/hieradata/vagrant/roles/network.yaml
+++ b/hieradata/vagrant/roles/network.yaml
@@ -4,3 +4,8 @@ profile::monitoring::sensu::agent::checks:              {}
 profile::base::common::packages:
   'gcc-c++': { ensure: absent }
   'make': { ensure: absent }
+
+profile::base::common::packages:
+  'python3-redis': {} # OSProfiler dependency
+
+profile::openstack::network::manage_osprofiler: true

--- a/hieradata/vagrant/roles/novactrl.yaml
+++ b/hieradata/vagrant/roles/novactrl.yaml
@@ -15,3 +15,8 @@ profile::openstack::resource::host_aggregate:
 
 # FIXME:sensu-go
 profile::monitoring::sensu::agent::checks:              {}
+
+profile::base::common::packages:
+  'python3-redis': {} # OSProfiler dependency
+
+profile::openstack::novactrl::manage_osprofiler: true

--- a/hieradata/vagrant/roles/proxy.yaml
+++ b/hieradata/vagrant/roles/proxy.yaml
@@ -1,3 +1,16 @@
 ---
+include:
+  default:
+    - profile::database::redis
+    - profile::firewall::rules
 # We do not want to NAT in vagrant
 profile::network::nat::enable_snat: false
+profile::database::redis::manage: true
+redis::bind:                      "%{::ipaddress_mgmt1}"
+redis::protected_mode:            false
+profile::firewall::rules::manage_custom_rules: true
+profile::firewall::rules::custom_rules:
+  '500 accept incoming tcp to redis':
+    proto:        'tcp'
+    dport:        ['6379']
+    action:       'accept'

--- a/hieradata/vagrant/roles/proxy.yaml
+++ b/hieradata/vagrant/roles/proxy.yaml
@@ -14,3 +14,5 @@ profile::firewall::rules::custom_rules:
     proto:        'tcp'
     dport:        ['6379']
     action:       'accept'
+profile::base::common::packages:
+  'graphviz': {} # OSProfiler dependency

--- a/hieradata/vagrant/roles/volume.yaml
+++ b/hieradata/vagrant/roles/volume.yaml
@@ -23,3 +23,8 @@ cinder::config::cinder_config:
 
 # FIXME:sensu-go
 profile::monitoring::sensu::agent::checks:              {}
+
+profile::base::common::packages:
+  'python3-redis': {} # OSProfiler dependency
+
+profile::openstack::volume::manage_osprofiler: true

--- a/profile/manifests/openstack/compute.pp
+++ b/profile/manifests/openstack/compute.pp
@@ -3,7 +3,8 @@ class profile::openstack::compute(
   $manage_az                    = false,
   $manage_telemetry             = false,
   $manage_nova_config           = false,
-  $manage_check_dhcp_lease_file = false
+  $manage_check_dhcp_lease_file = false,
+  $manage_osprofiler = false,
 ) {
   include ::nova
   include ::nova::config
@@ -33,5 +34,11 @@ class profile::openstack::compute(
       owner  => 'root',
       source => "puppet:///modules/${module_name}/openstack/compute/check-dhcp-lease-file.sh",
     }
+  }
+
+  if $manage_osprofiler {
+    include ::nova::deps
+    $osprofiler_config = lookup('profile::logging::osprofiler::osprofiler_config', Hash, 'first', {})
+    create_resources('nova_config', $osprofiler_config)
   }
 }

--- a/profile/manifests/openstack/identity.pp
+++ b/profile/manifests/openstack/identity.pp
@@ -31,6 +31,7 @@ class profile::openstack::identity (
   $gpg_receiver             = '',
   $manage_policy            = false,
   $placement_enabled        = false,
+  $manage_osprofiler = false,
 ) {
 
   include ::keystone
@@ -147,5 +148,11 @@ class profile::openstack::identity (
       dport  => 35357,
       extras => $firewall_extras_a
     }
+  }
+
+  if $manage_osprofiler {
+    include ::keystone::deps
+    $osprofiler_config = lookup('profile::logging::osprofiler::osprofiler_config', Hash, 'first', {})
+    create_resources('keystone_config', $osprofiler_config)
   }
 }

--- a/profile/manifests/openstack/image.pp
+++ b/profile/manifests/openstack/image.pp
@@ -3,7 +3,8 @@ class profile::openstack::image(
   $notify_enabled   = false,
   $manage_rbd       = false,
   $manage_policy    = false,
-  $manage_notify    = false
+  $manage_notify    = false,
+  $manage_osprofiler = false,
 ) {
 
   include ::profile::openstack::image::api
@@ -24,4 +25,10 @@ class profile::openstack::image(
     include ::glance::notify::rabbitmq
   }
 
+  if $manage_osprofiler {
+    include ::glance::deps
+    $osprofiler_config = lookup('profile::logging::osprofiler::osprofiler_config', Hash, 'first', {})
+    create_resources('glance_api_config', $osprofiler_config)
+    create_resources('glance_registry_config', $osprofiler_config)
+  }
 }

--- a/profile/manifests/openstack/network.pp
+++ b/profile/manifests/openstack/network.pp
@@ -4,6 +4,7 @@ class profile::openstack::network(
   $manage_firewall = true,
   $manage_quotas   = false,
   $firewall_extras = {},
+  $manage_osprofiler = false,
 ){
   include ::neutron
 
@@ -50,4 +51,9 @@ class profile::openstack::network(
     include neutron::quota
   }
 
+  if $manage_osprofiler {
+    include ::neutron::deps
+    $osprofiler_config = lookup('profile::logging::osprofiler::osprofiler_config', Hash, 'first', {})
+    create_resources('neutron_config', $osprofiler_config)
+  }
 }

--- a/profile/manifests/openstack/novactrl.pp
+++ b/profile/manifests/openstack/novactrl.pp
@@ -7,7 +7,8 @@ class profile::openstack::novactrl(
   $manage_az            = false,
   $manage_firewall      = false,
   $manage_nova_config   = false,
-  $firewall_extras      = {}
+  $firewall_extras      = {},
+  $manage_osprofiler = false,
 ) {
 
   if $manage_firewall {
@@ -68,4 +69,9 @@ class profile::openstack::novactrl(
     include ::nova::availability_zone
   }
 
+  if $manage_osprofiler {
+    include ::nova::deps
+    $osprofiler_config = lookup('profile::logging::osprofiler::osprofiler_config', Hash, 'first', {})
+    create_resources('nova_config', $osprofiler_config)
+  }
 }

--- a/profile/manifests/openstack/volume.pp
+++ b/profile/manifests/openstack/volume.pp
@@ -1,7 +1,8 @@
 #
 class profile::openstack::volume(
   $manage_rbd    = false,
-  $notify_service = false
+  $notify_service = false,
+  $manage_osprofiler = false
 ) {
   include ::cinder
   include ::cinder::nova
@@ -16,6 +17,12 @@ class profile::openstack::volume(
   if $notify_service {
     # This will make sure httpd service will be restarted on config changes
     Cinder_config <| |> ~> Class['apache::service']
+  }
+
+  if $manage_osprofiler {
+    include ::cinder::deps
+    $osprofiler_config = lookup('profile::logging::osprofiler::osprofiler_config', Hash, 'first', {})
+    create_resources('cinder_config', $osprofiler_config)
   }
 
 }


### PR DESCRIPTION
Enables OSProfiler for nova, cinder, glance, neutron and keystone with redis collector on proxy

Trace (anywhere):
nova --profile tracethis list --all
openstack --os-profile tracethis server list --all
openstack --os-profile tracethis network list
cinder --profile tracethis list --all
openstack --os-profile tracethis volume list
glance --profile tracethis image-list
openstack --os-profile tracethis image list

View (proxy):
sudo -i
virtualenv osprofiler
source osprofiler/bin/activate
pip install osprofiler graphviz
export OSPROFILER_CONNECTION_STRING=redis://172.31.0.12:6379
osprofiler trace list
osprofiler trace show --html id --out traces/id.html
osprofiler trace show --dot --render-dot traces/id id