### PR TITLE
Disaggregation of NREC APIs and object storage; Anycast haproxy frontends for rgw role with IPv6

### DIFF
--- a/hieradata/bgo/common.yaml
+++ b/hieradata/bgo/common.yaml
@@ -122,6 +122,8 @@ netcfg_trp_rr:
     peer_ipv4: '172.18.6.2'
     peer_ipv6: 'fd00::6:2'
 
+public__ip__object:            '158.39.74.249'
+public__ipv6__object:          '2001:700:2:83ff::1200'
 public__ip__proxy:             '158.39.77.253'
 public__ip__ns:                '158.39.77.251'
 public__ipv6__ns:              '2001:700:2:83ff::251'

--- a/hieradata/bgo/roles/rgw.yaml
+++ b/hieradata/bgo/roles/rgw.yaml
@@ -1,5 +1,19 @@
 ---
+
+named_interfaces::config:
+  mgmt:
+    - eth0
+  trp:
+    - eth1
+  public:
+    - dummy0
+
 ceph::profile::params::mon_host:              "%{::netpart_trp1}.89,%{::netpart_trp1}.90,%{::netpart_trp1}.94"
 ceph::profile::params::mon_initial_members:   '%{::location}-cephmon-object-01,%{::location}-cephmon-object-02,%{::location}-cephmon-object-03'
 ceph::profile::params::cluster_network:       "%{::network_ceph1}/%{::cidr_ceph1}"
 ceph::profile::params::public_network:        "%{::network_trp1}/%{cidr_trp1}"
+
+profile::highavailability::loadbalancing::haproxy::anycast_enable:      true
+profile::highavailability::loadbalancing::haproxy::manage_haproxy:      true
+profile::highavailability::loadbalancing::haproxy::manage_firewall:     true
+profile::highavailability::loadbalancing::haproxy::manage_firewall6:    true

--- a/hieradata/bgo/roles/spine.yaml
+++ b/hieradata/bgo/roles/spine.yaml
@@ -1301,6 +1301,23 @@ frrouting::frrouting::bgp_neighbor_groups:
       - 'fd00::1:143'
       - 'fd00::1:144'
       - 'fd00::1:145'
+  'object_rgw':
+    'options':
+      - 'peer-group'
+      - "remote-as %{hiera('bgp_as')}"
+      - 'addpath-tx-all-paths'
+      - 'bfd'
+    'options6':
+      - 'neighbor object_rgw activate'
+      - 'neighbor object_rgw addpath-tx-all-paths'
+    'ip_access_list':
+      - "%{hiera('public__ip__object')}/32"
+    'ip_access_list6':
+      - "%{hiera('public__ipv6__object')}/128"
+    'members':
+      - '172.18.00.84'  # rgw-01
+      - '172.18.00.85'  # rgw-02
+      - '172.18.00.87'  # rgw-03
   'elastic_rail_b1p':
     'options':
       - 'peer-group'

--- a/hieradata/common/roles/api.yaml
+++ b/hieradata/common/roles/api.yaml
@@ -45,6 +45,9 @@ profile::highavailability::loadbalancing::haproxy::firewall_ports:
   mgmt:      ['9000']
   limited:   []
 
+profile::highavailability::loadbalancing::haproxy::anycast_service_ip:  "%{hiera('public__ip__api')}"
+profile::highavailability::loadbalancing::haproxy::anycast_service_ip6: "%{hiera('public__ipv6__api')}"
+
 # HAproxy
 star_api_ssl_pem:         "star.api.%{hiera('domain_public')}.pem"
 star_api_ssl_pem2:        "star.api.%{hiera('domain_public2')}.pem"

--- a/hieradata/common/roles/rgw.yaml
+++ b/hieradata/common/roles/rgw.yaml
@@ -4,12 +4,86 @@ include:
     - profile::openstack::openrc
     - profile::openstack::object::radosgw
     - profile::storage::ceph::config
+    - profile::highavailability::loadbalancing::haproxy
     - profile::logging::rsyslog::client
 
 profile::base::common::packages:
   'python3-openstackclient': {}
   'bash-completion': {}
   'jq': {}
+
+profile::base::selinux::manage_selinux: true
+
+profile::network::interface::manage_dummy: true
+
+profile::highavailability::loadbalancing::haproxy::anycast_enable:      false
+profile::highavailability::loadbalancing::haproxy::bird_template:       'profile/bird/bird-rgw.conf.8'
+profile::highavailability::loadbalancing::haproxy::anycast_service_ip:  "%{hiera('public__ip__object')}"
+profile::highavailability::loadbalancing::haproxy::anycast_service_ip6: "%{hiera('public__ipv6__object')}"
+profile::highavailability::loadbalancing::haproxy::manage_haproxy:      false
+profile::highavailability::loadbalancing::haproxy::manage_firewall:     false
+profile::highavailability::loadbalancing::haproxy::manage_firewall6:    false
+profile::highavailability::loadbalancing::haproxy::firewall_ports:
+  public:    ['443', '8080']
+  internal:  []
+  mgmt:      []
+  limited:   []
+
+# HAproxy
+star_api_ssl_pem:         "star.api.%{hiera('domain_public')}.pem"
+star_api_ssl_pem2:        "star.api.%{hiera('domain_public2')}.pem"
+
+profile::highavailability::loadbalancing::haproxy::haproxy_frontends:
+  frontend_public:
+    bind:
+      ':::443 v4v6': ['ssl', "crt %{hiera('star_api_ssl_pem')}", "crt %{hiera('star_api_ssl_pem2')}"]
+      ':::8080 v4v6': ['ssl', "crt %{hiera('star_api_ssl_pem')}", "crt %{hiera('star_api_ssl_pem2')}"] # FIXME remove when nobody uses 8080
+    mode: 'http'
+    options:
+      - http-request:
+        - "set-header host object.api.%{hiera('domain_public')}"
+      - default_backend: 'bk_object'
+
+profile::highavailability::loadbalancing::haproxy::haproxy_backends:
+  bk_object:
+    mode: 'http'
+    options:
+      - option:
+        - 'tcp-check'
+
+profile::highavailability::loadbalancing::haproxy::haproxy_balancermembers:
+  object_primary:
+    listening_service:  'bk_object'
+    server_names:       "%{::hostname}"
+    ipaddresses:        "%{::ipaddress_trp1}"
+    ports:              '7480'
+    options:            'check'
+  object_backup:
+    listening_service:  'bk_object'
+    server_names:       "%{alias('object__backend__backups')}"
+    ipaddresses:        "%{alias('object__backend__backupips')}"
+    ports:              '7480'
+    options:            'check backup'
+
+haproxy::defaults_options:
+  mode:    'http'
+  option:  [ 'redispatch', 'forwardfor', 'http-server-close', 'httplog', 'dontlognull']
+  retries: '3'
+  maxconn: '8192' # per frontend
+  balance: 'roundrobin'
+  timeout:
+    - 'http-request 10s'
+    - 'connect 10s'
+    - 'check 10s'
+    - 'client 1m'
+    - 'server 3m'
+    - 'queue 1m'
+
+profile::base::selinux::ports:
+  object-http:
+    seltype:  'http_port_t'
+    protocol: 'tcp'
+    port:     7480
 
 profile::storage::ceph::config::manage_config: true
 profile::storage::ceph::config::config:
@@ -87,4 +161,4 @@ profile::base::yumrepo::repo_hash:
     ensure: present
   epel: # should be absent when using RDO, but whitelist can also work
     ensure: present
-    includepkgs: 'htop bash-completion-extras python-routes python2-bcrypt userspace-rcu lttng-ust liboath libbabeltrace leveldb liboath py-bcrypt python2-bcrypt python36-prettytable python36-requests python36-pyOpenSSL python36-bcrypt python36-six python36-PyYAML python36-dateutil python36-cryptography python36-urllib3 python36-chardet python36-cffi python36-idna python36-pysocks python36-pycparser python36-ply python36-asn1crypto fmt python3-cherrypy python3-zc-lockfile python3-portend python3-cheroot python3-trustme python3-tempora python3-jaraco-functools python3-jaraco thrift'
+    includepkgs: 'bird htop bash-completion-extras python-routes python2-bcrypt userspace-rcu lttng-ust liboath libbabeltrace leveldb liboath py-bcrypt python2-bcrypt python36-prettytable python36-requests python36-pyOpenSSL python36-bcrypt python36-six python36-PyYAML python36-dateutil python36-cryptography python36-urllib3 python36-chardet python36-cffi python36-idna python36-pysocks python36-pycparser python36-ply python36-asn1crypto fmt python3-cherrypy python3-zc-lockfile python3-portend python3-cheroot python3-trustme python3-tempora python3-jaraco-functools python3-jaraco thrift'

--- a/hieradata/nodes/bgo/bgo-rgw-01.yaml
+++ b/hieradata/nodes/bgo/bgo-rgw-01.yaml
@@ -1,0 +1,32 @@
+---
+network::interfaces_hash:
+  'eth0':
+    ipaddress:      "%{hiera('netcfg_mgmt_netpart')}.84"
+    netmask:        "%{hiera('netcfg_mgmt_netmask')}"
+    peerdns:        'yes'
+    dns1:           "%{hiera('netcfg_dns_server1')}"
+    dns2:           "%{hiera('netcfg_dns_server2')}"
+    domain:         "%{hiera('netcfg_dns_search')}"
+    defroute:       'no'
+  'eth1':
+    ipaddress:      "%{hiera('netcfg_trp_netpart')}.84"
+    netmask:        "%{hiera('netcfg_trp_netmask')}"
+    gateway:        "%{hiera('netcfg_trp_gateway')}"
+    srcaddr:        "%{hiera('public__ip__object')}"
+    ipv6init:       'yes'
+    ipv6addr:       "%{hiera('netcfg_trp_netpart6')}::84/%{hiera('netcfg_trp_netmask6')}"
+    ipv6_defaultgw: "%{hiera('netcfg_trp_gateway6')}"
+    defroute:       'yes'
+  'dummy0':
+    ipaddress:      "%{hiera('public__ip__object')}"
+    netmask:        '255.255.255.255'
+    ipv6init:       'yes'
+    ipv6addr:       "%{hiera('public__ipv6__object')}/128"
+    defroute:       'no'
+
+object__backend__backups:
+  - '%{::location}-rgw-02'
+  - '%{::location}-rgw-03'
+object__backend__backupips:
+  - "%{hiera('netcfg_trp_netpart')}.85"
+  - "%{hiera('netcfg_trp_netpart')}.87"

--- a/hieradata/nodes/bgo/bgo-rgw-02.yaml
+++ b/hieradata/nodes/bgo/bgo-rgw-02.yaml
@@ -1,0 +1,32 @@
+---
+network::interfaces_hash:
+  'eth0':
+    ipaddress:      "%{hiera('netcfg_mgmt_netpart')}.85"
+    netmask:        "%{hiera('netcfg_mgmt_netmask')}"
+    peerdns:        'yes'
+    dns1:           "%{hiera('netcfg_dns_server1')}"
+    dns2:           "%{hiera('netcfg_dns_server2')}"
+    domain:         "%{hiera('netcfg_dns_search')}"
+    defroute:       'no'
+  'eth1':
+    ipaddress:      "%{hiera('netcfg_trp_netpart')}.85"
+    netmask:        "%{hiera('netcfg_trp_netmask')}"
+    gateway:        "%{hiera('netcfg_trp_gateway')}"
+    srcaddr:        "%{hiera('public__ip__object')}"
+    ipv6init:       'yes'
+    ipv6addr:       "%{hiera('netcfg_trp_netpart6')}::85/%{hiera('netcfg_trp_netmask6')}"
+    ipv6_defaultgw: "%{hiera('netcfg_trp_gateway6')}"
+    defroute:       'yes'
+  'dummy0':
+    ipaddress:      "%{hiera('public__ip__object')}"
+    netmask:        '255.255.255.255'
+    ipv6init:       'yes'
+    ipv6addr:       "%{hiera('public__ipv6__object')}/128"
+    defroute:       'no'
+
+object__backend__backups:
+  - '%{::location}-rgw-03'
+  - '%{::location}-rgw-01'
+object__backend__backupips:
+  - "%{hiera('netcfg_trp_netpart')}.87"
+  - "%{hiera('netcfg_trp_netpart')}.84"

--- a/hieradata/nodes/bgo/bgo-rgw-03.yaml
+++ b/hieradata/nodes/bgo/bgo-rgw-03.yaml
@@ -1,0 +1,32 @@
+---
+network::interfaces_hash:
+  'eth0':
+    ipaddress:      "%{hiera('netcfg_mgmt_netpart')}.87"
+    netmask:        "%{hiera('netcfg_mgmt_netmask')}"
+    peerdns:        'yes'
+    dns1:           "%{hiera('netcfg_dns_server1')}"
+    dns2:           "%{hiera('netcfg_dns_server2')}"
+    domain:         "%{hiera('netcfg_dns_search')}"
+    defroute:       'no'
+  'eth1':
+    ipaddress:      "%{hiera('netcfg_trp_netpart')}.87"
+    netmask:        "%{hiera('netcfg_trp_netmask')}"
+    gateway:        "%{hiera('netcfg_trp_gateway')}"
+    srcaddr:        "%{hiera('public__ip__object')}"
+    ipv6init:       'yes'
+    ipv6addr:       "%{hiera('netcfg_trp_netpart6')}::87/%{hiera('netcfg_trp_netmask6')}"
+    ipv6_defaultgw: "%{hiera('netcfg_trp_gateway6')}"
+    defroute:       'yes'
+  'dummy0':
+    ipaddress:      "%{hiera('public__ip__object')}"
+    netmask:        '255.255.255.255'
+    ipv6init:       'yes'
+    ipv6addr:       "%{hiera('public__ipv6__object')}/128"
+    defroute:       'no'
+
+object__backend__backups:
+  - '%{::location}-rgw-01'
+  - '%{::location}-rgw-02'
+object__backend__backupips:
+  - "%{hiera('netcfg_trp_netpart')}.84"
+  - "%{hiera('netcfg_trp_netpart')}.85"

--- a/hieradata/nodes/osl/osl-rgw-01.yaml
+++ b/hieradata/nodes/osl/osl-rgw-01.yaml
@@ -1,0 +1,32 @@
+---
+network::interfaces_hash:
+  'eth0':
+    ipaddress:      "%{hiera('netcfg_mgmt_netpart')}.84"
+    netmask:        "%{hiera('netcfg_mgmt_netmask')}"
+    peerdns:        'yes'
+    dns1:           "%{hiera('netcfg_dns_server1')}"
+    dns2:           "%{hiera('netcfg_dns_server2')}"
+    domain:         "%{hiera('netcfg_dns_search')}"
+    defroute:       'no'
+  'eth1':
+    ipaddress:      "%{hiera('netcfg_trp_netpart')}.84"
+    netmask:        "%{hiera('netcfg_trp_netmask')}"
+    gateway:        "%{hiera('netcfg_trp_gateway')}"
+    srcaddr:        "%{hiera('public__ip__object')}"
+    ipv6init:       'yes'
+    ipv6addr:       "%{hiera('netcfg_trp_netpart6')}::84/%{hiera('netcfg_trp_netmask6')}"
+    ipv6_defaultgw: "%{hiera('netcfg_trp_gateway6')}"
+    defroute:       'yes'
+  'dummy0':
+    ipaddress:      "%{hiera('public__ip__object')}"
+    netmask:        '255.255.255.255'
+    ipv6init:       'yes'
+    ipv6addr:       "%{hiera('public__ipv6__object')}/128"
+    defroute:       'no'
+
+object__backend__backups:
+  - '%{::location}-rgw-02'
+  - '%{::location}-rgw-03'
+object__backend__backupips:
+  - "%{hiera('netcfg_trp_netpart')}.85"
+  - "%{hiera('netcfg_trp_netpart')}.87"

--- a/hieradata/nodes/osl/osl-rgw-02.yaml
+++ b/hieradata/nodes/osl/osl-rgw-02.yaml
@@ -1,0 +1,32 @@
+---
+network::interfaces_hash:
+  'eth0':
+    ipaddress:      "%{hiera('netcfg_mgmt_netpart')}.85"
+    netmask:        "%{hiera('netcfg_mgmt_netmask')}"
+    peerdns:        'yes'
+    dns1:           "%{hiera('netcfg_dns_server1')}"
+    dns2:           "%{hiera('netcfg_dns_server2')}"
+    domain:         "%{hiera('netcfg_dns_search')}"
+    defroute:       'no'
+  'eth1':
+    ipaddress:      "%{hiera('netcfg_trp_netpart')}.85"
+    netmask:        "%{hiera('netcfg_trp_netmask')}"
+    gateway:        "%{hiera('netcfg_trp_gateway')}"
+    srcaddr:        "%{hiera('public__ip__object')}"
+    ipv6init:       'yes'
+    ipv6addr:       "%{hiera('netcfg_trp_netpart6')}::85/%{hiera('netcfg_trp_netmask6')}"
+    ipv6_defaultgw: "%{hiera('netcfg_trp_gateway6')}"
+    defroute:       'yes'
+  'dummy0':
+    ipaddress:      "%{hiera('public__ip__object')}"
+    netmask:        '255.255.255.255'
+    ipv6init:       'yes'
+    ipv6addr:       "%{hiera('public__ipv6__object')}/128"
+    defroute:       'no'
+
+object__backend__backups:
+  - '%{::location}-rgw-03'
+  - '%{::location}-rgw-01'
+object__backend__backupips:
+  - "%{hiera('netcfg_trp_netpart')}.87"
+  - "%{hiera('netcfg_trp_netpart')}.84"

--- a/hieradata/nodes/osl/osl-rgw-03.yaml
+++ b/hieradata/nodes/osl/osl-rgw-03.yaml
@@ -1,0 +1,32 @@
+---
+network::interfaces_hash:
+  'eth0':
+    ipaddress:      "%{hiera('netcfg_mgmt_netpart')}.87"
+    netmask:        "%{hiera('netcfg_mgmt_netmask')}"
+    peerdns:        'yes'
+    dns1:           "%{hiera('netcfg_dns_server1')}"
+    dns2:           "%{hiera('netcfg_dns_server2')}"
+    domain:         "%{hiera('netcfg_dns_search')}"
+    defroute:       'no'
+  'eth1':
+    ipaddress:      "%{hiera('netcfg_trp_netpart')}.87"
+    netmask:        "%{hiera('netcfg_trp_netmask')}"
+    gateway:        "%{hiera('netcfg_trp_gateway')}"
+    srcaddr:        "%{hiera('public__ip__object')}"
+    ipv6init:       'yes'
+    ipv6addr:       "%{hiera('netcfg_trp_netpart6')}::87/%{hiera('netcfg_trp_netmask6')}"
+    ipv6_defaultgw: "%{hiera('netcfg_trp_gateway6')}"
+    defroute:       'yes'
+  'dummy0':
+    ipaddress:      "%{hiera('public__ip__object')}"
+    netmask:        '255.255.255.255'
+    ipv6init:       'yes'
+    ipv6addr:       "%{hiera('public__ipv6__object')}/128"
+    defroute:       'no'
+
+object__backend__backups:
+  - '%{::location}-rgw-01'
+  - '%{::location}-rgw-02'
+object__backend__backupips:
+  - "%{hiera('netcfg_trp_netpart')}.84"
+  - "%{hiera('netcfg_trp_netpart')}.85"

--- a/hieradata/osl/common.yaml
+++ b/hieradata/osl/common.yaml
@@ -104,6 +104,8 @@ netcfg_trp_rr:
 # Public addresses (bgo host frontend)
 #
 
+public__ip__object:            '158.39.75.249'
+public__ipv6__object:          '2001:700:2:82ff::1200'
 public__ip__proxy:             '158.37.63.253'
 public__ip__ns:                '158.37.63.251'
 public__ipv6__ns:              '2001:700:2:82ff::251'

--- a/hieradata/osl/roles/rgw.yaml
+++ b/hieradata/osl/roles/rgw.yaml
@@ -1,5 +1,18 @@
 ---
+named_interfaces::config:
+  mgmt:
+    - eth0
+  trp:
+    - eth1
+  public:
+    - dummy0
+
 ceph::profile::params::mon_host:              "%{::netpart_trp1}.89,%{::netpart_trp1}.90,%{::netpart_trp1}.94"
 ceph::profile::params::mon_initial_members:   '%{::location}-cephmon-object-01,%{::location}-cephmon-object-02,%{::location}-cephmon-object-03'
 ceph::profile::params::cluster_network:       "%{::network_ceph1}/%{::cidr_ceph1}"
 ceph::profile::params::public_network:        "%{::network_trp1}/%{cidr_trp1}"
+
+profile::highavailability::loadbalancing::haproxy::anycast_enable:      true
+profile::highavailability::loadbalancing::haproxy::manage_haproxy:      true
+profile::highavailability::loadbalancing::haproxy::manage_firewall:     true
+profile::highavailability::loadbalancing::haproxy::manage_firewall6:    true

--- a/hieradata/osl/roles/spine.yaml
+++ b/hieradata/osl/roles/spine.yaml
@@ -938,6 +938,23 @@ frrouting::frrouting::bgp_neighbor_groups:
       - 'fd32::1:122'
       - 'fd32::1:123'
       - 'fd32::1:124'
+  'object_rgw':
+    'options':
+      - 'peer-group'
+      - "remote-as %{hiera('bgp_as')}"
+      - 'addpath-tx-all-paths'
+      - 'bfd'
+    'options6':
+      - 'neighbor object_rgw activate'
+      - 'neighbor object_rgw addpath-tx-all-paths'
+    'ip_access_list':
+      - "%{hiera('public__ip__object')}/32"
+    'ip_access_list6':
+      - "%{hiera('public__ipv6__object')}/128"
+    'members':
+      - '172.18.32.84'  # rgw-01
+      - '172.18.32.85'  # rgw-02
+      - '172.18.32.87'  # rgw-03
   'elastic_rail_o1p':
     'options':
       - 'peer-group'

--- a/profile/templates/bird/bird-rgw.conf.8.erb
+++ b/profile/templates/bird/bird-rgw.conf.8.erb
@@ -1,0 +1,76 @@
+
+router id <%= @ipaddress_trp1 %>;
+
+filter export_bgp4 {
+  if net = <%= scope().call_function('hiera',['public__ip__object']) %>/32 then accept;
+    else {
+        reject;
+    }
+}
+
+filter export_bgp6 {
+  if net = <%= scope().call_function('hiera',['public__ipv6__object']) %>/128 then accept;
+    else {
+        reject;
+    }
+}
+
+filter export_kernel {
+  if dest = RTD_UNREACHABLE then {
+    reject;
+  } else {
+    accept;
+  }
+}
+
+# Configure synchronization between BIRD's routing tables and the
+# kernel.
+protocol kernel {
+  ipv4 {               # Connect protocol to IPv4 table by channel
+    import all;
+    export filter export_kernel;
+  };
+  scan time 2;         # Scan kernel routing table every 2 seconds
+  learn;               # Learn all alien routes from the kernel
+  graceful restart;
+}
+
+protocol kernel {
+  ipv6 {
+    import all;
+    export filter export_kernel;
+  };
+  scan time 2;         # Scan kernel routing table every 2 seconds
+  learn;               # Learn all alien routes from the kernel
+  graceful restart;
+}
+
+protocol bfd {
+<% scope().call_function('hiera',['netcfg_trp_rr']).each do |name| %><%if name[1]['peer_ipv4'] %>  neighbor <%= name[1]['peer_ipv4'] %>;
+<% end %><% end -%>
+}
+
+# Watch interface up/down events.
+protocol device {
+  scan time 2;    # Scan interfaces every 2 seconds
+}
+
+protocol direct {
+        disabled;
+}
+
+<% if scope().call_function('hiera',['netcfg_trp_rr']) -%><% scope().call_function('hiera',['netcfg_trp_rr']).each do |name, values| %>protocol bgp '<%= name %>_ipv4' {
+  local as <%= scope().call_function('hiera',['bgp_as']) %>;
+  neighbor <%= values["peer_ipv4"] %> as <%= scope().call_function('hiera',['bgp_as']) %>;
+  ipv4 {
+    import none;
+    export filter export_bgp4;
+  };
+  ipv6 {
+    import none;
+    export filter export_bgp6;    
+  };
+  graceful restart;
+  source address <%= @ipaddress_trp1 %>;  # The local address we use for the TCP connection
+}
+<% end %><% end -%>

--- a/profile/templates/loadbalancing/haproxy_check.erb
+++ b/profile/templates/loadbalancing/haproxy_check.erb
@@ -2,9 +2,9 @@
 
 _term() {
   echo "Caught SIGTERM signal!"
-    /sbin/ip route del <%= scope().call_function('hiera',['public__ip__api']) %>/32 dev dummy0 > /dev/null
-    /sbin/ip -6 route del <%= scope().call_function('hiera',['public__ipv6__api']) %> dev dummy0 > /dev/null
-    /sbin/ip -6 route del <%= scope().call_function('hiera',['public__ipv6__api']) %> dev dummy0 > /dev/null
+    /sbin/ip route del <%= @anycast_service_ip %>/32 dev dummy0 > /dev/null
+    /sbin/ip -6 route del <%= @anycast_service_ip6 %> dev dummy0 > /dev/null
+    /sbin/ip -6 route del <%= @anycast_service_ip6 %> dev dummy0 > /dev/null
   /bin/sleep 3
   exit 0
 #  kill -TERM "$child" 2>/dev/null
@@ -18,21 +18,21 @@ while true
 do
   if /usr/bin/systemctl is-active --quiet haproxy;
 then
-  if ! /sbin/ip route | grep <%= scope().call_function('hiera',['public__ip__api']) %> > /dev/null ; then
-    /sbin/ip route add <%= scope().call_function('hiera',['public__ip__api']) %>/32 dev dummy0 > /dev/null
+  if ! /sbin/ip route | grep <%= @anycast_service_ip %> | grep -v src > /dev/null ; then
+    /sbin/ip route add <%= @anycast_service_ip  %>/32 dev dummy0 > /dev/null
   fi
-  if ! /sbin/ip -6 route | grep <%= scope().call_function('hiera',['public__ipv6__api']) %> | grep -v kernel > /dev/null ; then
-    /sbin/ip -6 route add <%= scope().call_function('hiera',['public__ipv6__api']) %>/128 dev dummy0 > /dev/null
+  if ! /sbin/ip -6 route | grep <%= @anycast_service_ip6 %> | grep -v kernel > /dev/null ; then
+    /sbin/ip -6 route add <%= @anycast_service_ip6 %>/128 dev dummy0 > /dev/null
   fi
 else
-  if /sbin/ip route | grep <%= scope().call_function('hiera',['public__ip__api']) %> > /dev/null ; then
-    /sbin/ip route del <%= scope().call_function('hiera',['public__ip__api']) %>/32 dev dummy0 > /dev/null
+  if /sbin/ip route | grep <%= @anycast_service_ip %> > /dev/null ; then
+    /sbin/ip route del <%= @anycast_service_ip  %>/32 dev dummy0 > /dev/null
   fi
-  if /sbin/ip -6 route | grep <%= scope().call_function('hiera',['public__ipv6__api']) %> | grep -v kernel > /dev/null ; then
-    /sbin/ip -6 route del <%= scope().call_function('hiera',['public__ipv6__api']) %> dev dummy0 > /dev/null
+  if /sbin/ip -6 route | grep <%= @anycast_service_ip6 %> | grep -v kernel > /dev/null ; then
+    /sbin/ip -6 route del <%= @anycast_service_ip6 %> dev dummy0 > /dev/null
   fi
-  if /sbin/ip -6 route | grep <%= scope().call_function('hiera',['public__ipv6__api']) %> | grep -v kernel > /dev/null ; then
-    /sbin/ip -6 route del <%= scope().call_function('hiera',['public__ipv6__api']) %> dev dummy0 > /dev/null
+  if /sbin/ip -6 route | grep <%= @anycast_service_ip6 %> | grep -v kernel > /dev/null ; then
+    /sbin/ip -6 route del <%= @anycast_service_ip6 %> dev dummy0 > /dev/null
   fi
 fi
 sleep 2


### PR DESCRIPTION
## Disaggregation of NREC APIs and object storage

These changes enable the ability to disaggregate the object (rgw) gateways from the API frontend used today. In addition, the object service can be served over IPv6 and port 443.

### Benefits of these changes

There are several benefits to implement these changes:
**Load balancing**: The anycast feature ensures horizontal scaling of traffic across every RGW node
**High Availability**: Quick convergence if an RGW node fails or goes down for maintenance
**Less service disruption**: The object service will continue to work when the NREC APIs are down for maintenance
**IPv6**: Public facing services should ensure IPv6 compliance

**Implications** : The changes can be implemented without service disruption, as the RGW backends will continue to serve the existing API frontend. When changes are implemented, the DNS record for the object service can be updated with the new endpoint address, and an AAAA record can be created to implement IPv6 support. TLS is terminated on each RGW node.

### Order of implementation

To ensure implementation without service disruption, implement the changes in the correct order:
**1**: Disable puppet on RGW nodes in region [BGO/OSL]
**2**: Use `FACTER_RUNMODE=kickstart` var to create new interfaces on each node and bring them up.
**3**: Push TLS certificates to RGW nodes (ansible)
**4**: A normal puppet run will install haproxy and a bgp speaker (bird).

At this point you should observe ECMP routes on the spine nodes, for both IPv4 and IPv6.

**5**: Update DNS records (not a part of the PR)
**6**: Create AAAA records

Until DNS updates have propagated, the object service will be served by new and old concept simultaneously.

### Further work

- Remove object serving from the API nodes
- Stop serving object on port 8080 (users will need to informed and start using port 443)

