### PR TITLE
Move object dns pointers to new anycast servers and enable ipv6

### DIFF
--- a/hieradata/bgo/common.yaml
+++ b/hieradata/bgo/common.yaml
@@ -285,7 +285,7 @@ profile::network::services::dns_records:
     "placement.api.%{hiera('domain_public')}":    '158.39.77.250'
     "metric.api.%{hiera('domain_public')}":       '158.39.77.250'
     "dns.api.%{hiera('domain_public')}":          '158.39.77.250'
-    "object.api.%{hiera('domain_public')}":       '158.39.77.250'
+    "object.api.%{hiera('domain_public')}":       "%{hiera('public__ip__object')}"
 
     "resolver.%{hiera('domain_public')}":         '158.39.77.252'
 
@@ -299,7 +299,7 @@ profile::network::services::dns_records:
     "placement.api.%{hiera('domain_public2')}":   '158.39.77.250'
     "metric.api.%{hiera('domain_public2')}":      '158.39.77.250'
     "dns.api.%{hiera('domain_public2')}":         '158.39.77.250'
-    "object.api.%{hiera('domain_public2')}":      '158.39.77.250'
+    "object.api.%{hiera('domain_public2')}":      "%{hiera('public__ip__object')}"
 
     "resolver.%{hiera('domain_public2')}":        '158.39.77.252'
 
@@ -311,9 +311,11 @@ profile::network::services::dns_records:
     # Public records (<foo>.<location>.nrec.no)
     "resolver.%{hiera('domain_public')}":              '2001:700:2:83ff::252'
     "%{::location}-dns-01.%{hiera('domain_public')}":  '2001:700:2:83ff::256'
+    "object.api.%{hiera('domain_public')}":            "%{hiera('public__ipv6__object')}
     # Public records (<foo>.<location>.uh-iaas.no)
     "resolver.%{hiera('domain_public2')}":             '2001:700:2:83ff::252'
     "%{::location}-dns-01.%{hiera('domain_public2')}": '2001:700:2:83ff::256'
+    "object.api.%{hiera('domain_public2')}":           "%{hiera('public__ipv6__object')}
   PTR:
     # Management network (entries that differ from common/common.yaml)
     "8.%{hiera('reverse_mgmt_c2')}":   "%{::location}-mgmt-08.%{hiera('domain_mgmt')}"

--- a/hieradata/osl/common.yaml
+++ b/hieradata/osl/common.yaml
@@ -230,7 +230,7 @@ profile::network::services::dns_records:
     "placement.api.%{hiera('domain_public')}":    '158.37.63.250'
     "metric.api.%{hiera('domain_public')}":       '158.37.63.250'
     "dns.api.%{hiera('domain_public')}":          '158.37.63.250'
-    "object.api.%{hiera('domain_public')}":       '158.37.63.250'
+    "object.api.%{hiera('domain_public')}":       "%{hiera('public__ip__object')}"
 
     "resolver.%{hiera('domain_public')}":         '158.37.63.252'
 
@@ -268,7 +268,7 @@ profile::network::services::dns_records:
     "placement.api.%{hiera('domain_public2')}":   '158.37.63.250'
     "metric.api.%{hiera('domain_public2')}":      '158.37.63.250'
     "dns.api.%{hiera('domain_public2')}":         '158.37.63.250'
-    "object.api.%{hiera('domain_public2')}":      '158.37.63.250'
+    "object.api.%{hiera('domain_public2')}":      "%{hiera('public__ip__object')}"
 
     "resolver.%{hiera('domain_public2')}":        '158.37.63.252'
 
@@ -301,13 +301,14 @@ profile::network::services::dns_records:
     # Public records (<foo>.<location>.nrec.no)
     "resolver.%{hiera('domain_public')}":              '2001:700:2:82ff::252'
     "%{::location}-dns-01.%{hiera('domain_public')}":  '2001:700:2:82ff::256'
-
+    "object.api.%{hiera('domain_public')}":            "%{hiera('public__ipv6__object')}
     # Frontend records (<foo>.uh-iaas.no)
     "ns1.%{hiera('domain_frontend2')}":           '2001:700:2:82ff::251'
     "ns2.%{hiera('domain_frontend2')}":           '2001:700:2:83ff::251'
     # Public records (<foo>.<location>.uh-iaas.no)
     "resolver.%{hiera('domain_public2')}":             '2001:700:2:82ff::252'
     "%{::location}-dns-01.%{hiera('domain_public2')}": '2001:700:2:82ff::256'
+    "object.api.%{hiera('domain_public2')}":           "%{hiera('public__ipv6__object')}
   PTR:
     "199.%{hiera('reverse_mgmt_c0')}":    "%{::location}-login-01old.%{hiera('domain_mgmt')}"
     # FIXME: override common/common.yaml


### PR DESCRIPTION
Move the object service endpoint to the now anycast enabled rgw nodes and enable service for IPv6. The transition away from the api node should not cause any service disruption.