### PR TITLE
Disable backend check over ssl

### DIFF
--- a/hieradata/uib/roles/ha.yaml
+++ b/hieradata/uib/roles/ha.yaml
@@ -240,7 +240,7 @@ profile::highavailability::loadbalancing::haproxy::haproxy_balancermembers:
     ports:             '443'
     server_names:       ['docs01']
     ipaddresses:        ['uh-iaas.readthedocs.io']
-    options:            'verify none inter 1000 check check-ssl ssl'
+    options:            'verify none inter 1000 check ssl'
 # Apps
   'ssl-https-apps':
     listening_service:  'ssl-https-apps'

--- a/hieradata/vagrant/roles/ha-test.yaml
+++ b/hieradata/vagrant/roles/ha-test.yaml
@@ -76,7 +76,7 @@ profile::highavailability::loadbalancing::haproxy::haproxy_balancermembers:
     ports:              443
     server_names:       ['docs01']
     ipaddresses:        ['uh-iaas.readthedocs.io']
-    options:            'verify none inter 1000 check check-ssl ssl'
+    options:            'verify none inter 1000 check ssl'
 # Apps
   'ssl-https-apps':
     listening_service:  'ssl-https-apps'

--- a/hieradata/vagrant/roles/ha.yaml
+++ b/hieradata/vagrant/roles/ha.yaml
@@ -196,7 +196,7 @@ profile::highavailability::loadbalancing::haproxy::haproxy_balancermembers:
     ports:              '443'
     server_names:       ['docs01']
     ipaddresses:        ['uh-iaas.readthedocs.io']
-    options:            'verify none inter 1000 check check-ssl ssl'
+    options:            'verify none inter 1000 check ssl'
 # Apps
   'ssl-https-apps':
     listening_service:  'ssl-https-apps'


### PR DESCRIPTION
The haproxy frontend is unable to do a proper SSL handshake with the readthedocs backend.