### PR TITLE
Remove els disk on test01-logger-01

### DIFF
--- a/hieradata/test01/roles/logger.yaml
+++ b/hieradata/test01/roles/logger.yaml
@@ -1,3 +1,18 @@
 ---
 
 profile::base::common::manage_lvm: true
+# disks
+profile::base::lvm::physical_volume:
+  '/dev/vdb':
+    ensure: present
+    force:  true
+profile::base::lvm::volume_group:
+  'vg_log':
+    physical_volumes:
+      - /dev/vdb
+profile::base::lvm::logical_volume:
+  'lv_log':
+    volume_group: 'vg_log'
+    fs_type:      "xfs"
+    mountpath:    "/opt/log"
+    size:         '20G'


### PR DESCRIPTION
The goal here is to remove the LVM els disk from test01-logger-01 

/dev/mapper/vg_log-lv_els     80G  8.6G   72G  11% /opt/els