### PR TITLE
Victoria/horizon

### DIFF
--- a/hieradata/common/modules/horizon.yaml
+++ b/hieradata/common/modules/horizon.yaml
@@ -11,6 +11,7 @@ horizon::listen_ssl:                    true
 horizon::horizon_ca:                    "/etc/pki/tls/certs/cachain.pem"
 horizon::horizon_cert:                  "/etc/pki/tls/certs/%{hiera('public__address__dashboard')}.cert.pem"
 horizon::horizon_key:                   "/etc/pki/tls/private/%{hiera('public__address__dashboard')}.key.pem"
+horizon::access_log_format:             undef
 horizon::secure_cookies:                true
 horizon::images_panel:                  'angular'
 horizon::horizon_upload_mode:           "'direct'"
@@ -60,7 +61,7 @@ horizon::django_session_engine:         'django.contrib.sessions.backends.cached
 horizon::session_timeout:               10800 # 3 hours, default 30 min
 
 # logging
-horizon::log_handler:     'syslog'
+horizon::log_handlers:     ['syslog']
 horizon::wsgi::apache::extra_params:
   error_log_syslog: 'syslog:local1'
   error_log_file:   false

--- a/hieradata/common/roles/dashboard.yaml
+++ b/hieradata/common/roles/dashboard.yaml
@@ -30,6 +30,10 @@ profile::base::common::packages:
 profile::openstack::dashboard::designate_packages:
   'openstack-designate-ui': {}
 
+
+openstack_version: 'victoria'
+
+
 profile::base::network::manage_dummy:                              true # FIXME; remove when el7 is gone
 
 profile::base::common::manage_cron:                                true

--- a/hieradata/vagrant/roles/dashboard.yaml
+++ b/hieradata/vagrant/roles/dashboard.yaml
@@ -17,3 +17,8 @@ profile::openstack::dashboard::site_branding: 'dev-iaas'
 
 # FIXME:sensu-go
 profile::monitoring::sensu::agent::checks:              {}
+
+openstack_version: 'victoria'
+
+profile::openstack::dashboard::manage_dashboard:                   true
+profile::openstack::dashboard::manage_overrides:                   true


### PR DESCRIPTION
Upgrade by running the lib/upgrade/dashboard.yaml playbook.

Ref.
https://docs.openstack.org/releasenotes/puppet-horizon/victoria.html
https://docs.openstack.org/releasenotes/horizon/victoria.html

https://github.com/openstack/puppet-horizon/blob/17.5.0/metadata.json

The horizon::log_handler parameter -> horizon::log_handlers parameter, will be removed in a future release.
The new horizon::log_handlers parameter was added to specify multiple log handlers.