### PR TITLE
Remove object from api node and disable service on port 8080

### DIFF
--- a/hieradata/bgo/common.yaml
+++ b/hieradata/bgo/common.yaml
@@ -115,7 +115,6 @@ netcfg_oob_vlan:          '909'
 netcfg_elastic_cidr:      '10.5.0.0/19'
 netcfg_priv_anycast_net:   '10.254.253.224'
 netcfg_priv_anycast_cidr4: '27'
-netcfg_pub_object:        '158.39.77.250'
 netcfg_trp_rr:
   rr1:
     peer_ipv4: '172.18.6.1'

--- a/hieradata/bgo/roles/api.yaml
+++ b/hieradata/bgo/roles/api.yaml
@@ -65,14 +65,6 @@ volume__backend__names:
 volume__backend__ips:
   - "%{hiera('netcfg_trp_netpart')}.46"
   - "%{hiera('netcfg_trp_netpart')}.47"
-object__backend__names:
-  - '%{::location}-rgw-01'
-  - '%{::location}-rgw-02'
-  - '%{::location}-rgw-03'
-object__backend__ips:
-  - "%{hiera('netcfg_trp_netpart')}.84"
-  - "%{hiera('netcfg_trp_netpart')}.85"
-  - "%{hiera('netcfg_trp_netpart')}.87"
 
 profile::highavailability::loadbalancing::haproxy::haproxy_mapfile:
   internal_domains:

--- a/hieradata/bgo/roles/spine.yaml
+++ b/hieradata/bgo/roles/spine.yaml
@@ -19,9 +19,6 @@ profile::network::leaf::switchd_conf:
 profile::network::leaf::acls:
   '02control_plane_custom.rules':
     iptables:
-      # Allow access to the S3 service from everywhere
-      - "-A $FORWARD_CHAIN -i %{hiera('profile::base::network::uplink_interface')} -p tcp -d %{hiera('netcfg_pub_object')} --dport 8080 -j ACCEPT"
-      - "-A $FORWARD_CHAIN -i %{hiera('profile::base::network::uplink_interface')} -p tcp -d %{hiera('public__ip__object')} --dport 8080 -j ACCEPT"
       # Allow SMB and NFS from UiB network (only BGO)
       - "-A $FORWARD_CHAIN -i %{hiera('profile::base::network::uplink_interface')} -p tcp -s 129.177.0.0/16 --dport 139 -j ACCEPT"
       - "-A $FORWARD_CHAIN -i %{hiera('profile::base::network::uplink_interface')} -p udp -s 129.177.0.0/16 --dport 139 -j ACCEPT"
@@ -111,8 +108,6 @@ profile::network::leaf::acls:
       - "-A $FORWARD_CHAIN -i %{hiera('profile::base::network::uplink_interface')} -p tcp --dport 9200 -j DROP"
       - "-A $FORWARD_CHAIN -i %{hiera('profile::base::network::uplink_interface')} -p tcp --dport 27017 -j DROP"
     ip6tables:
-      # Allow access to the S3 service from everywhere
-      - "-A $FORWARD_CHAIN -i %{hiera('profile::base::network::uplink_interface')} -p tcp -d %{hiera('public__ipv6__object')} --dport 8080 -j ACCEPT"
       # Allow SMB and NFS from UiB network (only BGO)
       - "-A $FORWARD_CHAIN -i %{hiera('profile::base::network::uplink_interface')} -p tcp -s 2001:700:200::/48 --dport 139 -j ACCEPT"
       - "-A $FORWARD_CHAIN -i %{hiera('profile::base::network::uplink_interface')} -p udp -s 2001:700:200::/48 --dport 139 -j ACCEPT"

--- a/hieradata/common/roles/api.yaml
+++ b/hieradata/common/roles/api.yaml
@@ -91,7 +91,6 @@ profile::highavailability::loadbalancing::haproxy::haproxy_mapfile:
       - "placement.api.%{hiera('domain_public')}:8778":     'bk_placement'
       - "volume.api.%{hiera('domain_public')}:8776":        'bk_volume'
       - "image.api.%{hiera('domain_public')}:9292":         'bk_image'
-      - "object.api.%{hiera('domain_public')}:8080":        'bk_object'
       - "dns.api.%{hiera('domain_public')}:9001":           'bk_dns'
       - "status.%{hiera('domain_frontend')}":               'bk_status'
       - "status-%{::location}.%{hiera('domain_frontend')}": 'bk_status'
@@ -108,7 +107,6 @@ profile::highavailability::loadbalancing::haproxy::haproxy_mapfile:
       - "placement.api.%{hiera('domain_public2')}:8778":    'bk_placement'
       - "volume.api.%{hiera('domain_public2')}:8776":       'bk_volume'
       - "image.api.%{hiera('domain_public2')}:9292":        'bk_image'
-      - "object.api.%{hiera('domain_public2')}:8080":       'bk_object'
       - "dns.api.%{hiera('domain_public2')}:9001":          'bk_dns'
       - "status.%{hiera('domain_frontend2')}":              'bk_status'
       - "status-%{::location}.%{hiera('domain_frontend2')}": 'bk_status'
@@ -131,7 +129,6 @@ profile::highavailability::loadbalancing::haproxy::haproxy_mapfile:
       - "volume.%{hiera('domain_trp')}:8776":           'bk_volume'
       - "image.%{hiera('domain_trp')}:9292":            'bk_image'
       - "dns.%{hiera('domain_trp')}:9001":              'bk_dns'
-      - "object.%{hiera('domain_trp')}:8080":           'bk_object'
 
 # HAproxy backends: public, internal and haproxy monitor
 profile::highavailability::loadbalancing::haproxy::haproxy_frontends:
@@ -188,7 +185,6 @@ profile::highavailability::loadbalancing::haproxy::haproxy_frontends:
       "%{::ipaddress_trp1}:8776":  [] # volume
       "%{::ipaddress_trp1}:9292":  [] # image
       "%{::ipaddress_trp1}:9696":  [] # neutron
-      "%{::ipaddress_trp1}:8080":  [] # object
       "%{::ipaddress_trp1}:9001":  [] # designate
       "%{::ipaddress_trp1}:8778":  [] # placement
     options:
@@ -262,13 +258,6 @@ profile::highavailability::loadbalancing::haproxy::haproxy_backends:
       - option:       'httplog'
       - errorfile:    '503 /etc/haproxy/error.api.http'
       - balance:      'roundrobin'
-  bk_object:
-    options:
-      - fullconn:     500
-      - option:
-        - 'httplog'
-      - errorfile:    '503 /etc/haproxy/error.api.http'
-      - balance:      'roundrobin'
   bk_status:
     options:
       - fullconn:     200
@@ -310,8 +299,6 @@ volume__backend__names:    ["%{::location}-volume-01"]
 volume__backend__ips:      ["%{hiera('netcfg_trp_netpart')}.46"]
 image__backend__names:     ['%{::location}-image-01']
 image__backend__ips:       ["%{hiera('netcfg_trp_netpart')}.36"]
-object__backend__names:    []
-object__backend__ips:      []
 status__backend__names:    ['%{::location}-status-01']
 status__backend__ips:      ["%{hiera('netcfg_trp_netpart')}.50"]
 dns__backend__names:       ['%{::location}-dns-01']
@@ -366,12 +353,6 @@ profile::highavailability::loadbalancing::haproxy::haproxy_balancermembers:
     ipaddresses:        "%{alias('image__backend__ips')}"
     ports:              '9292'
     options:            'check'
-  object:
-    listening_service:  'bk_object'
-    server_names:       "%{alias('object__backend__names')}"
-    ipaddresses:        "%{alias('object__backend__ips')}"
-    ports:              '7480'
-    options:            'check'
   status:
     listening_service:  'bk_status'
     server_names:       "%{alias('status__backend__names')}"
@@ -409,10 +390,6 @@ profile::base::selinux::ports:
     seltype:  'http_port_t'
     protocol: 'tcp'
     port:     5000
-  object-http:
-    seltype:  'http_port_t'
-    protocol: 'tcp'
-    port:     7480
   network-http:
     seltype:  'http_port_t'
     protocol: 'tcp'

--- a/hieradata/common/roles/rgw.yaml
+++ b/hieradata/common/roles/rgw.yaml
@@ -24,7 +24,7 @@ profile::highavailability::loadbalancing::haproxy::manage_haproxy:      false
 profile::highavailability::loadbalancing::haproxy::manage_firewall:     false
 profile::highavailability::loadbalancing::haproxy::manage_firewall6:    false
 profile::highavailability::loadbalancing::haproxy::firewall_ports:
-  public:    ['443', '8080']
+  public:    ['443']
   internal:  []
   mgmt:      []
   limited:   []
@@ -37,7 +37,6 @@ profile::highavailability::loadbalancing::haproxy::haproxy_frontends:
   frontend_public:
     bind:
       ':::443 v4v6': ['ssl', "crt %{hiera('star_api_ssl_pem')}", "crt %{hiera('star_api_ssl_pem2')}"]
-      ':::8080 v4v6': ['ssl', "crt %{hiera('star_api_ssl_pem')}", "crt %{hiera('star_api_ssl_pem2')}"] # FIXME remove when nobody uses 8080
     mode: 'http'
     options:
       - default_backend: 'bk_object'

--- a/hieradata/osl/common.yaml
+++ b/hieradata/osl/common.yaml
@@ -96,7 +96,6 @@ netcfg_oob_vlan:          '3378'
 netcfg_elastic_cidr:      '10.6.0.0/19'
 netcfg_priv_anycast_net:   '10.254.252.224'
 netcfg_priv_anycast_cidr4: '27'
-netcfg_pub_object:        '158.37.63.250'
 netcfg_trp_rr:
   rr1:
     peer_ipv4: '172.18.38.1'

--- a/hieradata/osl/roles/api.yaml
+++ b/hieradata/osl/roles/api.yaml
@@ -65,14 +65,6 @@ volume__backend__names:
 volume__backend__ips:
   - "%{hiera('netcfg_trp_netpart')}.46"
   - "%{hiera('netcfg_trp_netpart')}.47"
-object__backend__names:
-  - '%{::location}-rgw-01'
-  - '%{::location}-rgw-02'
-  - '%{::location}-rgw-03'
-object__backend__ips:
-  - "%{hiera('netcfg_trp_netpart')}.84"
-  - "%{hiera('netcfg_trp_netpart')}.85"
-  - "%{hiera('netcfg_trp_netpart')}.87"
 
 # Temp. workaround for issue where network nodes in OSL want to contact
 # identity in BGO and is redirected thorugh an /etc/hosts entry

--- a/hieradata/osl/roles/spine.yaml
+++ b/hieradata/osl/roles/spine.yaml
@@ -19,9 +19,6 @@ profile::network::leaf::switchd_conf:
 profile::network::leaf::acls:
   '02control_plane_custom.rules':
     iptables:
-      # Allow access to the S3 service from everywhere
-      - "-A $FORWARD_CHAIN -i %{hiera('profile::base::network::uplink_interface')} -p tcp -d %{hiera('netcfg_pub_object')} --dport 8080 -j ACCEPT"
-      - "-A $FORWARD_CHAIN -i %{hiera('profile::base::network::uplink_interface')} -p tcp -d %{hiera('public__ip__object')} --dport 8080 -j ACCEPT"
       # Allow DNS requests to ns1.nrec.no
       - "-A $FORWARD_CHAIN -i %{hiera('profile::base::network::uplink_interface')} -p tcp -d 158.37.63.251 --dport 53 -j ACCEPT"
       - "-A $FORWARD_CHAIN -i %{hiera('profile::base::network::uplink_interface')} -p udp -d 158.37.63.251 --dport 53 -j ACCEPT"
@@ -113,8 +110,6 @@ profile::network::leaf::acls:
       - "-A $FORWARD_CHAIN -i %{hiera('profile::base::network::uplink_interface')} -p tcp --dport 9200 -j DROP"
       - "-A $FORWARD_CHAIN -i %{hiera('profile::base::network::uplink_interface')} -p tcp --dport 27017 -j DROP"
     ip6tables:
-      # Allow access to the S3 service from everywhere
-      - "-A $FORWARD_CHAIN -i %{hiera('profile::base::network::uplink_interface')} -p tcp -d %{hiera('public__ipv6__object')} --dport 8080 -j ACCEPT"
       # Allow DNS requests to ns1.nrec.no
       - "-A $FORWARD_CHAIN -i %{hiera('profile::base::network::uplink_interface')} -p tcp -d 2001:700:2:82ff::251 --dport 53 -j ACCEPT"
       - "-A $FORWARD_CHAIN -i %{hiera('profile::base::network::uplink_interface')} -p udp -d 2001:700:2:82ff::251 --dport 53 -j ACCEPT"


### PR DESCRIPTION
When the NREC is confident that users have migrated from port 8080 to 443 for the object service, we need to clean up config. These changes remove the object service from the api node, as well as disables service on port 8080 on the rgw nodes.