### PR TITLE
Cleanup of old calico versions - prepare for calico 3.27

### DIFF
--- a/hieradata/common/common.yaml
+++ b/hieradata/common/common.yaml
@@ -41,7 +41,7 @@ openstack_compute_api_version: '2.79'
 
 ceph_version:         'quincy'
 
-calico_version:       '312'
+calico_version:       '322'
 
 repo_dist:            "%{::os_platform}%{::os_version}"
 

--- a/hieradata/common/modules/profile.yaml
+++ b/hieradata/common/modules/profile.yaml
@@ -228,20 +228,6 @@ profile::base::yumrepo::repo_hash:
     gpgkey:         "%{hiera('yum_base_mirror')}/%{hiera('repo_dist')}/rdo-%{hiera('openstack_version')}/RPM-GPG-KEY-CentOS-SIG-Cloud"
     exclude:        'python2-bcrypt'
     #exclude:        'mariadb*' FIXME: this should be added after adding mariadb repo to all roles connecting to db
-  calico312:
-    ensure:         absent
-    descr:          'Calico 3.12 Repository'
-    baseurl:        "%{hiera('yum_base_mirror')}/%{hiera('repo_dist')}/calico312/"
-    enabled:        1
-    gpgcheck:       1
-    gpgkey:         "%{hiera('yum_base_mirror')}/%{hiera('repo_dist')}/calico312/key"
-  calico320:
-    ensure:         absent
-    descr:          'Calico 3.20 Repository'
-    baseurl:        "%{hiera('yum_base_mirror')}/generic/calico320"
-    enabled:        1
-    gpgcheck:       1
-    gpgkey:         "%{hiera('yum_base_mirror')}/generic/calico320/key"
   calico322:
     ensure:         absent
     descr:          'Calico 3.22 Repository'

--- a/hieradata/common/platform/el8.yaml
+++ b/hieradata/common/platform/el8.yaml
@@ -62,7 +62,6 @@ calico::enable_ipv6:  false                                      # The bird daem
 
 nova::migration::libvirt::libvirt_version: '7'                   # puppet-nova fails to detect libvirt version on alma and then misconfigures
 
-calico_version:       '322'                                      # FIXME This should move to common when el7 network and computes are gone
 mariadb_version:      '10.3'                                     # FIXME This should be removed when all database nodes are on el8 (use only in common/roles/db)
 
 # logrotate


### PR DESCRIPTION
These changes syncs the himlar codebase to existing reality: there are no nodes with calico deployed which are on the the el7 platform, and 3.22 is the existing version for all deployments.

When these changes are merged, there will be no calico compatibility for el7, and 3.12/3.20 repos can be deleted from the download server.