### PR TITLE
Allow access to the NREC object service from anywhere

### DIFF
--- a/hieradata/bgo/common.yaml
+++ b/hieradata/bgo/common.yaml
@@ -112,6 +112,7 @@ netcfg_anycast_dns6:      '2001:700:2:83ff::252'
 netcfg_ib_vlan:           '908'
 netcfg_oob_vlan:          '909'
 netcfg_elastic_cidr:      '10.5.0.0/20'
+netcfg_pub_object:        '158.39.77.250'
 netcfg_trp_rr:
   rr1:
     peer_ipv4: '172.18.6.1'

--- a/hieradata/bgo/roles/spine.yaml
+++ b/hieradata/bgo/roles/spine.yaml
@@ -19,6 +19,8 @@ profile::network::leaf::switchd_conf:
 profile::network::leaf::acls:
   '02control_plane_custom.rules':
     iptables:
+      # Allow access to the S3 service from everywhere
+      - "-A $FORWARD_CHAIN -i %{hiera('profile::base::network::uplink_interface')} -p tcp -d %{hiera('netcfg_pub_object')} --dport 8080 -j ACCEPT"
       # Allow SMB and NFS from UiB network (only BGO)
       - "-A $FORWARD_CHAIN -i %{hiera('profile::base::network::uplink_interface')} -p tcp -s 129.177.0.0/16 --dport 139 -j ACCEPT"
       - "-A $FORWARD_CHAIN -i %{hiera('profile::base::network::uplink_interface')} -p udp -s 129.177.0.0/16 --dport 139 -j ACCEPT"

--- a/hieradata/osl/common.yaml
+++ b/hieradata/osl/common.yaml
@@ -90,6 +90,7 @@ netcfg_anycast_dns6:      '2001:700:2:82ff::252'
 netcfg_ib_vlan:           '3379'
 netcfg_oob_vlan:          '3378'
 netcfg_elastic_cidr:      '10.6.0.0/20'
+netcfg_pub_object:        '158.37.63.250'
 netcfg_trp_rr:
   rr1:
     peer_ipv4: '172.18.38.1'

--- a/hieradata/osl/roles/spine.yaml
+++ b/hieradata/osl/roles/spine.yaml
@@ -19,6 +19,8 @@ profile::network::leaf::switchd_conf:
 profile::network::leaf::acls:
   '02control_plane_custom.rules':
     iptables:
+      # Allow access to the S3 service from everywhere
+      - "-A $FORWARD_CHAIN -i %{hiera('profile::base::network::uplink_interface')} -p tcp -d %{hiera('netcfg_pub_object')} --dport 8080 -j ACCEPT"
       # Allow DNS requests to ns1.nrec.no
       - "-A $FORWARD_CHAIN -i %{hiera('profile::base::network::uplink_interface')} -p tcp -d 158.37.63.251 --dport 53 -j ACCEPT"
       - "-A $FORWARD_CHAIN -i %{hiera('profile::base::network::uplink_interface')} -p udp -d 158.37.63.251 --dport 53 -j ACCEPT"


### PR DESCRIPTION
NREC drops inbound TCP traffic originating from outside the Norwegian research network to port 8080, as requested by the security team. However, as a side effect, this also disallows public consumption of the object service, which incidentally runs on port 8080 as well. This was not the intention.

These changes opens the object service for public consumption.