### PR TITLE
Neutron dns integration

### DIFF
--- a/hieradata/common/modules/horizon.yaml
+++ b/hieradata/common/modules/horizon.yaml
@@ -87,6 +87,8 @@ horizon::keystone_options:
 horizon::neutron_options:
   enable_quotas:      true
   enable_rbac_policy: false  # not supported by puppet?
+  supported_vnic_types: "None" # hides the option
+  enable_router:        false  # hides routers and floating ips tab
 
 # Image (Glance)
 horizon::image_backend:

--- a/hieradata/common/modules/neutron.yaml
+++ b/hieradata/common/modules/neutron.yaml
@@ -13,6 +13,7 @@
 
 neutron::bind_host:   "%{ipaddress_trp1}"
 neutron::core_plugin: 'calico'
+neutron::plugins::ml2::extension_drivers: ["port_security"]
 
 neutron::server::sync_db: true
 neutron::db::database_connection: "mysql+pymysql://neutron:%{hiera('neutron::db::mysql::password')}@%{hiera('service__address__db_regional')}/neutron"

--- a/hieradata/common/modules/neutron.yaml
+++ b/hieradata/common/modules/neutron.yaml
@@ -13,7 +13,9 @@
 
 neutron::bind_host:   "%{ipaddress_trp1}"
 neutron::core_plugin: 'calico'
-neutron::plugins::ml2::extension_drivers: ["port_security"]
+neutron::plugins::ml2::extension_drivers:
+  - "port_security"
+  - "subnet_dns_publish_fixed_ip"
 
 neutron::server::sync_db: true
 neutron::db::database_connection: "mysql+pymysql://neutron:%{hiera('neutron::db::mysql::password')}@%{hiera('service__address__db_regional')}/neutron"
@@ -67,6 +69,20 @@ neutron::keystone::auth::internal_url:  "%{hiera('endpoint__network__internal')}
 neutron::keystone::auth::admin_url:     "%{hiera('endpoint__network__admin')}"
 neutron::keystone::auth::region:        "%{::location}"
 neutron::keystone::auth::password:      "%{hiera('neutron_api_password')}"
+
+neutron::designate::url:                  "%{hiera('endpoint__designate__admin')}/v2"
+neutron::designate::auth_type:            "password"
+neutron::designate::auth_url:             "%{hiera('endpoint__identity__admin')}/v3"
+neutron::designate::username:             "designate"
+neutron::designate::password:             "%{hiera('designate_api_password')}"
+neutron::designate::user_domain_name:     "%{hiera('keystone__default__domain')}"
+neutron::designate::project_name:         "%{hiera('keystone__service__project')}"
+neutron::designate::project_domain_name:  "%{hiera('keystone__default__domain')}"
+neutron::designate::region_name:          "%{::location}"
+
+
+# Needs to be non-empty and different from openstacklocal to activate the dns integration
+neutron::dns_domain: "instances.nrec.no."
 
 neutron::config::server_config:
   neutron/region_name:

--- a/hieradata/common/modules/nova.yaml
+++ b/hieradata/common/modules/nova.yaml
@@ -227,6 +227,9 @@ nova::keystone::service_user::project_domain_name:     "%{hiera('keystone__defau
 nova::keystone::service_user::user_domain_name:        "%{hiera('keystone__default__domain')}"
 nova::keystone::service_user::send_service_user_token: true
 
+# Avoid sending novalocal to the instances
+nova::metadata::dhcp_domain: ""
+
 # Disable reboot through api until DHCP is fixed upstream (calico)
 nova::policy::policies:
   nova_disable_reboot:

--- a/hieradata/common/roles/compute.yaml
+++ b/hieradata/common/roles/compute.yaml
@@ -107,6 +107,9 @@ profile::openstack::network::calico::manage_etcd_grpc_proxy: true
 profile::openstack::network::calico::manage_etcd:            true
 profile::openstack::network::calico::manage_dhcp_agent:      true
 
+# Ensure dhcp-agent doesn't send dns search domains
+neutron::dns_domain: ""
+
 profile::base::common::packages:
   'networking-calico': {}
   'bash-completion': {}

--- a/hieradata/test01/roles/network.yaml
+++ b/hieradata/test01/roles/network.yaml
@@ -1,4 +1,5 @@
 ---
+profile::openstack::network::manage_dns_integration: true
 profile::network::interface::create_custom_routes: true
 
 profile::base::network::nm_auto_routes:

--- a/profile/files/openstack/horizon/overrides.py
+++ b/profile/files/openstack/horizon/overrides.py
@@ -15,14 +15,8 @@ settings_dashboard = horizon.get_dashboard("settings")
 
 project_panels = list()
 
-# Network->Routers
-project_panels.append(project_dashboard.get_panel("routers"))
-# Network->Networks
-project_panels.append(project_dashboard.get_panel("networks"))
 # Network->Network Topology
 project_panels.append(project_dashboard.get_panel("network_topology"))
-# Network->Floating IPs
-project_panels.append(project_dashboard.get_panel("floating_ips"))
 # Compute->API
 project_panels.append(project_dashboard.get_panel("api_access"))
 # Volumes-> Consistency Groups

--- a/profile/manifests/openstack/network.pp
+++ b/profile/manifests/openstack/network.pp
@@ -5,6 +5,7 @@ class profile::openstack::network(
   $manage_quotas   = false,
   $firewall_extras = {},
   $manage_osprofiler = false,
+  $manage_dns_integration = false,
 ){
 
   include ::keystone::bootstrap
@@ -57,5 +58,9 @@ class profile::openstack::network(
     include ::neutron::deps
     $osprofiler_config = lookup('profile::logging::osprofiler::osprofiler_config', Hash, 'first', {})
     create_resources('neutron_config', $osprofiler_config)
+  }
+
+  if $manage_dns_integration {
+    include neutron::designate
   }
 }


### PR DESCRIPTION
Goes after #1069 since they complement eachother and both modify the ml2 extension list

When a subnet has `dns_publish_fixed_ip=True`, and the network has a suitable dns_domain, neutron will automatically create a designate recordset in that zone (if the user has permission) with the A and AAAA record for the instance

```
openstack server create 1074 --network=elastic_rail_test_test01 --image="GOLD Alma Linux 10" --flavor="m1.small"
openstack recordset list test01.test.rail.uhdc.no. --fit
| 1beed9b4-7a8f-4f98-9b93-829d19d86b0f | 1074.test01.test.rail.uhdc.no.   | A    | 10.0.241.      | PENDING | CREATE |
| 1cc23888-ff87-48eb-b957-29dd7d21c9d2 | 1074.test01.test.rail.uhdc.no.   | AAAA | 2001:700:200:  | PENDING | CREATE |
```

This PR also makes dnsmasq stop sending openstacklocal as a search domain, and stops the nova metadata api server from inserting .novalocal into the hostname with the metadata api

More details: https://docs.openstack.org/neutron/zed/admin/config-dns-int.html