### PR TITLE
feat: enable shelving

### DIFF
--- a/hieradata/common/modules/nova.yaml
+++ b/hieradata/common/modules/nova.yaml
@@ -154,6 +154,8 @@ profile::openstack::compute::default_nova_config:
 profile::openstack::novactrl::default_nova_config:
   glance/region_name:
     value: "%{::location}"
+  "quota/count_usage_from_placement":
+    value: "true"
 
 # compute (node: compute)
 nova::compute::enabled:                          true

--- a/hieradata/test01/roles/novactrl.yaml
+++ b/hieradata/test01/roles/novactrl.yaml
@@ -22,8 +22,3 @@ profile::openstack::resource::host_aggregate:
         9edeba0543ac4824a0aa95f947528c02,
         2ce04b3aaf3e45378f4f00072ceb5f20,
         8664497aa1224161bb1ed3bd88a65858
-
-nova::config::nova_config:
-  # Enable Placement-based quota counting (this enables freeing up resources when VM is shelved_offloaded)
-  "quota/count_usage_from_placement":
-    value: "true"


### PR DESCRIPTION
Hadde tidligere verifisert i test01 at shelving med count usage from placement aktivert frigjør VCPU og RAM.

Antar at shelving også frigjør PCPU og VGPU, men det det er ikke testet.

Grunnen til at DISK_GB ikke blir frigjort ved shelving er fordi Ceph RBD blir brukt for ephemeral lagring.

Slik kan man verifisere at innstillingen virker:

- Opprett ny instans

- Shelve og unshelve (med --wait)

- Sjekk underveis at limits viser at vcpu og ram blir frigitt, men ikke disk

Eksempel (test01):

```
openstack limits show --absolute | grep -E 'totalCoresUsed|totalRAMUsed|totalGigabytesUsed'
| totalRAMUsed             |   57344 |
| totalCoresUsed           |      24 |
| totalGigabytesUsed       |    1470 |

openstack server shelve nrec-tests-vm --wait

openstack limits show --absolute | grep -E 'totalCoresUsed|totalRAMUsed|totalGigabytesUsed'
| totalRAMUsed             |   55296 |
| totalCoresUsed           |      23 |
| totalGigabytesUsed       |    1470 |
```