### PR TITLE
Allow internal anycast ipv4 cidr

### DIFF
--- a/hieradata/bgo/common.yaml
+++ b/hieradata/bgo/common.yaml
@@ -113,6 +113,7 @@ netcfg_anycast_dns6:      '2001:700:2:83ff::252'
 netcfg_ib_vlan:           '908'
 netcfg_oob_vlan:          '909'
 netcfg_elastic_cidr:      '10.5.0.0/19'
+netcfg_priv_anycast_cidr: '10.254.253.224/27'
 netcfg_pub_object:        '158.39.77.250'
 netcfg_trp_rr:
   rr1:

--- a/hieradata/bgo/roles/spine.yaml
+++ b/hieradata/bgo/roles/spine.yaml
@@ -1377,6 +1377,7 @@ frrouting::frrouting::bgp_accesslist:
     - 'seq 35 permit 10.3.0.0 0.0.15.255'
     - 'seq 40 permit 10.5.0.0/19'
     - "seq 41 permit %{hiera('bgp_loopback_addr')}/32"
+    - "seq 42 permit %{hiera('netcfg_priv_anycast_cidr')}"
     - 'seq 45 permit 10.109.0.0 0.0.15.255'
     - 'seq 50 permit 109.105.127.128 0.0.0.63'
     - 'seq 55 permit 172.18.0.0 0.0.7.255'

--- a/hieradata/nodes/bgo/bgo-spine-01.yaml
+++ b/hieradata/nodes/bgo/bgo-spine-01.yaml
@@ -152,6 +152,7 @@ frrouting::frrouting::bgp_networks:
   - '158.39.77.0/24'
   - '158.39.201.0/24'
   - "%{hiera('bgp_loopback_addr')}/32"
+  - "%{hiera('netcfg_priv_anycast_cidr')}"
 
 frrouting::frrouting::bgp_networks6:
   - '2001:948:62:1::/64'

--- a/hieradata/nodes/bgo/bgo-spine-02.yaml
+++ b/hieradata/nodes/bgo/bgo-spine-02.yaml
@@ -134,6 +134,7 @@ frrouting::frrouting::bgp_networks:
   - '158.39.77.0/24'
   - '158.39.201.0/24'
   - "%{hiera('bgp_loopback_addr')}/32"
+  - "%{hiera('netcfg_priv_anycast_cidr')}"
 
 frrouting::frrouting::bgp_networks6:
   - '2001:948:62:1::/64'

--- a/hieradata/nodes/osl/osl-spine-01.yaml
+++ b/hieradata/nodes/osl/osl-spine-01.yaml
@@ -92,6 +92,7 @@ frrouting::frrouting::bgp_networks:
   - '158.39.75.0/24'
   - '158.39.200.0/24'
   - "%{hiera('bgp_loopback_addr')}/32"
+  - "%{hiera('netcfg_priv_anycast_cidr')}"
 frrouting::frrouting::bgp_networks6:
   - '2001:700:2:8200::/56'
 

--- a/hieradata/nodes/osl/osl-spine-02.yaml
+++ b/hieradata/nodes/osl/osl-spine-02.yaml
@@ -92,6 +92,8 @@ frrouting::frrouting::bgp_networks:
   - '158.39.48.0/24'
   - '158.39.75.0/24'
   - '158.39.200.0/24'
+  - "%{hiera('bgp_loopback_addr')}/32"
+  - "%{hiera('netcfg_priv_anycast_cidr')}"
 frrouting::frrouting::bgp_networks6:
   - '2001:700:2:8200::/56'
 

--- a/hieradata/osl/common.yaml
+++ b/hieradata/osl/common.yaml
@@ -94,6 +94,7 @@ netcfg_anycast_dns6:      '2001:700:2:82ff::252'
 netcfg_ib_vlan:           '3379'
 netcfg_oob_vlan:          '3378'
 netcfg_elastic_cidr:      '10.6.0.0/19'
+netcfg_priv_anycast_cidr: '10.254.252.224/27'
 netcfg_pub_object:        '158.37.63.250'
 netcfg_trp_rr:
   rr1:

--- a/hieradata/osl/roles/spine.yaml
+++ b/hieradata/osl/roles/spine.yaml
@@ -1019,6 +1019,7 @@ frrouting::frrouting::bgp_accesslist:
     - 'seq 30 permit 10.4.0.0 0.0.15.255'
     - 'seq 35 permit 10.6.0.0/19'
     - "seq 36 permit %{hiera('bgp_loopback_addr')}/32"
+    - "seq 37 permit %{hiera('netcfg_priv_anycast_cidr')}"
     - 'seq 40 permit 172.18.32.0 0.0.0.255'
     - 'seq 250 deny 0.0.0.0/0'
   '20':


### PR DESCRIPTION
Add a CIDR to each production region which allows a range of private IPv4 addresses to be announced internally in an NREC region.