### PR TITLE
Upgrade calico network plugin to 3.26/3.27

### DIFF
--- a/hieradata/common/common.yaml
+++ b/hieradata/common/common.yaml
@@ -41,7 +41,7 @@ openstack_compute_api_version: '2.79'
 
 ceph_version:         'quincy'
 
-calico_version:       '322'
+calico_version:       '326'
 
 repo_dist:            "%{::os_platform}%{::os_version}"
 

--- a/hieradata/common/roles/network.yaml
+++ b/hieradata/common/roles/network.yaml
@@ -16,6 +16,7 @@ etcd::initial_cluster_token: 'etcd-cluster'
 profile::application::etcd::install_bootstrap_script: true
 
 calico::controller: true
+calico_version:     '327' # FIXME: move to common when versions on compute have been reconciled
 
 profile::openstack::network::manage_quotas: true
 


### PR DESCRIPTION
In order for the API upgrades to succeed, we need to upgrade the calico network plugin as well. Because of a bug in the calico-felix 3.27 RPM package we need to install 3.26 on the compute hosts for now, but the network nodes can be upgraded to 3.26.

There are updated playbooks for the upgrade tasks. Upgrade steps:
1. deploy himlar to admin hosts
2. run upgrade playbook on the network nodes:
`sudo ansible-playbook -e "myhosts=test01-network" lib/upgrade/calico-network.yaml`
3. run upgrade playbook on the compute hosts:
`sudo ansible-playbook -e "myhosts=test01-compute" lib/upgrade/calico-compute.yaml`
4. clear all etcd data:
`sudo ansible-playbook -e "myhosts=test01-network clear_etcd_data=true" lib/upgrade/calico-network.yaml`

The clear_etcd_data variable does what could be expected, and clears all the calico network plugin's data in the etcd data store. This is necessary. The data will be repopulated by calico felix on each compute host.