### PR TITLE
Test01: dashboard EL9 mysqlclient

### DIFF
--- a/hieradata/test01/roles/dashboard.yaml
+++ b/hieradata/test01/roles/dashboard.yaml
@@ -10,3 +10,11 @@ profile::openstack::dashboard::allow_from_network:
 
 # Disable admin dashboard
 profile::openstack::dashboard::disable_admin_dashboard: true
+
+profile::base::yumrepo::repo_hash:
+  epel: # should be absent when using RDO, but whitelist can also work
+    includepkgs: 'htop python3-mysqlclient'
+
+profile::base::common::packages:
+  'python3-mysql':       { ensure: absent }
+  'python3-mysqlclient': {}


### PR DESCRIPTION
Mikael: Må bytte fra python3-mysql (finnes ikke i EPEL for EL9). Prøver python3-mysqlclient

Jeg antar dette er det ene steget vi må gjøre.