### PR TITLE
fix: use layer 4 hash policy to distribute load better

### DIFF
--- a/hieradata/test01/roles/compute.yaml
+++ b/hieradata/test01/roles/compute.yaml
@@ -36,6 +36,7 @@ profile::base::network::network_auto_bonding:
       'team_port_config': '{ "prio" : 100 }'
       'mtu': '9000'
 
+profile::base::common::manage_multipath: true
 # IPv6 is enabled for bgp, bfd
 profile::openstack::network::calico::manage_firewall6: true
 

--- a/profile/manifests/base/common.pp
+++ b/profile/manifests/base/common.pp
@@ -22,8 +22,10 @@ class profile::base::common (
   $manage_puppet          = false,
   $manage_cron            = false,
   $manage_fake_ssd        = false,
+  $manage_multipath       = false,
   $manage_vm_swappiness   = false,
   $disable_firewalld      = false,
+  $multipath_hash_policy  = 1,         # Layer 4 hash policy (source port, dest port, source addr, dest addr, protocol)
   $vm_swappiness          = '10',
   $include_physical       = false,
   $include_virtual        = false,
@@ -166,6 +168,17 @@ class profile::base::common (
   if $manage_fake_ssd {
     $disk_devices = lookup('profile::storage::fake_ssds', Hash, 'deep', {})
     create_resources('profile::storage::fake_ssd', $disk_devices)
+  }
+
+  if $manage_multipath {
+    sysctl::value {
+      'net.ipv4.fib_multipath_hash_policy':
+        value => $multipath_hash_policy,
+    } ~>
+    sysctl::value {
+      'net.ipv6.fib_multipath_hash_policy':
+        value => $multipath_hash_policy,
+    }
   }
 
   if $manage_vm_swappiness {


### PR DESCRIPTION
https://codecave.cc/multipath-routing-in-linux-part-2.html

The default value is 0, which results in layer3 policy, so source/dest addr (+ipv6 flow label), setting it to 1 gives the layer4 policy, which additionally includes source/dest port and the used protocol