### PR TITLE
Enable port-security extension

### DIFF
--- a/hieradata/common/modules/horizon.yaml
+++ b/hieradata/common/modules/horizon.yaml
@@ -87,6 +87,8 @@ horizon::keystone_options:
 horizon::neutron_options:
   enable_quotas:      true
   enable_rbac_policy: false  # not supported by puppet?
+  supported_vnic_types: "None" # hides the option
+  enable_router:        false  # hides routers and floating ips tab
 
 # Image (Glance)
 horizon::image_backend:

--- a/hieradata/common/modules/neutron.yaml
+++ b/hieradata/common/modules/neutron.yaml
@@ -13,6 +13,7 @@
 
 neutron::bind_host:   "%{ipaddress_trp1}"
 neutron::core_plugin: 'calico'
+neutron::plugins::ml2::extension_drivers: ["port_security"]
 
 neutron::server::sync_db: true
 neutron::db::database_connection: "mysql+pymysql://neutron:%{hiera('neutron::db::mysql::password')}@%{hiera('service__address__db_regional')}/neutron"

--- a/profile/files/openstack/horizon/overrides.py
+++ b/profile/files/openstack/horizon/overrides.py
@@ -15,14 +15,8 @@ settings_dashboard = horizon.get_dashboard("settings")
 
 project_panels = list()
 
-# Network->Routers
-project_panels.append(project_dashboard.get_panel("routers"))
-# Network->Networks
-project_panels.append(project_dashboard.get_panel("networks"))
 # Network->Network Topology
 project_panels.append(project_dashboard.get_panel("network_topology"))
-# Network->Floating IPs
-project_panels.append(project_dashboard.get_panel("floating_ips"))
 # Compute->API
 project_panels.append(project_dashboard.get_panel("api_access"))
 # Volumes-> Consistency Groups


### PR DESCRIPTION
This allows configuring security groups per port, which e.g. some terraform setups rely on, and the button is already exposed in the user interface

(coreplugin=ml2 is not required after all)