### PR TITLE
feat(bgo): remove volume mass-storage-dcache-temp-slow

### DIFF
--- a/hieradata/bgo/roles/storage-dcache2.yaml
+++ b/hieradata/bgo/roles/storage-dcache2.yaml
@@ -57,15 +57,6 @@ ceph::profile::params::osd_recovery_max_active: '3'
 ceph::profile::params::osd_max_backfills: '1'
 
 profile::storage::ceph_ecpool::ec_pools:
-  'dcache_hdd_ec_data8':
-    pg_num:              "8192"
-    manage:              true
-    allow_ec_overwrites: true
-    k_data:              "8"
-    m_code:              "2"
-    crush_root:          "dcache"
-    plugin:              "jerasure"
-    technique:           "liber8tion"
   'dcache_hdd_ec82_data':
     pg_num:              "8192"
     manage:              true
@@ -79,20 +70,6 @@ profile::storage::ceph_ecpool::ec_pools:
 profile::storage::ceph::pool::pools:
   'rbd':
     ensure: absent
-  'dcache_hdd_ec_meta8':
-    size:    3
-    pg_num:  64
-    tag:    'rbd'
-    custom:
-      crush_rule: 'ssd-storage'
-      nodelete:   'true'
-      min_size:   '2'
-  'dcache_hdd_ec_data8':
-    custom:
-      deep_scrub_interval: '1.93536e+07' # every 32 weeks - overrides osd setting
-      scrub_max_interval:  '2.4192e+06'  # normal scrub at least every 4 weeks - overrides osd setting
-      scrub_min_interval:  '604800'      # minimum one week between each scrub
-      fast_read:           '1'           # read all k+m for read, trade bandwith for lower latency
   'dcache_hdd_ec82_meta':
     size:    3
     pg_num:  64
@@ -112,9 +89,6 @@ profile::storage::ceph::pool::ec_pools:
     manage: false
 
 profile::storage::cephpool_params::pools:
-  'dcache_hdd_ec_data8':
-    application_enable: 'rbd'
-    replicas_min_size:  '9'
   'dcache_hdd_ec82_data':
     application_enable: 'rbd'
     replicas_min_size:  '9'

--- a/hieradata/bgo/roles/volume.yaml
+++ b/hieradata/bgo/roles/volume.yaml
@@ -16,10 +16,6 @@ profile::openstack::volume::type:
     is_public: false
     properties:
       - 'volume_backend_name=mass-storage-ssd'
-  mass-storage-dcache-temp-slow:
-    is_public: false
-    properties:
-      - 'volume_backend_name=mass-storage-dcache8'
   mass-storage-dcache:
     is_public: false
     properties:
@@ -79,20 +75,6 @@ profile::openstack::volume::backend::rbd:
         value: 'False'
       mass-storage-ssd/max_over_subscription_ratio:
         value: '1000.0'
-  mass-storage-dcache8:
-    rbd_pool: 'dcache_hdd_ec_meta8'
-    rbd_user: 'cinder-dcache-hdd-ec8'
-    rbd_flatten_volume_from_snapshot: 'True'
-    rbd_secret_uuid: "%{hiera('libvirt_rbd_secret_uuid')}"
-    extra_options:
-      mass-storage-dcache8/enable_deferred_deletion:
-        value: 'True'
-      mass-storage-dcache8/rbd_exclusive_cinder_pool:
-        value: 'True'
-      mass-storage-dcache8/report_dynamic_total_capacity:
-        value: 'False'
-      mass-storage-dcache8/max_over_subscription_ratio:
-        value: '5600.0'
   dcache-hdd-ec82:
     rbd_pool: 'dcache_hdd_ec82_meta'
     rbd_user: 'cinder-dcache-hdd-ec82'
@@ -115,5 +97,4 @@ cinder::backends::enabled_backends:
   - mass-storage-default
   - mass-storage-dcache
   - mass-storage-ssd
-  - mass-storage-dcache8
   - dcache-hdd-ec82

--- a/hieradata/common/modules/ceph.yaml
+++ b/hieradata/common/modules/ceph.yaml
@@ -71,13 +71,6 @@ ceph::profile::params::client_keys:
     group: 'cinder'
     cap_mon: 'profile rbd'
     cap_osd: 'profile rbd pool=dcache_hdd_ec_meta, profile rbd pool=dcache_hdd_ec_data'
-  'client.cinder-dcache-hdd-ec8':
-    secret: "%{hiera('ceph_storage_client_cinder_key')}"
-    mode: '0600'
-    user: 'cinder'
-    group: 'cinder'
-    cap_mon: 'profile rbd'
-    cap_osd: 'profile rbd pool=dcache_hdd_ec_meta8, profile rbd pool=dcache_hdd_ec_data8'
   'client.cinder-dcache-hdd-ec82':
     secret: "%{hiera('ceph_storage_client_cinder_key')}"
     mode: '0600'

--- a/hieradata/common/roles/compute.yaml
+++ b/hieradata/common/roles/compute.yaml
@@ -283,13 +283,6 @@ ceph::profile::params::client_keys:
     group: 'cinder'
     cap_mon: 'profile rbd'
     cap_osd: 'profile rbd pool=dcache_hdd_ec_meta, profile rbd pool=dcache_hdd_ec_data'
-  'client.cinder-dcache-hdd-ec8':
-    secret: "%{hiera('ceph_storage_client_cinder_key')}"
-    mode: '0600'
-    user: 'cinder'
-    group: 'cinder'
-    cap_mon: 'profile rbd'
-    cap_osd: 'profile rbd pool=dcache_hdd_ec_meta8, profile rbd pool=dcache_hdd_ec_data8'
   'client.cinder-dcache-hdd-ec82':
     secret: "%{hiera('ceph_storage_client_cinder_key')}"
     mode: '0600'
@@ -309,9 +302,6 @@ profile::storage::ceph_extraconf::config:
   client_dcache_backend:
     'config_key'  : "client.cinder-dcache-hdd-ec/rbd_default_data_pool"
     'config_value': "dcache_hdd_ec_data"
-  client_dcache_backend8:
-    'config_key'  : "client.cinder-dcache-hdd-ec8/rbd_default_data_pool"
-    'config_value': "dcache_hdd_ec_data8"
   client_dcache_backend_82:
     'config_key'  : "client.cinder-dcache-hdd-ec82/rbd_default_data_pool"
     'config_value': "dcache_hdd_ec82_data"

--- a/hieradata/common/roles/volume.yaml
+++ b/hieradata/common/roles/volume.yaml
@@ -130,13 +130,6 @@ ceph::profile::params::client_keys:
     group: 'cinder'
     cap_mon: 'profile rbd'
     cap_osd: 'profile rbd pool=dcache_hdd_ec_meta, profile rbd pool=dcache_hdd_ec_data'
-  'client.cinder-dcache-hdd-ec8':
-    secret: "%{hiera('ceph_storage_client_cinder_key')}"
-    mode: '0600'
-    user: 'cinder'
-    group: 'cinder'
-    cap_mon: 'profile rbd'
-    cap_osd: 'profile rbd pool=dcache_hdd_ec_meta8, profile rbd pool=dcache_hdd_ec_data8'
   'client.cinder-dcache-hdd-ec82':
     secret: "%{hiera('ceph_storage_client_cinder_key')}"
     mode: '0600'
@@ -156,9 +149,6 @@ profile::storage::ceph_extraconf::config:
   client_dcache_backend:
     'config_key'  : "client.cinder-dcache-hdd-ec/rbd_default_data_pool"
     'config_value': "dcache_hdd_ec_data"
-  client_dcache_backend8:
-    'config_key'  : "client.cinder-dcache-hdd-ec8/rbd_default_data_pool"
-    'config_value': "dcache_hdd_ec_data8"
   client_dcache_backend_82:
     'config_key'  : "client.cinder-dcache-hdd-ec82/rbd_default_data_pool"
     'config_value': "dcache_hdd_ec82_data"


### PR DESCRIPTION
removes from himlar:
  - ceph-pool dcache_hdd_ec_meta8 and dcache_hdd_ec_data8
  - cinder volume type: mass-storage-dcache-temp-slow
  - cinder user/client key-config