### PR TITLE
Route internal anycast addr to spine

### DIFF
--- a/hieradata/bgo/common.yaml
+++ b/hieradata/bgo/common.yaml
@@ -113,7 +113,8 @@ netcfg_anycast_dns6:      '2001:700:2:83ff::252'
 netcfg_ib_vlan:           '908'
 netcfg_oob_vlan:          '909'
 netcfg_elastic_cidr:      '10.5.0.0/19'
-netcfg_priv_anycast_cidr: '10.254.253.224/27'
+netcfg_priv_anycast_net:   '10.254.253.224'
+netcfg_priv_anycast_cidr4: '27'
 netcfg_pub_object:        '158.39.77.250'
 netcfg_trp_rr:
   rr1:

--- a/hieradata/bgo/roles/compute.yaml
+++ b/hieradata/bgo/roles/compute.yaml
@@ -64,11 +64,11 @@ profile::openstack::network::calico::manage_firewall6: true
 # Add custom routing table for private network to NAT, lhc to other gw
 profile::base::network::routes:
   'team1':
-    'ipaddress': [ '0.0.0.0', '192.168.243.0', '0.0.0.0', '0.0.0.0', '0.0.0.0', '::', '129.177.0.0', '2001:700:200::', ]
-    'netmask':   [ '0.0.0.0', '255.255.255.0', '0.0.0.0', '0.0.0.0', '0.0.0.0', '0', '255.255.0.0', '48', ]
-    'gateway':   [ "%{hiera('netcfg_priv_gateway')}", "%{hiera('netcfg_trp_gateway')}", "%{hiera('netcfg_trp_gateway')}", "%{hiera('netcfg_lhc_gateway')}", "%{hiera('netcfg_lhcpriv_gateway')}", "%{hiera('netcfg_lhc_gateway6')}", "%{hiera('netcfg_uib_gateway')}", "%{hiera('netcfg_uib_gateway6')}",  ]
-    'table':     [ 'private', 'lhc', 'main', 'lhc', 'lhc-private', 'lhc', 'uib', 'uib', ]
-    'family':    [ 'inet4', 'inet4', 'inet4', 'inet4', 'inet4', 'inet6', 'inet4', 'inet6', ]
+    'ipaddress': [ '0.0.0.0', "%{hiera('netcfg_priv_anycast_net')}", '192.168.243.0', '0.0.0.0', '0.0.0.0', '0.0.0.0', '::', '129.177.0.0', '2001:700:200::', ]
+    'netmask':   [ '0.0.0.0', "%{hiera('netcfg_priv_anycast_cidr4')}", '255.255.255.0', '0.0.0.0', '0.0.0.0', '0.0.0.0', '0', '255.255.0.0', '48', ]
+    'gateway':   [ "%{hiera('netcfg_priv_gateway')}", "%{hiera('netcfg_trp_gateway')}", "%{hiera('netcfg_trp_gateway')}", "%{hiera('netcfg_trp_gateway')}", "%{hiera('netcfg_lhc_gateway')}", "%{hiera('netcfg_lhcpriv_gateway')}", "%{hiera('netcfg_lhc_gateway6')}", "%{hiera('netcfg_uib_gateway')}", "%{hiera('netcfg_uib_gateway6')}",  ]
+    'table':     [ 'private', 'private', 'lhc', 'main', 'lhc', 'lhc-private', 'lhc', 'uib', 'uib', ]
+    'family':    [ 'inet4', 'inet4', 'inet4', 'inet4', 'inet4', 'inet4', 'inet6', 'inet4', 'inet6', ]
 profile::base::network::routing_tables:
   'private':
     'table_id':  '240'

--- a/hieradata/bgo/roles/spine.yaml
+++ b/hieradata/bgo/roles/spine.yaml
@@ -1377,7 +1377,7 @@ frrouting::frrouting::bgp_accesslist:
     - 'seq 35 permit 10.3.0.0 0.0.15.255'
     - 'seq 40 permit 10.5.0.0/19'
     - "seq 41 permit %{hiera('bgp_loopback_addr')}/32"
-    - "seq 42 permit %{hiera('netcfg_priv_anycast_cidr')}"
+    - "seq 42 permit %{hiera('netcfg_priv_anycast_net')}/%{hiera('netcfg_priv_anycast_cidr4')}"
     - 'seq 45 permit 10.109.0.0 0.0.15.255'
     - 'seq 50 permit 109.105.127.128 0.0.0.63'
     - 'seq 55 permit 172.18.0.0 0.0.7.255'

--- a/hieradata/nodes/bgo/bgo-spine-01.yaml
+++ b/hieradata/nodes/bgo/bgo-spine-01.yaml
@@ -152,7 +152,7 @@ frrouting::frrouting::bgp_networks:
   - '158.39.77.0/24'
   - '158.39.201.0/24'
   - "%{hiera('bgp_loopback_addr')}/32"
-  - "%{hiera('netcfg_priv_anycast_cidr')}"
+  - "%{hiera('netcfg_priv_anycast_net')}/%{hiera('netcfg_priv_anycast_cidr4')}"
 
 frrouting::frrouting::bgp_networks6:
   - '2001:948:62:1::/64'

--- a/hieradata/nodes/bgo/bgo-spine-02.yaml
+++ b/hieradata/nodes/bgo/bgo-spine-02.yaml
@@ -134,7 +134,7 @@ frrouting::frrouting::bgp_networks:
   - '158.39.77.0/24'
   - '158.39.201.0/24'
   - "%{hiera('bgp_loopback_addr')}/32"
-  - "%{hiera('netcfg_priv_anycast_cidr')}"
+  - "%{hiera('netcfg_priv_anycast_net')}/%{hiera('netcfg_priv_anycast_cidr4')}"
 
 frrouting::frrouting::bgp_networks6:
   - '2001:948:62:1::/64'

--- a/hieradata/nodes/osl/osl-spine-01.yaml
+++ b/hieradata/nodes/osl/osl-spine-01.yaml
@@ -92,7 +92,7 @@ frrouting::frrouting::bgp_networks:
   - '158.39.75.0/24'
   - '158.39.200.0/24'
   - "%{hiera('bgp_loopback_addr')}/32"
-  - "%{hiera('netcfg_priv_anycast_cidr')}"
+  - "%{hiera('netcfg_priv_anycast_net')}/%{hiera('netcfg_priv_anycast_cidr4')}"
 frrouting::frrouting::bgp_networks6:
   - '2001:700:2:8200::/56'
 

--- a/hieradata/nodes/osl/osl-spine-02.yaml
+++ b/hieradata/nodes/osl/osl-spine-02.yaml
@@ -93,7 +93,7 @@ frrouting::frrouting::bgp_networks:
   - '158.39.75.0/24'
   - '158.39.200.0/24'
   - "%{hiera('bgp_loopback_addr')}/32"
-  - "%{hiera('netcfg_priv_anycast_cidr')}"
+  - "%{hiera('netcfg_priv_anycast_net')}/%{hiera('netcfg_priv_anycast_cidr4')}"
 frrouting::frrouting::bgp_networks6:
   - '2001:700:2:8200::/56'
 

--- a/hieradata/osl/common.yaml
+++ b/hieradata/osl/common.yaml
@@ -94,7 +94,8 @@ netcfg_anycast_dns6:      '2001:700:2:82ff::252'
 netcfg_ib_vlan:           '3379'
 netcfg_oob_vlan:          '3378'
 netcfg_elastic_cidr:      '10.6.0.0/19'
-netcfg_priv_anycast_cidr: '10.254.252.224/27'
+netcfg_priv_anycast_net:   '10.254.252.224'
+netcfg_priv_anycast_cidr4: '27'
 netcfg_pub_object:        '158.37.63.250'
 netcfg_trp_rr:
   rr1:

--- a/hieradata/osl/roles/compute.yaml
+++ b/hieradata/osl/roles/compute.yaml
@@ -38,10 +38,10 @@ profile::openstack::network::calico::manage_firewall6: true
 # Add custom routing table for private network to NAT
 profile::base::network::routes:
   'team1':
-    'ipaddress': [ '0.0.0.0', '0.0.0.0', ]
-    'netmask':   [ '0.0.0.0', '0.0.0.0', ]
-    'gateway':   [ "%{hiera('netcfg_priv_gateway')}", "%{hiera('netcfg_trp_gateway')}" ]
-    'table':     [ 'private', 'main', ]
+    'ipaddress': [ '0.0.0.0', "%{hiera('netcfg_priv_anycast_net')}", '0.0.0.0', ]
+    'netmask':   [ '0.0.0.0', "%{hiera('netcfg_priv_anycast_cidr4')}", '0.0.0.0', ]
+    'gateway':   [ "%{hiera('netcfg_priv_gateway')}", "%{hiera('netcfg_trp_gateway')}", "%{hiera('netcfg_trp_gateway')}" ]
+    'table':     [ 'private', 'private', 'main', ]
 profile::base::network::routing_tables:
   'private':
     'table_id':  '240'

--- a/hieradata/osl/roles/spine.yaml
+++ b/hieradata/osl/roles/spine.yaml
@@ -1019,7 +1019,7 @@ frrouting::frrouting::bgp_accesslist:
     - 'seq 30 permit 10.4.0.0 0.0.15.255'
     - 'seq 35 permit 10.6.0.0/19'
     - "seq 36 permit %{hiera('bgp_loopback_addr')}/32"
-    - "seq 37 permit %{hiera('netcfg_priv_anycast_cidr')}"
+    - "seq 37 permit %{hiera('netcfg_priv_anycast_net')}/%{hiera('netcfg_priv_anycast_cidr4')}"
     - 'seq 40 permit 172.18.32.0 0.0.0.255'
     - 'seq 250 deny 0.0.0.0/0'
   '20':


### PR DESCRIPTION
Neither NAT nodes nor computes can not know about anycasted addresses from instances (running on other computes). Traffic directed to an anycasted address must be routed to spine - hence this PR.