### PR TITLE
feat: remove $manage_rbd -> don't use hidden implicit include for profile::storage::cephclient

### DIFF
--- a/hieradata/bgo/common.yaml
+++ b/hieradata/bgo/common.yaml
@@ -345,7 +345,6 @@ ceph::profile::params::mon_host:                    '172.18.0.91, 172.18.0.92, 1
 ceph::profile::params::cluster_network:             '172.20.0.0/21'
 ceph::profile::params::public_network:              '172.18.0.0/21'
 
-profile::openstack::volume::manage_rbd: true
 profile::openstack::compute::hypervisor::manage_libvirt_rbd: true
 
 # If backend != file, you must explicitly define stores in %location/modules/glance.yaml

--- a/hieradata/bgo/roles/compute.yaml
+++ b/hieradata/bgo/roles/compute.yaml
@@ -110,5 +110,3 @@ profile::base::cron::crontabs:
     minute:   '*/5'
     weekday:  '*'
     command:  "/usr/local/bin/power_metric.sh >/dev/null"
-
-profile::storage::cephclient::enable: true

--- a/hieradata/bgo/roles/compute.yaml
+++ b/hieradata/bgo/roles/compute.yaml
@@ -1,4 +1,5 @@
 ---
+
 # collectd
 include:
   default:
@@ -110,3 +111,4 @@ profile::base::cron::crontabs:
     minute:   '*/5'
     weekday:  '*'
     command:  "/usr/local/bin/power_metric.sh >/dev/null"
+

--- a/hieradata/bgo/roles/compute.yaml
+++ b/hieradata/bgo/roles/compute.yaml
@@ -110,3 +110,5 @@ profile::base::cron::crontabs:
     minute:   '*/5'
     weekday:  '*'
     command:  "/usr/local/bin/power_metric.sh >/dev/null"
+
+profile::storage::cephclient::enable: true

--- a/hieradata/bgo/roles/image.yaml
+++ b/hieradata/bgo/roles/image.yaml
@@ -1,2 +1,0 @@
----
-profile::openstack::image::manage_rbd: true

--- a/hieradata/common/roles/compute.yaml
+++ b/hieradata/common/roles/compute.yaml
@@ -322,3 +322,5 @@ nova::config::nova_config:
 # Red Hat Subscription Management (RHSM)
 profile::rhsm::subscription::manage: true
 profile::rhsm::virtwho::manage:      true
+
+profile::storage::cephclient::enable: true

--- a/hieradata/common/roles/compute.yaml
+++ b/hieradata/common/roles/compute.yaml
@@ -11,6 +11,7 @@ include:
     - profile::rhsm::subscription
     - profile::rhsm::virtwho
     - profile::base::httpproxy
+    - profile::storage::cephclient
   kickstart:
     - profile::virtualization::nested
     - profile::network::yum_proxy

--- a/hieradata/common/roles/image.yaml
+++ b/hieradata/common/roles/image.yaml
@@ -67,3 +67,5 @@ profile::base::selinux::boolean:
 profile::base::selinux::semodules:
   'postfix_glance':
     avc_file:   "postfix_glance.avc"
+
+profile::storage::cephclient::enable: true

--- a/hieradata/common/roles/image.yaml
+++ b/hieradata/common/roles/image.yaml
@@ -5,6 +5,7 @@ include:
     - profile::openstack::openrc
     - profile::logging::rsyslog::client
     - profile::openstack::cache
+    - profile::storage::cephclient
 
 profile::base::common::packages:
   # we need newer version of six to avoid breaking requests and openstack cli

--- a/hieradata/common/roles/volume.yaml
+++ b/hieradata/common/roles/volume.yaml
@@ -9,6 +9,7 @@ include:
     - profile::openstack::cache
     - profile::logging::rsyslog::client
     - profile::webserver::apache::status
+    - profile::storage::cephclient
 
 profile::base::common::packages:
   # we need newer version of six to avoid breaking requests and openstack cli

--- a/hieradata/common/roles/volume.yaml
+++ b/hieradata/common/roles/volume.yaml
@@ -167,3 +167,5 @@ profile::base::selinux::semodules:
     avc_file:   "attach_cinder.avc"
   'httpd_cinder':
     avc_file:   "httpd_cinder.avc"
+
+profile::storage::cephclient::enable: true

--- a/hieradata/local3/common.yaml
+++ b/hieradata/local3/common.yaml
@@ -136,7 +136,6 @@ ceph::profile::params::mon_host:                    '172.31.12.91, 172.31.12.92,
 ceph::profile::params::cluster_network:             '172.31.12.0/24'
 ceph::profile::params::public_network:              '172.31.12.0/24'
 
-profile::openstack::volume::manage_rbd: true
 profile::openstack::compute::hypervisor::manage_libvirt_rbd: true
 
 # If backend != file, you must explicitly define stores in %location/modules/glance.yaml

--- a/hieradata/local3/roles/image.yaml
+++ b/hieradata/local3/roles/image.yaml
@@ -1,5 +1,4 @@
 ---
-profile::openstack::image::manage_rbd:  true
 profile::base::selinux::manage_selinux: true
 
 include:

--- a/hieradata/nodes/bgo/bgo-compute-vgpu-54.yaml
+++ b/hieradata/nodes/bgo/bgo-compute-vgpu-54.yaml
@@ -13,6 +13,4 @@ profile::base::lvm::logical_volume:
     fs_type:      "xfs"
     mountpath:    "/var/lib/nova/instances"
 
-profile::storage::cephclient::enable: true
-
 nova::compute::libvirt::cpu_models: ['Cascadelake-Server-noTSX']

--- a/hieradata/osl/common.yaml
+++ b/hieradata/osl/common.yaml
@@ -360,7 +360,6 @@ ceph::profile::params::mon_host:                    '172.18.32.91, 172.18.32.92,
 ceph::profile::params::cluster_network:             '172.20.32.0/21'
 ceph::profile::params::public_network:              '172.18.32.0/21'
 
-profile::openstack::volume::manage_rbd: true
 profile::openstack::compute::hypervisor::manage_libvirt_rbd: true
 
 # If backend != file, you must explicitly define stores in %location/modules/glance.yaml

--- a/hieradata/osl/roles/compute.yaml
+++ b/hieradata/osl/roles/compute.yaml
@@ -84,5 +84,3 @@ profile::monitoring::sensu::agent::checks:
     subscribers:  ['checks']
 
 calico::compute::felix_mtuIfacePattern: '^team*'
-
-profile::storage::cephclient::enable: true

--- a/hieradata/osl/roles/compute.yaml
+++ b/hieradata/osl/roles/compute.yaml
@@ -84,3 +84,5 @@ profile::monitoring::sensu::agent::checks:
     subscribers:  ['checks']
 
 calico::compute::felix_mtuIfacePattern: '^team*'
+
+profile::storage::cephclient::enable: true

--- a/hieradata/osl/roles/image.yaml
+++ b/hieradata/osl/roles/image.yaml
@@ -1,2 +1,0 @@
----
-profile::openstack::image::manage_rbd: true

--- a/hieradata/test01/common.yaml
+++ b/hieradata/test01/common.yaml
@@ -210,7 +210,6 @@ chrony::servers:
   - ntp.uib.no
   - ntp2.uib.no
 
-profile::openstack::volume::manage_rbd: true
 profile::openstack::compute::hypervisor::manage_libvirt_rbd: true
 
 # If backend != file, you must explicitly define stores in %location/modules/glance.yaml

--- a/hieradata/test01/roles/compute.yaml
+++ b/hieradata/test01/roles/compute.yaml
@@ -121,3 +121,5 @@ nova::config::nova_config:
     value: '4'
   libvirt/remote_filesystem_transport:
     value: 'rsync'
+
+profile::storage::cephclient::enable: true

--- a/hieradata/test01/roles/compute.yaml
+++ b/hieradata/test01/roles/compute.yaml
@@ -121,5 +121,3 @@ nova::config::nova_config:
     value: '4'
   libvirt/remote_filesystem_transport:
     value: 'rsync'
-
-profile::storage::cephclient::enable: true

--- a/hieradata/test01/roles/image.yaml
+++ b/hieradata/test01/roles/image.yaml
@@ -1,2 +1,0 @@
----
-profile::openstack::image::manage_rbd:      true

--- a/hieradata/test02/common.yaml
+++ b/hieradata/test02/common.yaml
@@ -160,7 +160,6 @@ chrony::servers:
   - ntp1.uio.no
   - ntp2.uio.no
 
-profile::openstack::volume::manage_rbd: true
 profile::openstack::compute::hypervisor::manage_libvirt_rbd: true
 
 # If backend != file, you must explicitly define stores in %location/modules/glance.yaml

--- a/hieradata/test02/roles/image.yaml
+++ b/hieradata/test02/roles/image.yaml
@@ -1,2 +1,0 @@
----
-profile::openstack::image::manage_rbd:    true

--- a/hieradata/tos/common.yaml
+++ b/hieradata/tos/common.yaml
@@ -189,7 +189,6 @@ ceph::profile::params::mon_host:                    '10.246.16.91, 10.246.16.92,
 ceph::profile::params::cluster_network:             '172.20.64.0/21'
 ceph::profile::params::public_network:              '10.246.16.0/21'
 
-profile::openstack::volume::manage_rbd: true
 profile::openstack::compute::hypervisor::manage_libvirt_rbd: true
 
 # If backend != file, you must explicitly define stores in %location/modules/glance.yaml

--- a/hieradata/vagrant/roles/compute.yaml
+++ b/hieradata/vagrant/roles/compute.yaml
@@ -89,3 +89,5 @@ profile::base::common::packages:
   'python3-redis': {} # OSProfiler dependency
 
 profile::openstack::compute::manage_osprofiler: true
+
+profile::storage::cephclient::enable: false

--- a/hieradata/vagrant/roles/image.yaml
+++ b/hieradata/vagrant/roles/image.yaml
@@ -2,3 +2,5 @@ profile::base::common::packages:
   'python3-redis': {} # OSProfiler dependency
 
 profile::openstack::image::manage_osprofiler: true
+
+profile::storage::cephclient::enable: false

--- a/hieradata/vagrant/roles/volume.yaml
+++ b/hieradata/vagrant/roles/volume.yaml
@@ -28,3 +28,5 @@ profile::base::common::packages:
   'python3-redis': {} # OSProfiler dependency
 
 profile::openstack::volume::manage_osprofiler: true
+
+profile::storage::cephclient::enable: false

--- a/profile/manifests/openstack/image.pp
+++ b/profile/manifests/openstack/image.pp
@@ -1,7 +1,6 @@
 #
 class profile::openstack::image(
   $notify_enabled   = false,
-  $manage_rbd       = false,
   $manage_policy    = false,
   $manage_notify    = false,
   $manage_osprofiler = false,
@@ -11,10 +10,6 @@ class profile::openstack::image(
 
   if $notify_enabled {
     include ::profile::openstack::image::notify
-  }
-
-  if $manage_rbd {
-    include profile::storage::cephclient
   }
 
   if $manage_policy {

--- a/profile/manifests/openstack/volume.pp
+++ b/profile/manifests/openstack/volume.pp
@@ -1,6 +1,5 @@
 #
 class profile::openstack::volume(
-  $manage_rbd    = false,
   $notify_service = false,
   $manage_osprofiler = false
 ) {
@@ -9,10 +8,6 @@ class profile::openstack::volume(
   include ::cinder::client
   include ::cinder::config
   include ::cinder::logging
-
-  if $manage_rbd {
-    include profile::storage::cephclient
-  }
 
   if $notify_service {
     # This will make sure httpd service will be restarted on config changes


### PR DESCRIPTION
* use profile::storage::cephclient::enable directly in hieradata
* moved setting to hieradata/common/roles/stuff.yaml
* must opt out on non-ceph locations, eg. vagrant