### PR TITLE
feat(bgo): remove unused volume 'mass-storage-dcache-temp' from openstack

### DIFF
--- a/hieradata/bgo/roles/volume.yaml
+++ b/hieradata/bgo/roles/volume.yaml
@@ -8,10 +8,6 @@ profile::openstack::volume::type:
     is_public: true
     properties:
       - 'volume_backend_name=mass-storage-default'
-  mass-storage-dcache-temp:
-    is_public: false
-    properties:
-      - 'volume_backend_name=mass-storage-dcache'
   mass-storage-ssd:
     is_public: false
     properties:
@@ -27,8 +23,6 @@ cinder::config::cinder_config:
     value: 'rbd:volumes'
   mass-storage-default/backend_host:
     value: 'rbd:volumes_hdd_ec_meta'
-  mass-storage-dcache/backend_host:
-    value: 'rbd:dcache_hdd_ec_meta'
   mass-storage-ssd/backend_host:
     value: 'rbd:volumes_ssd_ec_meta'
   dcache-hdd-ec82/backend_host:
@@ -56,18 +50,6 @@ profile::openstack::volume::backend::rbd:
         value: 'True'
       mass-storage-default/max_over_subscription_ratio:
         value: '2000.0'
-  mass-storage-dcache:
-    rbd_pool: 'dcache_hdd_ec_meta'
-    rbd_user: 'cinder-dcache-hdd-ec'
-    rbd_flatten_volume_from_snapshot: 'True'
-    rbd_secret_uuid: "%{hiera('libvirt_rbd_secret_uuid')}"
-    rbd_exclusive_cinder_pool: 'True'
-    report_dynamic_total_capacity: 'False'
-    extra_options:
-      mass-storage-dcache/enable_deferred_deletion:
-        value: 'True'
-      mass-storage-dcache/max_over_subscription_ratio:
-        value: '2500.0'
   mass-storage-ssd:
     rbd_pool: 'volumes_ssd_ec_meta'
     rbd_user: 'cinder-ssd-ec'
@@ -98,6 +80,5 @@ cinder::api::default_volume_type: 'mass-storage-default'
 cinder::backends::enabled_backends:
   - rbd-volumes
   - mass-storage-default
-  - mass-storage-dcache
   - mass-storage-ssd
   - dcache-hdd-ec82

--- a/hieradata/common/roles/compute.yaml
+++ b/hieradata/common/roles/compute.yaml
@@ -307,13 +307,6 @@ ceph::profile::params::client_keys:
     group: 'cinder'
     cap_mon: 'profile rbd'
     cap_osd: 'profile rbd pool=volumes_ssd_ec_meta, profile rbd pool=volumes_ssd_ec_data'
-  'client.cinder-dcache-hdd-ec':
-    secret: "%{hiera('ceph_storage_client_cinder_key')}"
-    mode: '0600'
-    user: 'cinder'
-    group: 'cinder'
-    cap_mon: 'profile rbd'
-    cap_osd: 'profile rbd pool=dcache_hdd_ec_meta, profile rbd pool=dcache_hdd_ec_data'
   'client.cinder-dcache-hdd-ec82':
     secret: "%{hiera('ceph_storage_client_cinder_key')}"
     mode: '0600'
@@ -330,9 +323,6 @@ profile::storage::ceph_extraconf::config:
   client_ssd_ecc_backend:
     'config_key'  : "client.cinder-ssd-ec/rbd_default_data_pool"
     'config_value': "volumes_ssd_ec_data"
-  client_dcache_backend:
-    'config_key'  : "client.cinder-dcache-hdd-ec/rbd_default_data_pool"
-    'config_value': "dcache_hdd_ec_data"
   client_dcache_backend_82:
     'config_key'  : "client.cinder-dcache-hdd-ec82/rbd_default_data_pool"
     'config_value': "dcache_hdd_ec82_data"

--- a/hieradata/common/roles/volume.yaml
+++ b/hieradata/common/roles/volume.yaml
@@ -134,13 +134,6 @@ ceph::profile::params::client_keys:
     group: 'cinder'
     cap_mon: 'profile rbd'
     cap_osd: 'profile rbd pool=volumes_ssd_ec_meta, profile rbd pool=volumes_ssd_ec_data'
-  'client.cinder-dcache-hdd-ec':
-    secret: "%{hiera('ceph_storage_client_cinder_key')}"
-    mode: '0600'
-    user: 'cinder'
-    group: 'cinder'
-    cap_mon: 'profile rbd'
-    cap_osd: 'profile rbd pool=dcache_hdd_ec_meta, profile rbd pool=dcache_hdd_ec_data'
   'client.cinder-dcache-hdd-ec82':
     secret: "%{hiera('ceph_storage_client_cinder_key')}"
     mode: '0600'
@@ -157,9 +150,6 @@ profile::storage::ceph_extraconf::config:
   client_ssd_ecc_backend:
     'config_key'  : "client.cinder-ssd-ec/rbd_default_data_pool"
     'config_value': "volumes_ssd_ec_data"
-  client_dcache_backend:
-    'config_key'  : "client.cinder-dcache-hdd-ec/rbd_default_data_pool"
-    'config_value': "dcache_hdd_ec_data"
   client_dcache_backend_82:
     'config_key'  : "client.cinder-dcache-hdd-ec82/rbd_default_data_pool"
     'config_value': "dcache_hdd_ec82_data"


### PR DESCRIPTION
Det står att å rydde i sjølve ceph (modules/ceph.yaml og bgo/roles/storage-dcache.yaml), men vi startar her.
Treng ein sjekk på at ting heng saman.

Tips til review: start med bgo/roles/volume.yaml og sjå på sletta linje 11 "mass-storage-dcache-temp"