### PR TITLE
feat: disable nouveau on bgo-compute-vgpu-54

### DIFF
--- a/hieradata/nodes/bgo/bgo-compute-vgpu-54.yaml
+++ b/hieradata/nodes/bgo/bgo-compute-vgpu-54.yaml
@@ -14,3 +14,14 @@ profile::base::lvm::logical_volume:
     mountpath:    "/var/lib/nova/instances"
 
 nova::compute::libvirt::cpu_models: ['Cascadelake-Server-noTSX']
+
+#kmod::list_of_blacklists:
+#  'nouveau': {}
+kmod::list_of_installs:
+  'nouveau':
+    command: '/bin/false'
+kmod::list_of_options:
+  'nouveau modeset':
+    module: 'nouveau'
+    option: 'modeset'
+    value: '0'


### PR DESCRIPTION
in /etc/modprobe.d/somefile
sets `options nouveau modeset=0`